### PR TITLE
Using extrinsic mesh data pattern

### DIFF
--- a/src/coreComponents/fileIO/coupling/ChomboCoupler.cpp
+++ b/src/coreComponents/fileIO/coupling/ChomboCoupler.cpp
@@ -15,9 +15,10 @@
 #include "ChomboCoupler.hpp"
 #include "hdf5_interface/coupler.hpp"
 #include "mesh/FaceManager.hpp"
+#include "mesh/ExtrinsicMeshData.hpp"
+
 #include <cstdint>
 #include <tuple>
-
 #include <cstdio>
 
 namespace geosx
@@ -56,7 +57,7 @@ void ChomboCoupler::write( double dt )
     }
   }
 
-  arrayView1d< integer const > const & ruptureState = faces->getReference< integer_array >( "ruptureState" );
+  arrayView1d< integer const > const & ruptureState = faces->getExtrinsicData< extrinsicMeshData::RuptureState >();
   arrayView1d< integer const > const & ghostRank = faces->getReference< integer_array >( faces->viewKeys.ghostRank );
 
   bool * faceMask = new bool[n_faces];

--- a/src/coreComponents/managers/ObjectManagerBase.cpp
+++ b/src/coreComponents/managers/ObjectManagerBase.cpp
@@ -34,6 +34,7 @@ ObjectManagerBase::ObjectManagerBase( std::string const & name,
   m_localToGlobalMap(),
   m_globalToLocalMap(),
   m_isExternal(),
+  m_domainBoundaryIndicator(),
   m_ghostRank(),
   m_neighborData()
 {
@@ -52,7 +53,7 @@ ObjectManagerBase::ObjectManagerBase( std::string const & name,
     setApplyDefaultValue( -2 )->
     setPlotLevel( PlotLevel::LEVEL_0 );
 
-  registerWrapper< array1d< integer > >( viewKeyStruct::domainBoundaryIndicatorString );
+  registerWrapper< array1d< integer > >( viewKeyStruct::domainBoundaryIndicatorString, &m_domainBoundaryIndicator );
 
   m_sets.registerWrapper< SortedArray< localIndex > >( this->m_ObjectManagerBaseViewKeys.externalSet );
 }

--- a/src/coreComponents/managers/ObjectManagerBase.cpp
+++ b/src/coreComponents/managers/ObjectManagerBase.cpp
@@ -171,7 +171,7 @@ void ObjectManagerBase::ConstructSetFromSetAndMap( SortedArrayView< localIndex c
 
 void ObjectManagerBase::ConstructLocalListOfBoundaryObjects( localIndex_array & objectList ) const
 {
-  arrayView1d< integer const > const & isDomainBoundary = this->getReference< integer_array >( m_ObjectManagerBaseViewKeys.domainBoundaryIndicator );
+  arrayView1d< integer const > const & isDomainBoundary = this->getDomainBoundaryIndicator();
   for( localIndex k=0; k<size(); ++k )
   {
     if( isDomainBoundary[k] == 1 )
@@ -183,7 +183,7 @@ void ObjectManagerBase::ConstructLocalListOfBoundaryObjects( localIndex_array & 
 
 void ObjectManagerBase::ConstructGlobalListOfBoundaryObjects( globalIndex_array & objectList ) const
 {
-  arrayView1d< integer const > const & isDomainBoundary = this->getReference< integer_array >( m_ObjectManagerBaseViewKeys.domainBoundaryIndicator );
+  arrayView1d< integer const > const & isDomainBoundary = this->getDomainBoundaryIndicator();
   for( localIndex k=0; k<size(); ++k )
   {
     if( isDomainBoundary[k] == 1 )

--- a/src/coreComponents/managers/ObjectManagerBase.hpp
+++ b/src/coreComponents/managers/ObjectManagerBase.hpp
@@ -718,13 +718,11 @@ public:
     /// String key to the local->global map
     static constexpr auto localToGlobalMapString = "localToGlobalMap";
 
-    /// View key to domain boundary indicator
-    dataRepository::ViewKey domainBoundaryIndicator = { domainBoundaryIndicatorString };
     /// View key to external set
     dataRepository::ViewKey externalSet = { externalSetString };
     /// View key to ghost ranks
     dataRepository::ViewKey ghostRank = { ghostRankString };
-    /// View key to global->local mao
+    /// View key to global->local map
     dataRepository::ViewKey globalToLocalMap = { globalToLocalMapString };
     /// View key to the local->global map
     dataRepository::ViewKey localToGlobalMap = { localToGlobalMapString };
@@ -909,6 +907,22 @@ public:
    */
   globalIndex maxGlobalIndex() const
   { return m_maxGlobalIndex; }
+
+  /**
+   * @brief Get the domain boundary indicator
+   * @return The information in an array of integers, mainly treated as booleans
+   *         (1 meaning the "index" is on the boundary).
+   */
+  arrayView1d< integer > const & getDomainBoundaryIndicator()
+  {
+    return getReference< array1d< integer > >( viewKeyStruct::domainBoundaryIndicatorString ).toView();
+  }
+
+  /// @copydoc getDomainBoundaryIndicator()
+  arrayView1d< integer const > const & getDomainBoundaryIndicator() const
+  {
+    return getReference< array1d< integer > >( viewKeyStruct::domainBoundaryIndicatorString ).toViewConst();
+  }
 
 protected:
   /// Group that holds object sets.

--- a/src/coreComponents/managers/ObjectManagerBase.hpp
+++ b/src/coreComponents/managers/ObjectManagerBase.hpp
@@ -915,13 +915,13 @@ public:
    */
   arrayView1d< integer > const & getDomainBoundaryIndicator()
   {
-    return getReference< array1d< integer > >( viewKeyStruct::domainBoundaryIndicatorString ).toView();
+    return m_domainBoundaryIndicator.toView();
   }
 
   /// @copydoc getDomainBoundaryIndicator()
   arrayView1d< integer const > const & getDomainBoundaryIndicator() const
   {
-    return getReference< array1d< integer > >( viewKeyStruct::domainBoundaryIndicatorString ).toViewConst();
+    return m_domainBoundaryIndicator.toViewConst();
   }
 
 protected:
@@ -939,6 +939,9 @@ protected:
 
   /// Array that holds if an object is external.
   array1d< integer > m_isExternal;
+
+  /// Domain boundary indicator: 1 means the "index" is on the boundary.
+  array1d< integer > m_domainBoundaryIndicator;
 
   /**
    * @brief Array that holds the ghost information about each object.

--- a/src/coreComponents/mesh/EdgeManager.cpp
+++ b/src/coreComponents/mesh/EdgeManager.cpp
@@ -539,11 +539,10 @@ void EdgeManager::SetDomainBoundaryObjects( ObjectManagerBase const * const refe
 
   // get the "isDomainBoundary" field from the faceManager. This should have
   // been set already!
-  arrayView1d< integer const > const & isFaceOnDomainBoundary =
-    faceManager->getReference< array1d< integer > >( faceManager->viewKeys.domainBoundaryIndicator );
+  arrayView1d< integer const > const & isFaceOnDomainBoundary = faceManager->getDomainBoundaryIndicator();
 
   // get the "isDomainBoundary" field from for *this, and set it to zero
-  array1d< integer > & isEdgeOnDomainBoundary = this->getReference< array1d< integer > >( viewKeys.domainBoundaryIndicatorString );
+  arrayView1d< integer > const & isEdgeOnDomainBoundary = this->getDomainBoundaryIndicator();
   isEdgeOnDomainBoundary.setValues< serialPolicy >( 0 );
 
   ArrayOfArraysView< localIndex const > const & faceToEdgeMap = faceManager->edgeList().toViewConst();
@@ -624,7 +623,7 @@ void EdgeManager::ExtractMapFromObjectForAssignGlobalIndexNumbers( ObjectManager
   localIndex const numEdges = size();
 
   arrayView2d< localIndex const > const & edgeNodes = this->nodeList();
-  arrayView1d< integer const > const & isDomainBoundary = this->getReference< integer_array >( viewKeys.domainBoundaryIndicator );
+  arrayView1d< integer const > const & isDomainBoundary = this->getDomainBoundaryIndicator();
 
   globalEdgeNodes.resize( numEdges );
 

--- a/src/coreComponents/mesh/FaceElementRegion.cpp
+++ b/src/coreComponents/mesh/FaceElementRegion.cpp
@@ -16,6 +16,7 @@
  * @file FaceElementRegion.cpp
  */
 
+#include "ExtrinsicMeshData.hpp"
 #include "EdgeManager.hpp"
 #include "FaceElementRegion.hpp"
 
@@ -73,8 +74,7 @@ localIndex FaceElementRegion::AddToFractureMesh( real64 const time_np1,
   rval = subRegion->size() - 1;
 
 
-  arrayView1d< real64 > const &
-  ruptureTime = subRegion->getReference< real64_array >( viewKeyStruct::ruptureTimeString );
+  arrayView1d< real64 > const & ruptureTime = subRegion->getExtrinsicData< extrinsicMeshData::RuptureTime >();
 
   arrayView1d< real64 > const &
   creationMass = subRegion->getReference< real64_array >( FaceElementSubRegion::viewKeyStruct::creationMassString );

--- a/src/coreComponents/mesh/FaceElementRegion.hpp
+++ b/src/coreComponents/mesh/FaceElementRegion.hpp
@@ -130,10 +130,6 @@ public:
 
     /// Default aperture string
     static constexpr auto defaultApertureString = "defaultAperture";
-
-    /// Rupture time string
-    constexpr static auto ruptureTimeString = "ruptureTime";
-
   };
 
 protected:

--- a/src/coreComponents/mesh/FaceManager.cpp
+++ b/src/coreComponents/mesh/FaceManager.cpp
@@ -619,7 +619,7 @@ void FaceManager::SetDomainBoundaryObjects( NodeManager * const nodeManager )
 {
   // Set value of domainBounaryIndicator to one if it is found to have only one elements that it
   // is connected to.
-  integer_array & faceDomainBoundaryIndicator = this->getReference< integer_array >( viewKeys.domainBoundaryIndicator );
+  arrayView1d< integer > const & faceDomainBoundaryIndicator = this->getDomainBoundaryIndicator();
   faceDomainBoundaryIndicator.setValues< serialPolicy >( 0 );
 
   arrayView2d< localIndex const > const & elemRegionList = this->elementRegionList();
@@ -632,7 +632,7 @@ void FaceManager::SetDomainBoundaryObjects( NodeManager * const nodeManager )
     }
   } );
 
-  integer_array & nodeDomainBoundaryIndicator = nodeManager->getReference< integer_array >( nodeManager->viewKeys.domainBoundaryIndicator );
+  arrayView1d< integer > const & nodeDomainBoundaryIndicator = nodeManager->getDomainBoundaryIndicator();
   nodeDomainBoundaryIndicator.setValues< serialPolicy >( 0 );
 
   ArrayOfArraysView< localIndex const > const & faceToNodesMap = this->nodeList().toViewConst();
@@ -653,8 +653,7 @@ void FaceManager::SetDomainBoundaryObjects( NodeManager * const nodeManager )
 
 void FaceManager::SetIsExternal()
 {
-  integer_array const &
-  isDomainBoundary = this->getReference< integer_array >( viewKeys.domainBoundaryIndicator );
+  arrayView1d< integer const > const & isDomainBoundary = this->getDomainBoundaryIndicator();
 
   m_isExternal.setValues< serialPolicy >( 0 );
   for( localIndex k=0; k<size(); ++k )
@@ -804,7 +803,7 @@ void FaceManager::ExtractMapFromObjectForAssignGlobalIndexNumbers( ObjectManager
   localIndex const numFaces = size();
 
   ArrayOfArraysView< localIndex const > const & faceToNodeMap = this->nodeList().toViewConst();
-  arrayView1d< integer const > const & isDomainBoundary = this->getReference< integer_array >( viewKeys.domainBoundaryIndicator );
+  arrayView1d< integer const > const & isDomainBoundary = this->getDomainBoundaryIndicator();
 
   globalFaceNodes.resize( numFaces );
 

--- a/src/coreComponents/mesh/WellElementSubRegion.cpp
+++ b/src/coreComponents/mesh/WellElementSubRegion.cpp
@@ -612,8 +612,7 @@ void WellElementSubRegion::UpdateNodeManagerSize( MeshLevel & mesh,
   // resize nodeManager to account for the new well nodes and update the properties
   nodeManager->resize( oldNumNodesLocal + numWellNodesLocal );
 
-  array1d< integer > &
-  isDomainBoundary = nodeManager->getReference< integer_array >( m_ObjectManagerBaseViewKeys.domainBoundaryIndicator );
+  arrayView1d< integer > const & isDomainBoundary = nodeManager->getDomainBoundaryIndicator();
 
   arrayView1d< globalIndex > const & nodeLocalToGlobal = nodeManager->localToGlobalMap();
 

--- a/src/coreComponents/mpiCommunications/CommunicationTools.cpp
+++ b/src/coreComponents/mpiCommunications/CommunicationTools.cpp
@@ -418,7 +418,7 @@ CommunicationTools::
                                        std::vector< NeighborCommunicator > & allNeighbors )
 {
   GEOSX_MARK_FUNCTION;
-  integer_array & domainBoundaryIndicator = objectManager->getReference< integer_array >( objectManager->m_ObjectManagerBaseViewKeys.domainBoundaryIndicator );
+  arrayView1d< integer > const & domainBoundaryIndicator = objectManager->getDomainBoundaryIndicator();
 
   array1d< globalIndex > globalPartitionBoundaryObjectsIndices;
   objectManager->ConstructGlobalListOfBoundaryObjects( globalPartitionBoundaryObjectsIndices );

--- a/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
@@ -340,7 +340,7 @@ void SurfaceGenerator::InitializePostInitialConditions_PreSubGroups( Group * con
     arrayView2d< real64 const > const & faceNormals = faceManager->faceNormal();
 
     //TODO: roughness to KIC should be made a material constitutive relationship.
-    arrayView1d< R1Tensor > const & KIC = faceManager->getReference< r1_array >( "K_IC" );
+    arrayView1d< R1Tensor > const & KIC = faceManager->getExtrinsicData< extrinsicMeshData::K_IC >();
 
     for( localIndex kf=0; kf<faceManager->size(); ++kf )
     {
@@ -777,7 +777,7 @@ void SurfaceGenerator::SynchronizeTipSets ( FaceManager & faceManager,
     }
   }
 
-  integer_array & isFaceSeparable = faceManager.getReference< integer_array >( "isFaceSeparable" );
+  arrayView1d< integer const > const & isFaceSeparable = faceManager.getExtrinsicData< extrinsicMeshData::IsFaceSeparable >();
   arrayView2d< localIndex const > const & faceToElementMap = faceManager.elementList();
 
   arrayView1d< localIndex const > const & childNodeIndices = nodeManager.getExtrinsicData< extrinsicMeshData::ChildIndex >();
@@ -1626,7 +1626,7 @@ void SurfaceGenerator::PerformFracture( const localIndex nodeID,
   arrayView1d< integer > const & nodeIsExternal = nodeManager.isExternal();
 
   FaceElementRegion * const fractureElementRegion = elementManager.GetRegion< FaceElementRegion >( "Fracture" );
-  integer_array & isFaceSeparable = faceManager.getReference< integer_array >( "isFaceSeparable" );
+  arrayView1d< integer const > const & isFaceSeparable = faceManager.getExtrinsicData< extrinsicMeshData::IsFaceSeparable >();
 
   arrayView2d< real64 > const & faceNormals = faceManager.faceNormal();
 
@@ -1635,21 +1635,12 @@ void SurfaceGenerator::PerformFracture( const localIndex nodeID,
   arrayView1d< localIndex const > const & parentNodeIndices = nodeManager.getExtrinsicData< extrinsicMeshData::ParentIndex >();
   arrayView1d< localIndex const > const & childNodeIndices = nodeManager.getExtrinsicData< extrinsicMeshData::ChildIndex >();
 
-  arrayView1d< integer > const &
-  degreeFromCrack = nodeManager.getExtrinsicData< extrinsicMeshData::DegreeFromCrack >();
+  arrayView1d< integer > const & degreeFromCrack = nodeManager.getExtrinsicData< extrinsicMeshData::DegreeFromCrack >();
+  arrayView1d< integer > const & nodeDegreeFromCrackTip = nodeManager.getExtrinsicData< extrinsicMeshData::DegreeFromCrackTip >();
+  arrayView1d< integer > const & faceDegreeFromCrackTip = faceManager.getExtrinsicData< extrinsicMeshData::DegreeFromCrackTip >();
 
-  arrayView1d< integer > const &
-  nodeDegreeFromCrackTip = nodeManager.getExtrinsicData< extrinsicMeshData::DegreeFromCrackTip >();
-
-  arrayView1d< integer > const &
-  faceDegreeFromCrackTip = faceManager.getExtrinsicData< extrinsicMeshData::DegreeFromCrackTip >();
-
-
-  arrayView1d< real64 > const &
-  nodeRuptureTime = nodeManager.getExtrinsicData< extrinsicMeshData::RuptureTime >();
-
-  arrayView1d< real64 > const &
-  faceRuptureTime = faceManager.getExtrinsicData< extrinsicMeshData::RuptureTime >();
+  arrayView1d< real64 > const & nodeRuptureTime = nodeManager.getExtrinsicData< extrinsicMeshData::RuptureTime >();
+  arrayView1d< real64 > const & faceRuptureTime = faceManager.getExtrinsicData< extrinsicMeshData::RuptureTime >();
 
   // ***** split all the objects first *****
 
@@ -1765,7 +1756,7 @@ void SurfaceGenerator::PerformFracture( const localIndex nodeID,
 
 
   // split the faces
-  arrayView1d< integer > & ruptureState = faceManager.getReference< integer_array >( "ruptureState" );
+  arrayView1d< integer > const & ruptureState = faceManager.getExtrinsicData< extrinsicMeshData::RuptureState >();
   map< localIndex, localIndex > splitFaces;
 
 
@@ -2711,7 +2702,8 @@ void SurfaceGenerator::IdentifyRupturedFaces( DomainPartition & domain,
                                               const bool prefrac )
 {
   arrayView1d< integer > const & isEdgeGhost = edgeManager.ghostRank();
-  real64_array & SIFNode = nodeManager.getReference< real64_array >( "SIFNode" );
+  arrayView1d< real64 const > const & SIFNode = nodeManager.getExtrinsicData< extrinsicMeshData::SIFNode >();
+
 
   // We use the color map scheme because we can mark a face to be rupture ready from a partition where the face is a
   // ghost.
@@ -2796,8 +2788,8 @@ void SurfaceGenerator::CalculateNodeAndFaceSIF( DomainPartition & domain,
                                                 FaceManager & faceManager,
                                                 ElementRegionManager & elementManager )
 {
-  arrayView1d< real64 > const & SIFNode = nodeManager.getReference< real64_array >( "SIFNode" );
-  arrayView1d< real64 > const & SIFonFace = faceManager.getReference< real64_array >( "SIFonFace" );
+  arrayView1d< real64 > const & SIFNode = nodeManager.getExtrinsicData< extrinsicMeshData::SIFNode >();
+  arrayView1d< real64 > const & SIFonFace = faceManager.getExtrinsicData< extrinsicMeshData::SIFonFace >();
 
   std::vector< std::vector< realT > > SIFNode_All, SIFonFace_All;
   std::vector< realT > SIFOnEdge;
@@ -3218,9 +3210,9 @@ realT SurfaceGenerator::CalculateEdgeSIF( DomainPartition & domain,
 {
   realT rval;
   localIndex_array faceInvolved;
-  real64_array & SIF_I = edgeManager.getReference< real64_array >( "SIF_I" );
-  real64_array & SIF_II = edgeManager.getReference< real64_array >( "SIF_II" );
-  real64_array & SIF_III = edgeManager.getReference< real64_array >( "SIF_III" );
+  arrayView1d< real64 > const & SIF_I = edgeManager.getExtrinsicData< extrinsicMeshData::SIF_I >();
+  arrayView1d< real64 > const & SIF_II = edgeManager.getExtrinsicData< extrinsicMeshData::SIF_II >();
+  arrayView1d< real64 > const & SIF_III = edgeManager.getExtrinsicData< extrinsicMeshData::SIF_III >();
 
   ArrayOfSetsView< localIndex const > const & nodeToEdgeMap = nodeManager.edgeList().toViewConst();
   arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const & X = nodeManager.referencePosition();
@@ -3831,7 +3823,7 @@ int SurfaceGenerator::CheckOrphanElement ( ElementRegionManager & elementManager
 
   arrayView1d< integer const > const & faceIsExternal = faceManager.isExternal();
 
-  integer_array & ruptureState = faceManager.getReference< integer_array >( "ruptureState" );
+  arrayView1d< integer const > const & ruptureState = faceManager.getExtrinsicData< extrinsicMeshData::RuptureState >();
 
   int flagOrphan = 0;
   for( localIndex k=0; k<faceToRegionMap.size( 1 ); ++k )
@@ -3874,9 +3866,9 @@ void SurfaceGenerator::MarkRuptureFaceFromNode ( const localIndex nodeIndex,
                                                  ElementRegionManager & GEOSX_UNUSED_PARAM( elementManager ),
                                                  ModifiedObjectLists & modifiedObjects )
 {
-  arrayView1d< integer > & ruptureState = faceManager.getReference< integer_array >( "ruptureState" );
-  real64_array & SIFonFace = faceManager.getReference< real64_array >( "SIFonFace" );
-  array1d< R1Tensor > & KIC = faceManager.getReference< array1d< R1Tensor > >( "K_IC" );
+  arrayView1d< integer > const & ruptureState = faceManager.getExtrinsicData< extrinsicMeshData::RuptureState >();
+  arrayView1d< real64 const > const & SIFonFace = faceManager.getExtrinsicData< extrinsicMeshData::SIFonFace >();
+  arrayView1d< R1Tensor const > const & KIC = faceManager.getExtrinsicData< extrinsicMeshData::K_IC >();
   ArrayOfArraysView< localIndex const > const & faceToEdgeMap = faceManager.edgeList().toViewConst();
   arrayView2d< real64 const > const & faceCenter = faceManager.faceCenter();
 
@@ -3990,13 +3982,13 @@ void SurfaceGenerator::MarkRuptureFaceFromEdge ( localIndex const edgeID,
                                                  ModifiedObjectLists & modifiedObjects,
                                                  int const edgeMode )
 {
-  arrayView1d< integer > & ruptureState = faceManager.getReference< integer_array >( "ruptureState" );
-  real64_array & SIFonFace = faceManager.getReference< real64_array >( "SIFonFace" );
-  array1d< R1Tensor > & KIC = faceManager.getReference< r1_array >( "K_IC" );
-  real64_array & SIF_I = edgeManager.getReference< real64_array >( "SIF_I" );
-  real64_array & SIF_II = edgeManager.getReference< real64_array >( "SIF_II" );
-  localIndex_array & primaryCandidateFace = faceManager.getReference< localIndex_array >( "primaryCandidateFace" );
-  integer_array & isFaceSeparable = faceManager.getReference< integer_array >( "isFaceSeparable" );
+  arrayView1d< integer > const & ruptureState = faceManager.getExtrinsicData< extrinsicMeshData::RuptureState >();
+  arrayView1d< real64 > const & SIFonFace = faceManager.getExtrinsicData< extrinsicMeshData::SIFonFace >();
+  arrayView1d< R1Tensor const > const & KIC = faceManager.getExtrinsicData< extrinsicMeshData::K_IC >();
+  arrayView1d< real64 > const & SIF_I = edgeManager.getExtrinsicData< extrinsicMeshData::SIF_I >();
+  arrayView1d< real64 > const & SIF_II = edgeManager.getExtrinsicData< extrinsicMeshData::SIF_II >();
+  arrayView1d< localIndex > const & primaryCandidateFace = faceManager.getExtrinsicData< extrinsicMeshData::PrimaryCandidateFace >();
+  arrayView1d< integer const > const & isFaceSeparable = faceManager.getExtrinsicData< extrinsicMeshData::IsFaceSeparable >();
 //  integer_array* dfnIndexMap = faceManager.getReferencePointer<integer_array>( "DFN_Index" );
 
   arrayView1d< integer const > const & faceIsExternal = faceManager.isExternal();
@@ -4223,7 +4215,7 @@ void SurfaceGenerator::PostUpdateRuptureStates( NodeManager & nodeManager,
   nodesToRupturedFaces.resize( nodeManager.size() );
   edgesToRupturedFaces.resize( edgeManager.size() );
 
-  arrayView1d< integer > & faceRuptureState = faceManager.getReference< integer_array >( "ruptureState" );
+  arrayView1d< integer const > const & faceRuptureState = faceManager.getExtrinsicData< extrinsicMeshData::RuptureState >();
   arrayView1d< localIndex const > const & faceParentIndex = faceManager.getExtrinsicData< extrinsicMeshData::ParentIndex >();
 
   // assign the values of the nodeToRupturedFaces and edgeToRupturedFaces arrays.
@@ -4351,7 +4343,7 @@ realT SurfaceGenerator::MinimumToughnessOnEdge( const localIndex edgeID,
   edgeCenter += X[edgeManager.nodeList( edgeID, 1 )];
   edgeCenter *= 0.5;
 
-  arrayView1d< R1Tensor > & KIC = faceManager.getReference< r1_array >( "K_IC" );
+  arrayView1d< R1Tensor const > const & KIC = faceManager.getExtrinsicData< extrinsicMeshData::K_IC >();
   ArrayOfArraysView< localIndex const > const & faceToNodes = faceManager.nodeList().toViewConst();
   for( localIndex const iface : edgeManager.faceList()[ edgeID ] )
   {
@@ -4380,7 +4372,7 @@ realT SurfaceGenerator::MinimumToughnessOnNode( const localIndex nodeID,
   arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const & X = nodeManager.referencePosition();
   ArrayOfSetsView< localIndex const > const & nodeToFaceMap = nodeManager.faceList().toViewConst();
 
-  array1d< R1Tensor > & KIC = faceManager.getReference< array1d< R1Tensor > >( "K_IC" );
+  arrayView1d< R1Tensor const > const & KIC = faceManager.getExtrinsicData< extrinsicMeshData::K_IC >();
   ArrayOfArraysView< localIndex const > const & faceToEdgeMap = faceManager.edgeList().toViewConst();
   arrayView2d< real64 const > const & faceCenter = faceManager.faceCenter();
 

--- a/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.hpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.hpp
@@ -507,7 +507,6 @@ private:
     constexpr static auto failCriterionString = "failCriterion";
     constexpr static auto solidMaterialNameString = "solidMaterialNames";
     constexpr static auto fExternalString = "fExternal";
-    constexpr static auto SIFNodeString = "SIFNode";
     constexpr static auto tipNodesString = "tipNodes";
     constexpr static auto tipEdgesString = "tipEdges";
     constexpr static auto tipFacesString = "tipFaces";


### PR DESCRIPTION
Keep on refactoring about the `extrinsicMeshData`. All defined traits are now exclusively used. `const`ness of the fields has been challenged.
Centralisation of the type of `domainBoundaryIndicators` inside `ObjectManagerBase`.

Is this what we want?
I did not go to defining some `typedef array1d< integer >domainBoundaryIndicatorsType` as `private` nested type.