### PR TITLE
Adding a script to test for xml attribute coverage

### DIFF
--- a/src/coreComponents/python/modules/geosx_xml_tools_package/geosx_xml_tools/attribute_coverage.py
+++ b/src/coreComponents/python/modules/geosx_xml_tools_package/geosx_xml_tools/attribute_coverage.py
@@ -137,7 +137,7 @@ def process_xml_files(geosx_root, output_name):
 
   # Parse the schema
   geosx_root = os.path.expanduser(geosx_root)
-  schema = '%s/src/coreComponents/fileIO/schema/schema.xsd' % (geosx_root)
+  schema = '%ssrc/coreComponents/schema/schema.xsd' % (geosx_root)
   xml_types = parse_schema(schema)
 
   # Find all xml files, collect their attributes

--- a/src/coreComponents/python/modules/geosx_xml_tools_package/geosx_xml_tools/attribute_coverage.py
+++ b/src/coreComponents/python/modules/geosx_xml_tools_package/geosx_xml_tools/attribute_coverage.py
@@ -1,0 +1,174 @@
+
+from lxml import etree as ElementTree
+import os
+from pathlib import Path
+import argparse
+
+
+def parse_schema_element(root,
+                         node,
+                         xsd='{http://www.w3.org/2001/XMLSchema}',
+                         recursive_types=['PeriodicEvent', 'SoloEvent', 'HaltEvent'],
+                         folders=['src', 'examples']):
+  """Parse the xml schema at the current level
+
+  @arg root the root schema node
+  @arg node current schema node
+  @arg xsd the file namespace
+  @arg recursive_types node tags that allow recursive nesting
+  @arg folders folders to sort xml attribute usage into
+  """
+
+  element_type = node.get('type')
+  element_name = node.get('name')
+  element_def = root.find("%scomplexType[@name='%s']" % (xsd, element_type))
+  local_types = {'attributes': {}, 'children': {}}
+
+  # Parse attributes
+  for attribute in element_def.findall('%sattribute' % (xsd)):
+    attribute_name = attribute.get('name')
+    local_types['attributes'][attribute_name] = {ka: [] for ka in folders}
+    if ('default' in attribute.attrib):
+      local_types['attributes'][attribute_name]['default'] = attribute.get('default')
+
+  # Parse children
+  choice_node = element_def.findall('%schoice' % (xsd))
+  if choice_node:
+    for child in choice_node[0].findall('%selement' % (xsd)):
+      child_name = child.get('name')
+      if not ((child_name in recursive_types) and (element_name in recursive_types)):
+        local_types['children'][child_name] = parse_schema_element(root, child)
+
+  return local_types
+
+
+def parse_schema(fname):
+  """Parse the schema file into the xml attribute usage dict
+
+  @arg fname schema name
+  """
+  xml_tree = ElementTree.parse(fname)
+  xml_root = xml_tree.getroot()
+  problem_node = xml_root.find("{http://www.w3.org/2001/XMLSchema}element")
+  return {'Problem': parse_schema_element(xml_root, problem_node)}
+
+
+def collect_xml_attributes_level(local_types, node, folder):
+  """Collect xml attribute usage at the current level
+
+  @arg local_types dict containing attribute usage
+  @arg node current xml node
+  @arg folder the source folder for the current file
+  """
+  for ka in node.attrib.keys():
+    local_types['attributes'][ka][folder].append(node.get(ka))
+
+  for child in node:
+    if child.tag in local_types['children']:
+      collect_xml_attributes_level(local_types['children'][child.tag],
+                                   child,
+                                   folder)
+
+
+def collect_xml_attributes(xml_types, fname, folder):
+  """Collect xml attribute usage in a file
+
+  @arg xml_types dict containing attribute usage
+  @arg fname name of the target file
+  @arg folder the source folder for the current file
+  """
+  parser = ElementTree.XMLParser(remove_comments=True, remove_blank_text=True)
+  xml_tree = ElementTree.parse(fname, parser=parser)
+  xml_root = xml_tree.getroot()
+
+  collect_xml_attributes_level(xml_types['Problem'], xml_root, folder)
+
+
+def write_attribute_usage_xml_level(local_types, node, folders=['src', 'examples']):
+  """Write xml attribute usage file at a given level
+
+  @arg local_types dict containing attribute usage at the current level
+  @arg node current xml node
+  """
+
+  # Write attributes
+  for ka in local_types['attributes'].keys():
+    attribute_node = ElementTree.Element(ka)
+    node.append(attribute_node)
+
+    if ('default' in local_types['attributes'][ka]):
+      attribute_node.set('default', local_types['attributes'][ka]['default'])
+
+    unique_values = []
+    for f in folders:
+      sub_values = list(set(local_types['attributes'][ka][f]))
+      unique_values.extend(sub_values)
+      attribute_node.set(f, ' | '.join(sub_values))
+
+    unique_length = len(set(unique_values))
+    attribute_node.set('unique_values', str(unique_length))
+
+  # Write children
+  for ka in sorted(local_types['children']):
+    child = ElementTree.Element(ka)
+    node.append(child)
+    write_attribute_usage_xml_level(local_types['children'][ka], child)
+
+
+def write_attribute_usage_xml(xml_types, fname):
+  """Write xml attribute usage file
+
+  @arg xml_types dict containing attribute usage by xml type
+  @arg fname output file name
+  """
+  xml_root = ElementTree.Element('Problem')
+  xml_tree = ElementTree.ElementTree(xml_root)
+
+  write_attribute_usage_xml_level(xml_types['Problem'], xml_root)
+  xml_tree.write(fname, pretty_print=True)
+
+
+def process_xml_files(geosx_root, output_name):
+  """Test for xml attribute usage
+
+  @arg geosx_root GEOSX root directory
+  @arg output_name output file name
+  """
+
+  # Parse the schema
+  geosx_root = os.path.expanduser(geosx_root)
+  schema = '%s/src/coreComponents/fileIO/schema/schema.xsd' % (geosx_root)
+  xml_types = parse_schema(schema)
+
+  # Find all xml files, collect their attributes
+  for folder in ['src', 'examples']:
+    print(folder)
+    xml_files = Path(os.path.join(geosx_root, folder)).rglob('*.xml')
+    for f in xml_files:
+      print('  %s' % (str(f)))
+      collect_xml_attributes(xml_types, str(f), folder)
+
+  # Consolidate attributes
+  write_attribute_usage_xml(xml_types, output_name)
+
+
+def main():
+  """Entry point for the xml attribute usage test script
+
+  @arg -r/--root GEOSX root directory
+  @arg -o/--output output file name
+  """
+
+  # Parse the user arguments
+  parser = argparse.ArgumentParser()
+  parser.add_argument('-r', '--root', type=str, help='GEOSX root', default='')
+  parser.add_argument('-o', '--output', type=str, help='Output file name', default='attribute_test.xml')
+  args = parser.parse_args()
+
+  # Parse the xml files
+  process_xml_files(args.root, args.output)
+
+
+if __name__ == "__main__":
+  main()
+

--- a/src/coreComponents/python/modules/geosx_xml_tools_package/setup.py
+++ b/src/coreComponents/python/modules/geosx_xml_tools_package/setup.py
@@ -8,6 +8,7 @@ setup(name='geosx_xml_tools',
       packages=['geosx_xml_tools', 'geosx_xml_tools.tests'],
       entry_points={'console_scripts': ['preprocess_xml = geosx_xml_tools.__main__:main',
                                         'format_xml = geosx_xml_tools.xml_formatter:main',
-                                        'test_geosx_xml_tools = geosx_xml_tools.tests.test_manager:run_unit_tests']},
+                                        'test_geosx_xml_tools = geosx_xml_tools.tests.test_manager:run_unit_tests',
+                                        'test_attribute_coverage = geosx_xml_tools.attribute_coverage:main']},
       install_requires=['lxml>=4.5.0'])
 


### PR DESCRIPTION
@TotoGaz, @rrsettgast  -  I added a script that will attempt to parse every xml file in the repository, finding every unique instance of an attribute.  The results are written into an attribute coverage xml file.  Here are some examples of the attribute summary:

```xml
<rockToughness
        src="0.5e100 | 1e7 | 1.0e6 | 1e6 | 1e5 | 0.707e7"
        examples="3e6 | 0.01e6 | 3.0e6 | 0.5e6 | 1.0e6 | 0.1e6 | 0.3e6 | 1e6"
        unique_values="12"/>
<solidMaterialNames
        src="{ granite } | { rock }"
        examples="{ granite } | { rock }"
        unique_values="2"/>
<newtonTol
        default="1e-06"
        src=""
        examples=""
        unique_values="0"/>
```

Here, src and examples are a list of unique values for xml files found in their corresponding directories (delimited by " | ").  If there is a default value specified in the schema, it will be listed.  The number of unique values across all xml files is given by unique_values.

See this file for the current summary: 
[attribute_coverage.xml.txt](https://github.com/GEOSX/GEOSX/files/5053882/attribute_coverage.xml.txt)




