### PR TITLE
Add a function to return shear and bulk modulus from constitutive model

### DIFF
--- a/examples/hydraulicFracturing/PKN/PKNBase.xml
+++ b/examples/hydraulicFracturing/PKN/PKNBase.xml
@@ -17,12 +17,12 @@
     <InternalMesh
       name="mesh1"
       elementTypes="{ C3D8 }"
-      xCoords="{ 0, 150, 200, 400 }"
-      yCoords="{ 0, 150, 200, 400 }"
-      zCoords="{ -400, -100, -20, 20, 100, 400 }"
-      nx="{ 75, 10, 20 }"
-      ny="{ 75, 10, 20 }"
-      nz="{ 10, 10, 20, 10, 10 }"
+      xCoords="{ 0, 10 }"
+      yCoords="{ 0, 10 }"
+      zCoords="{ -20, 20 }"
+      nx="{ 10 }"
+      ny="{ 10 }"
+      nz="{ 10 }"
       cellBlockNames="{ cb1 }"/>
 
     <!--InternalMesh name="mesh1"

--- a/examples/hydraulicFracturing/PKN/PKN_ZeroToughness.xml
+++ b/examples/hydraulicFracturing/PKN/PKN_ZeroToughness.xml
@@ -13,7 +13,7 @@
       name="hydrofracture"
       solidSolverName="lagsolve"
       fluidSolverName="SinglePhaseFlow"
-      couplingTypeOption="TightlyCoupled"
+      couplingTypeOption="FIM"
       logLevel="1"
       targetRegions="{ Region2, Fracture }"
       contactRelationName="fractureContact"


### PR DESCRIPTION
The Surface generator requires shear and bulk moduli to calculate nodal forces. In the linear elastic isotropic model, the shear and bulk moduli are provided or calculated from elastic parameters. However, in the transverse isotropic model, the shear and bulk moduli do not exist. This PR aims to add a function to calculate and return the shear and bulk moduli, for both the isotropic and transverse isotropic models. 