### PR TITLE
Using accessors when they are available.

### DIFF
--- a/src/coreComponents/fileIO/coupling/ChomboCoupler.cpp
+++ b/src/coreComponents/fileIO/coupling/ChomboCoupler.cpp
@@ -58,7 +58,7 @@ void ChomboCoupler::write( double dt )
   }
 
   arrayView1d< integer const > const & ruptureState = faces->getExtrinsicData< extrinsicMeshData::RuptureState >();
-  arrayView1d< integer const > const & ghostRank = faces->getReference< integer_array >( faces->viewKeys.ghostRank );
+  arrayView1d< integer const > const & ghostRank = faces->ghostRank();
 
   bool * faceMask = new bool[n_faces];
   for( localIndex i = 0; i < n_faces; ++i )

--- a/src/coreComponents/linearAlgebra/unitTests/testDofManagerUtils.hpp
+++ b/src/coreComponents/linearAlgebra/unitTests/testDofManagerUtils.hpp
@@ -141,8 +141,7 @@ struct forLocalObjectsImpl
     using helper = testMeshHelper< LOC >;
     ObjectManagerBase const * const manager = mesh->GetGroup< ObjectManagerBase >( helper::managerKey );
 
-    arrayView1d< integer const > ghostRank =
-      manager->getReference< array1d< integer > >( ObjectManagerBase::viewKeyStruct::ghostRankString );
+    arrayView1d< integer const > ghostRank = manager->ghostRank();
 
     array1d< bool > visited( ghostRank.size() );
 
@@ -186,8 +185,7 @@ struct forLocalObjectsImpl< DofManager::Location::Elem >
                                                                             ElementRegionBase const &,
                                                                             ElementSubRegionBase const & subRegion )
     {
-      arrayView1d< integer const > ghostRank =
-        subRegion.getReference< array1d< integer > >( ObjectManagerBase::viewKeyStruct::ghostRankString );
+      arrayView1d< integer const > ghostRank = subRegion.ghostRank();
 
       for( localIndex ei = 0; ei < subRegion.size(); ++ei )
       {

--- a/src/coreComponents/managers/DomainPartition.cpp
+++ b/src/coreComponents/managers/DomainPartition.cpp
@@ -89,21 +89,20 @@ void DomainPartition::GenerateSets()
   GEOSX_MARK_FUNCTION;
 
   MeshLevel * const mesh = this->getMeshBody( 0 )->getMeshLevel( 0 );
-  Group const * const nodeManager = mesh->getNodeManager();
+  NodeManager const * const nodeManager = mesh->getNodeManager();
 
-  dataRepository::Group const * const
-  nodeSets = nodeManager->GetGroup( ObjectManagerBase::groupKeyStruct::setsString );
+  dataRepository::Group const & nodeSets = nodeManager->sets();
 
   map< string, array1d< bool > > nodeInSet; // map to contain indicator of whether a node is in a set.
   string_array setNames; // just a holder for the names of the sets
 
   // loop over all wrappers and fill the nodeIndSet arrays for each set
-  for( auto & wrapper : nodeSets->wrappers() )
+  for( auto & wrapper : nodeSets.wrappers() )
   {
     string name = wrapper.second->getName();
     nodeInSet[name].resize( nodeManager->size() );
     nodeInSet[name].setValues< serialPolicy >( false );
-    Wrapper< SortedArray< localIndex > > const * const setPtr = nodeSets->getWrapper< SortedArray< localIndex > >( name );
+    Wrapper< SortedArray< localIndex > > const * const setPtr = nodeSets.getWrapper< SortedArray< localIndex > >( name );
     if( setPtr!=nullptr )
     {
       setNames.emplace_back( name );

--- a/src/coreComponents/mpiCommunications/CommunicationTools.cpp
+++ b/src/coreComponents/mpiCommunications/CommunicationTools.cpp
@@ -87,7 +87,7 @@ void CommunicationTools::AssignGlobalIndices( ObjectManagerBase & object,
                                               std::vector< NeighborCommunicator > & neighbors )
 {
   GEOSX_MARK_FUNCTION;
-  integer_array & ghostRank = object.getReference< integer_array >( object.m_ObjectManagerBaseViewKeys.ghostRank );
+  arrayView1d< integer > const & ghostRank = object.ghostRank();
   ghostRank.setValues< serialPolicy >( -2 );
 
   int const commRank = MpiWrapper::Comm_rank();

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFlow.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFlow.cpp
@@ -1409,8 +1409,7 @@ void CompositionalMultiphaseFlow::ChopNegativeDensities( DomainPartition & domai
   localIndex const NC = m_numComponents;
   forTargetSubRegions( mesh, [&]( localIndex const, ElementSubRegionBase & subRegion )
   {
-    arrayView1d< integer const > const & ghostRank =
-      subRegion.getReference< array1d< integer > >( ObjectManagerBase::viewKeyStruct::ghostRankString );
+    arrayView1d< integer const > const & ghostRank = subRegion.ghostRank();
 
     arrayView2d< real64 const > const & compDens =
       subRegion.getReference< array2d< real64 > >( viewKeyStruct::globalCompDensityString );

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseHybridFVM.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseHybridFVM.cpp
@@ -318,8 +318,7 @@ real64 SinglePhaseHybridFVM::CalculateResidualNorm( DomainPartition const & doma
     subRegionCounter++;
   } );
 
-  arrayView1d< integer const > const & faceGhostRank =
-    faceManager.getReference< array1d< integer > >( ObjectManagerBase::viewKeyStruct::ghostRankString );
+  arrayView1d< integer const > const & faceGhostRank = faceManager.ghostRank();
   arrayView1d< globalIndex const > const & faceDofNumber =
     faceManager.getReference< array1d< globalIndex > >( faceDofKey );
 
@@ -410,8 +409,7 @@ SinglePhaseHybridFVM::CheckSystemSolution( DomainPartition const & domain,
 
   } );
 
-  arrayView1d< integer const > const & faceGhostRank =
-    faceManager.getReference< array1d< integer > >( ObjectManagerBase::viewKeyStruct::ghostRankString );
+  arrayView1d< integer const > const & faceGhostRank = faceManager.ghostRank();
   arrayView1d< globalIndex const > const & faceDofNumber =
     faceManager.getReference< array1d< globalIndex > >( faceDofKey );
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseHybridFVMKernels.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseHybridFVMKernels.cpp
@@ -448,8 +448,7 @@ FluxKernel::Launch( localIndex er,
                     arrayView1d< real64 > const & localRhs )
 {
   // get the cell-centered DOF numbers and ghost rank for the assembly
-  arrayView1d< integer const > const & elemGhostRank =
-    subRegion.getReference< array1d< integer > >( ObjectManagerBase::viewKeyStruct::ghostRankString );
+  arrayView1d< integer const > const & elemGhostRank = subRegion.ghostRank();
 
   // get the map from elem to faces
   arrayView2d< localIndex const > const & elemToFaces = subRegion.faceList();

--- a/src/coreComponents/physicsSolvers/fluidFlow/unitTests/testCompMultiphaseFlow.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/unitTests/testCompMultiphaseFlow.cpp
@@ -530,8 +530,7 @@ void testNumericalJacobian( CompositionalMultiphaseFlow & solver,
   solver.forTargetSubRegions( mesh, [&]( localIndex const,
                                          ElementSubRegionBase & subRegion )
   {
-    arrayView1d< integer const > const & elemGhostRank =
-      subRegion.getReference< array1d< integer > >( ObjectManagerBase::viewKeyStruct::ghostRankString );
+    arrayView1d< integer const > const & elemGhostRank = subRegion.ghostRank();
 
     arrayView1d< globalIndex const > const & dofNumber =
       subRegion.getReference< array1d< globalIndex > >( dofKey );

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
@@ -579,8 +579,7 @@ void CompositionalMultiphaseWell::AssembleVolumeBalanceTerms( real64 const GEOSX
     string const wellDofKey = dofManager.getKey( WellElementDofName() );
     arrayView1d< globalIndex const > const & wellElemDofNumber =
       subRegion.getReference< array1d< globalIndex > >( wellDofKey );
-    arrayView1d< integer const > const & wellElemGhostRank =
-      subRegion.getReference< array1d< integer > >( ObjectManagerBase::viewKeyStruct::ghostRankString );
+    arrayView1d< integer const > const & wellElemGhostRank = subRegion.ghostRank();
 
     // get the properties on the well element
     arrayView2d< real64 const > const & wellElemPhaseVolFrac =
@@ -627,8 +626,7 @@ CompositionalMultiphaseWell::CalculateResidualNorm( DomainPartition const & doma
     string const wellDofKey = dofManager.getKey( WellElementDofName() );
     arrayView1d< globalIndex const > const & wellElemDofNumber =
       subRegion.getReference< array1d< globalIndex > >( wellDofKey );
-    arrayView1d< integer const > const & wellElemGhostRank =
-      subRegion.getReference< array1d< integer > >( ObjectManagerBase::viewKeyStruct::ghostRankString );
+    arrayView1d< integer const > const & wellElemGhostRank = subRegion.ghostRank();
     arrayView1d< real64 const > const & wellElemVolume =
       subRegion.getReference< array1d< real64 > >( ElementSubRegionBase::viewKeyStruct::elementVolumeString );
 
@@ -673,8 +671,7 @@ CompositionalMultiphaseWell::ScalingForSystemSolution( DomainPartition const & d
     string const wellDofKey = dofManager.getKey( WellElementDofName() );
     arrayView1d< globalIndex const > const & wellElemDofNumber =
       subRegion.getReference< array1d< globalIndex > >( wellDofKey );
-    arrayView1d< integer const > const & wellElemGhostRank =
-      subRegion.getReference< array1d< integer > >( ObjectManagerBase::viewKeyStruct::ghostRankString );
+    arrayView1d< integer const > const & wellElemGhostRank = subRegion.ghostRank();
 
     // get a reference to the primary variables on well elements
     arrayView2d< real64 const > const & wellElemCompDens =
@@ -721,8 +718,7 @@ CompositionalMultiphaseWell::CheckSystemSolution( DomainPartition const & domain
     string const wellDofKey = dofManager.getKey( WellElementDofName() );
     arrayView1d< globalIndex const > const & wellElemDofNumber =
       subRegion.getReference< array1d< globalIndex > >( wellDofKey );
-    arrayView1d< integer const > const & wellElemGhostRank =
-      subRegion.getReference< array1d< integer > >( ObjectManagerBase::viewKeyStruct::ghostRankString );
+    arrayView1d< integer const > const & wellElemGhostRank = subRegion.ghostRank();
 
     // get a reference to the primary variables on well elements
     arrayView1d< real64 const > const & wellElemPressure =
@@ -902,8 +898,7 @@ void CompositionalMultiphaseWell::ChopNegativeDensities( DomainPartition & domai
   forTargetSubRegions< WellElementSubRegion >( meshLevel, [&]( localIndex const,
                                                                WellElementSubRegion & subRegion )
   {
-    arrayView1d< integer const > const & wellElemGhostRank =
-      subRegion.getReference< array1d< integer > >( ObjectManagerBase::viewKeyStruct::ghostRankString );
+    arrayView1d< integer const > const & wellElemGhostRank = subRegion.ghostRank();
 
     arrayView2d< real64 const > const & wellElemCompDens =
       subRegion.getReference< array2d< real64 > >( viewKeyStruct::globalCompDensityString );

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/SinglePhaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/SinglePhaseWell.cpp
@@ -397,8 +397,7 @@ SinglePhaseWell::CalculateResidualNorm( DomainPartition const & domain,
     string const wellDofKey = dofManager.getKey( WellElementDofName() );
     arrayView1d< globalIndex const > const & wellElemDofNumber =
       subRegion.getReference< array1d< globalIndex > >( wellDofKey );
-    arrayView1d< integer const > const & wellElemGhostRank =
-      subRegion.getReference< array1d< integer > >( ObjectManagerBase::viewKeyStruct::ghostRankString );
+    arrayView1d< integer const > const & wellElemGhostRank = subRegion.ghostRank();
     arrayView1d< real64 const > const & wellElemVolume = subRegion.getElementVolume();
 
     SingleFluidBase const & fluid = GetConstitutiveModel< SingleFluidBase >( subRegion, m_fluidModelNames[targetIndex] );
@@ -437,8 +436,7 @@ bool SinglePhaseWell::CheckSystemSolution( DomainPartition const & domain,
     string const wellDofKey = dofManager.getKey( WellElementDofName() );
     arrayView1d< globalIndex const > const & wellElemDofNumber =
       subRegion.getReference< array1d< globalIndex > >( wellDofKey );
-    arrayView1d< integer const > const & wellElemGhostRank =
-      subRegion.getReference< array1d< integer > >( ObjectManagerBase::viewKeyStruct::ghostRankString );
+    arrayView1d< integer const > const & wellElemGhostRank = subRegion.ghostRank();
 
     // get a reference to the primary variables on well elements
     arrayView1d< real64 const > const & wellElemPressure =


### PR DESCRIPTION
I've kept on refactoring a little bit `ObjectManagerBase`, trying to make the source code more homogeneous.
Here I change the `Group::getReference` + `key` class into `ObjectManagerBase` when they were available.