### PR TITLE
Travis CI - Cancel Travis builds for draft Pull Requests & Allow checks to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,72 +99,86 @@ geosx_pangea_build: &geosx_pangea_build
   - gcloud auth activate-service-account --key-file=${GEOSX_GCLOUD_KEY}
   - gsutil cp -a public-read ${GEOSX_BUNDLE} gs://geosx/Pangea2/
 
+return_script: &return_script
+  script:
+  - |
+    if [[ $(curl -sS -H "Travis-API-Version: 3" -X \
+          GET https://api.travis-ci.com/build/$TRAVIS_BUILD_ID/jobs | \
+          jq -r '.jobs[] | select( (.stage.name == "checks") and
+          (.allow_failure == true)) | .state') == *failed* ]]; then
+      exit 1
+    else
+      exit 0
+    fi
+
 stages:
-  - check_code_style_and_docs
-  - check_submodules
-  - build
+  - checks
+  - builds
+  - return_status
 
 jobs:
   allow_failures:
-  - name: code_style
   - name: documentation
   - name: check_submodules
   include:
-  - stage: check_code_style_and_docs
+  - stage: checks
     name: code_style
     <<: *geosx_linux_build
     env:
     - DOCKER_REPOSITORY=geosx/ubuntu18.04-gcc8
     - CMAKE_BUILD_TYPE=Release
     - BUILD_AND_TEST_ARGS=--test-code-style
-  - stage: check_code_style_and_docs
+  - stage: checks
     name: documentation
     <<: *geosx_linux_build
     env:
     - DOCKER_REPOSITORY=geosx/ubuntu18.04-gcc8
     - CMAKE_BUILD_TYPE=Release
     - BUILD_AND_TEST_ARGS=--test-documentation
-  - stage: check_submodules
+  - stage: checks
+    name: check_submodules
     script: scripts/test_submodule_updated.sh
-  - stage: build
+  - stage: builds
     name: Ubuntu18.04_clang8.0.0_cuda10.1.243_release
     <<: *geosx_linux_build
     env:
     - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
     - CMAKE_BUILD_TYPE=Release
     - BUILD_AND_TEST_ARGS=--disable-unit-tests
-  - stage: build
+  - stage: builds
     name: Centos7.6_gcc8.3.1_cuda10.1.243_release
     <<: *geosx_linux_build
     env:
     - DOCKER_REPOSITORY=geosx/centos7.6.1810-gcc8.3.1-cuda10.1.243
     - CMAKE_BUILD_TYPE=Release
     - BUILD_AND_TEST_ARGS=--disable-unit-tests
-  - stage: build
+  - stage: builds
     name: Pangea2_gcc8.3.0_release
     <<: *geosx_pangea_build
     env:
     - DOCKER_REPOSITORY=geosx/pangea2-gcc8.3.0-openmpi2.1.5-mkl2019.3
     - CMAKE_BUILD_TYPE=Release
     - BUILD_AND_TEST_ARGS=--disable-unit-tests
-  - stage: build
+  - stage: builds
     name: Mac_OSX
     <<: *geosx_osx_build
-  - stage: build
+  - stage: builds
     name: Centos7.7_clang9.0.0_release
     <<: *geosx_linux_build
     env:
     - DOCKER_REPOSITORY=geosx/centos7.7.1908-clang9.0.0
     - CMAKE_BUILD_TYPE=Release
-  - stage: build
+  - stage: builds
     name: Ubuntu18.04_gcc8_release
     <<: *geosx_linux_build
     env:
     - DOCKER_REPOSITORY=geosx/ubuntu18.04-gcc8
     - CMAKE_BUILD_TYPE=Release
-  - stage: build
+  - stage: builds
     name: Ubuntu18.04_gcc8_debug
     <<: *geosx_linux_build
     env:
     - DOCKER_REPOSITORY=geosx/ubuntu18.04-gcc8
     - CMAKE_BUILD_TYPE=Debug
+  - stage: return_status
+    <<: *return_script

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,10 +101,14 @@ geosx_pangea_build: &geosx_pangea_build
 
 stages:
   - check_code_style_and_docs
-  - build
   - check_submodules
+  - build
 
 jobs:
+  allow_failures:
+  - name: code_style
+  - name: documentation
+  - name: check_submodules
   include:
   - stage: check_code_style_and_docs
     name: code_style
@@ -120,6 +124,8 @@ jobs:
     - DOCKER_REPOSITORY=geosx/ubuntu18.04-gcc8
     - CMAKE_BUILD_TYPE=Release
     - BUILD_AND_TEST_ARGS=--test-documentation
+  - stage: check_submodules
+    script: scripts/test_submodule_updated.sh
   - stage: build
     name: Ubuntu18.04_clang8.0.0_cuda10.1.243_release
     <<: *geosx_linux_build
@@ -162,5 +168,3 @@ jobs:
     env:
     - DOCKER_REPOSITORY=geosx/ubuntu18.04-gcc8
     - CMAKE_BUILD_TYPE=Debug
-  - stage: check_submodules
-    script: scripts/test_submodule_updated.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ geosx_osx_build: &geosx_osx_build
     -DENABLE_GEOSX_PTP:BOOL=ON -DENABLE_DOXYGEN:BOOL=OFF
   - cd build-darwin-clang-debug
   - make -j $(nproc) VERBOSE=1
-  - ctest -V
+  - ctest -V -E "testUncrustifyCheck|testDoxygenCheck"
 
 geosx_pangea_build: &geosx_pangea_build
   <<: *geosx_linux_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: minimal
 env:
   global:
   - GEOSX_TPL_TAG=121-439
+  - secure: CGs2uH6efq1Me6xJWRr0BnwtwxoujzlowC4FHXHdWbNOkPsXf7nCgdaW5vthfD3bhnOeEUQSrfxdhTRtyU/NfcKLmKgGBnZOdUG4/JJK4gDSJ2Wp8LZ/mB0QEoODKVxbh+YtoAiHe3y4M9PGCs+wkNDw/3eEU00cK12DZ6gad0RbLjI3xkhEr/ZEZDZkcYg9yHAhl5bmpqoh/6QGnIg8mxIqdAtGDw+6tT0EgUqjeqc5bG5WwsamKzJItHSXD5zx8IJAlgDk4EzEGjZe0m56YnNfb9iwqqUsmL3Cuwgs7ByVDYw78JC5Kv42YqoxA5BxMT2mFsEe37TpYNXlzofU7ma2Duw9DGXWQd4IkTCcBxlyR0I0bfo0TmgO+y7PYG9lIyHPUkENemdozsZcWamqqkqegiEdRhDVYlSRo3mu7iCwTS6ZTALliVyEYjYxYb7oAnR3cNywXjblTCI8oKfgLSY+8WijM9SRl57JruIHLkLMCjmRI+cZBfv5tS2tYQTBPkygGrigrrN77ZiC7/TGyfggSN0+y0oYtOAgqEnBcKcreiibMW7tKcV2Z1RFD9ZvIkSc1EXLUPDP8FX1oyhmqBMqVo8LksrYLDJHQ05+F3YNgl2taSt7uMjQ4e8iZ3/IjFeMnbylDw+cj/RbS520HXsFPbWFm2Pb9pceA9n6GnY=
 
 # The integrated test repository contains large data (using git lfs) and we do not use them here.
 # To save time (and money) we do not let travis automatically clone all our (lfs) subrepositories and do it by hand.
@@ -105,13 +106,16 @@ draft_script: &draft_script
   - if [[ $TRAVIS_PULL_REQUEST == false ]]; then exit 0; fi;
   - |
     is_draft=$(curl -H "Accept: application/vnd.github.v3+json" \
-        https://api.github.com/repos/GEOSX/GEOSX/pulls/$TRAVIS_PULL_REQUEST | \
+        https://api.github.com/repos/$TRAVIS_PULL_REQUEST_SLUG/pulls/$TRAVIS_PULL_REQUEST | \
         jq ".draft")
 
   # CI jobs will be cancelled if PR is a draft.
   # PR status must be "Open" to run CI.
   - |
     if [[ $is_draft == true ]]; then
+      curl -sS -H "Travis-API-Version: 3" \
+      -H "Authorization: token $AUTH_VAR" \
+      -X POST https://api.travis-ci.com/build/$TRAVIS_BUILD_ID/cancel
       exit 1
     else
       exit 0
@@ -119,20 +123,20 @@ draft_script: &draft_script
 
 return_script: &return_script
   script:
+  # Verifies if all the "checks" jobs passed
   - |
-    if [[ $(curl -sS -H "Travis-API-Version: 3" -X \
-          GET https://api.travis-ci.com/build/$TRAVIS_BUILD_ID/jobs | \
-          jq -r '.jobs[] | select( (.stage.name == "checks") and
-          (.allow_failure == true)) | .state') == *failed* ]]; then
-      exit 1
-    else
-      exit 0
-    fi
+    states=$(curl -sS -H "Travis-API-Version: 3" \
+             -X GET https://api.travis-ci.com/build/$TRAVIS_BUILD_ID/jobs | \
+             jq -r '.jobs[] | select( (.stage.name == "checks") and
+             (.allow_failure == true)) | .state ')
+  - num_states=$(echo $states | wc -w)
+  - num_passed=$(echo $states | grep -o "passed" | wc -w)
+  - if [[ $num_states == $num_passed ]]; then exit 0; else exit 1; fi
 
 stages:
-  - checks
-  - builds
-  - return_status
+- checks
+- builds
+- return_status
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,24 @@ geosx_pangea_build: &geosx_pangea_build
   - gcloud auth activate-service-account --key-file=${GEOSX_GCLOUD_KEY}
   - gsutil cp -a public-read ${GEOSX_BUNDLE} gs://geosx/Pangea2/
 
+draft_script: &draft_script
+  script:
+  # TRAVIS_PULL_REQUEST is false if job is not from a PR
+  - if [[ $TRAVIS_PULL_REQUEST == false ]]; then exit 0; fi;
+  - |
+    is_draft=$(curl -H "Accept: application/vnd.github.v3+json" \
+        https://api.github.com/repos/GEOSX/GEOSX/pulls/$TRAVIS_PULL_REQUEST | \
+        jq ".draft")
+
+  # CI jobs will be cancelled if PR is a draft.
+  # PR status must be "Open" to run CI.
+  - |
+    if [[ $is_draft == true ]]; then
+      exit 1
+    else
+      exit 0
+    fi
+
 return_script: &return_script
   script:
   - |
@@ -118,9 +136,13 @@ stages:
 
 jobs:
   allow_failures:
+  - name: code_style
   - name: documentation
   - name: check_submodules
   include:
+  - stage: checks
+    name: check_pr_is_not_a_draft
+    <<: *draft_script
   - stage: checks
     name: code_style
     <<: *geosx_linux_build

--- a/scripts/travis_build_and_test.sh
+++ b/scripts/travis_build_and_test.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 env
+
 # The or_die function run the passed command line and
 # exits the program in case of non zero error code
 function or_die () {
     "$@"
     local status=$?
+
     if [[ $status != 0 ]] ; then
         echo ERROR $status command: $@
         exit $status

--- a/scripts/travis_build_and_test.sh
+++ b/scripts/travis_build_and_test.sh
@@ -50,9 +50,9 @@ fi
 or_die make -j $(nproc) VERBOSE=1
 or_die make install VERBOSE=1
 
-# Unit tests
+# Unit tests (excluding previously ran checks)
 if [[ "$*" != *--disable-unit-tests* ]]; then
-  or_die ctest -V
+  or_die ctest -V -E "testUncrustifyCheck|testDoxygenCheck"
 fi
 
 exit 0


### PR DESCRIPTION
This PR makes the following changes to Travis:

- **Travis builds from _draft_ pull requests will be cancelled**. The `check_pr_is_not_a_draft` job will cancel builds from draft PR's.  **Open** pull requests should not be affected, Travis builds should run.
-  Allows the `code_style`, `documentation`, and `check_submodules` jobs in the `checks` stage to fail.  Failing these jobs will no longer block the Travis build from progressing to the `builds` stage.
- Adds a `return_status` stage at the end of the build that fails if any of the jobs in the `checks` stage fails. This was added as a workaround to Travis returning a "passed" build status when `checks` jobs were failing.