### PR TITLE
Fix parallel VTK output for wells

### DIFF
--- a/src/coreComponents/fileIO/vtk/VTKPolyDataWriterInterface.cpp
+++ b/src/coreComponents/fileIO/vtk/VTKPolyDataWriterInterface.cpp
@@ -114,10 +114,11 @@ std::pair< vtkSmartPointer< vtkPoints >, vtkSmartPointer< vtkCellArray > >VTKPol
                                                                                                                NodeManager const & nodeManager ) const
 {
   vtkSmartPointer< vtkPoints > points = vtkPoints::New();
-  points->SetNumberOfPoints( esr.size() + 1 );
+  localIndex const numPoints = esr.size() > 0 ? esr.size() + 1 : 0;
+  points->SetNumberOfPoints( numPoints );
   vtkSmartPointer< vtkCellArray > cellsArray = vtkCellArray::New();
   cellsArray->SetNumberOfCells( esr.size() );
-  localIndex numberOfNodesPerElement = esr.numNodesPerElement();
+  localIndex const numberOfNodesPerElement = esr.numNodesPerElement();
   GEOSX_ERROR_IF_NE( numberOfNodesPerElement, 2 );
   std::vector< vtkIdType > connectivity( numberOfNodesPerElement );
 


### PR DESCRIPTION
The PR fixes a crash in parallel simulations with wells that is occurring when a given rank does not have a well. In that case, the `WellElementSubRegion` on this rank has a size equal to zero, but we were specifying a number of points equal to one. This PR sets the number of points to zero is the sub-region size is zero, and to `esr.size()+1` otherwise.

This fixes this crash for the HI24L case that exhibited this problem.

Resolves #1018.

 