### PR TITLE
Travis CI - Check if LvArray commit is in develop's history

### DIFF
--- a/scripts/test_submodule_updated.sh
+++ b/scripts/test_submodule_updated.sh
@@ -42,6 +42,8 @@ length=${#paths_array[@]}
 
 # Returns exit code 0 if the hash for every submodule in the PR is equal
 # to the hash of each submodule's main branch (develop or master).
+# Note: For LvArray submodule only, checks if the PR hash is in the
+#       main branch's commit history.
 # Note: See "exclusion_list" for submodules that are exempted.
 exit_code=0
 unsync_submodules=()
@@ -77,7 +79,22 @@ do
   # PR hash with prefixed character removed
   pr_hash="$( echo ${pr_hashes_array[$i]} | tr -cd [:alnum:] )"
 
-  if [ $pr_hash == $main_hash ]
+  if [ $module_name == "LvArray" ]
+  then
+    lv_array_commits="$(git -C ${paths_array[$i]} log $main_branch --pretty=%H)"
+    if grep -q "$pr_hash" <<< "$lv_array_commits"
+    then
+      echo "Submodule LvArray's main branch $main_branch contains"\
+            "PR branch's latest commit : $pr_hash"
+    else
+      echo "Submodule LvArray's main branch $main_branch does not contain"\
+            "PR branch's latest commit : $pr_hash"
+      echo "---- PR branch has latest hash $pr_hash"
+      echo "---- $module_name/$main_branch has latest hash $main_hash"
+      unsync_submodules+=( "$module_name" )
+      exit_code=1
+    fi
+  elif [ $pr_hash == $main_hash ]
   then
     echo "PR branch and $main_branch have the same hashes for submodule"\
          "$module_name : $pr_hash"


### PR DESCRIPTION
This PR relaxes the submodule check for the LvArray submodule. 
Instead of checking if the PR branch's LvArray commit is the same as the head of LvArray's develop branch, 
the submodule check will verify if the PR commit is in LvArray's develop commit history.