### PR TITLE
Prevent Adiak conversion issue on AppleClang

### DIFF
--- a/src/coreComponents/managers/initialization.cpp
+++ b/src/coreComponents/managers/initialization.cpp
@@ -181,7 +181,7 @@ void setupCaliper()
   std::int64_t const numThreads = 1;
   adiak::value( "OpenMP", "Off" );
 #endif
-  pushStatsIntoAdiak( "numThreads", static_cast<int>(numThreads) );
+  pushStatsIntoAdiak( "numThreads", static_cast< int >(numThreads) );
 
   // CUDA info
   int cudaRuntimeVersion = 0;

--- a/src/coreComponents/managers/initialization.cpp
+++ b/src/coreComponents/managers/initialization.cpp
@@ -181,7 +181,7 @@ void setupCaliper()
   std::int64_t const numThreads = 1;
   adiak::value( "OpenMP", "Off" );
 #endif
-  pushStatsIntoAdiak( "numThreads", numThreads );
+  pushStatsIntoAdiak( "numThreads", static_cast<int>(numThreads) );
 
   // CUDA info
   int cudaRuntimeVersion = 0;


### PR DESCRIPTION
Had to `static_cast` a variable of type `long long` to a simple `int` for Adiak. 