### PR TITLE
Fixing a typo in the default executable group timestep request

### DIFF
--- a/src/coreComponents/dataRepository/ExecutableGroup.hpp
+++ b/src/coreComponents/dataRepository/ExecutableGroup.hpp
@@ -90,7 +90,7 @@ public:
   virtual real64 GetTimestepRequest( real64 const time )
   {
     GEOSX_UNUSED_VAR( time );
-    return std::numeric_limits< integer >::max();
+    return 0.1 * std::numeric_limits< real64 >::max();
   }
 
 

--- a/src/coreComponents/dataRepository/ExecutableGroup.hpp
+++ b/src/coreComponents/dataRepository/ExecutableGroup.hpp
@@ -90,7 +90,7 @@ public:
   virtual real64 GetTimestepRequest( real64 const time )
   {
     GEOSX_UNUSED_VAR( time );
-    return 0.1 * std::numeric_limits< real64 >::max();
+    return 1e99;
   }
 
 


### PR DESCRIPTION
I'm suspicious about allowing the maximum double size for the default timestep request, so I'm setting it to 1/10th of max.

resolves #1163 