### PR TITLE
Enable unit tests for Pangea 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -174,21 +174,18 @@ jobs:
     env:
     - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
     - CMAKE_BUILD_TYPE=Release
-    - BUILD_AND_TEST_ARGS=--disable-unit-tests
   - stage: builds
     name: Centos7.6_gcc8.3.1_cuda10.1.243_release
     <<: *geosx_linux_build
     env:
     - DOCKER_REPOSITORY=geosx/centos7.6.1810-gcc8.3.1-cuda10.1.243
     - CMAKE_BUILD_TYPE=Release
-    - BUILD_AND_TEST_ARGS=--disable-unit-tests
   - stage: builds
     name: Pangea2_gcc8.3.0_release
     <<: *geosx_pangea_build
     env:
     - DOCKER_REPOSITORY=geosx/pangea2-gcc8.3.0-openmpi2.1.5-mkl2019.3
     - CMAKE_BUILD_TYPE=Release
-    - BUILD_AND_TEST_ARGS=--disable-unit-tests
   - stage: builds
     name: Mac_OSX
     <<: *geosx_osx_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -174,14 +174,14 @@ jobs:
     env:
     - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
     - CMAKE_BUILD_TYPE=Release
-    - BUILD_AND_TEST_ARGS=--disable-unit-tests	
+    - BUILD_AND_TEST_ARGS=--disable-unit-tests
   - stage: builds
     name: Centos7.6_gcc8.3.1_cuda10.1.243_release
     <<: *geosx_linux_build
     env:
     - DOCKER_REPOSITORY=geosx/centos7.6.1810-gcc8.3.1-cuda10.1.243
     - CMAKE_BUILD_TYPE=Release
-    - BUILD_AND_TEST_ARGS=--disable-unit-tests	
+    - BUILD_AND_TEST_ARGS=--disable-unit-tests
   - stage: builds
     name: Pangea2_gcc8.3.0_release
     <<: *geosx_pangea_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -174,12 +174,14 @@ jobs:
     env:
     - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
     - CMAKE_BUILD_TYPE=Release
+    - BUILD_AND_TEST_ARGS=--disable-unit-tests	
   - stage: builds
     name: Centos7.6_gcc8.3.1_cuda10.1.243_release
     <<: *geosx_linux_build
     env:
     - DOCKER_REPOSITORY=geosx/centos7.6.1810-gcc8.3.1-cuda10.1.243
     - CMAKE_BUILD_TYPE=Release
+    - BUILD_AND_TEST_ARGS=--disable-unit-tests	
   - stage: builds
     name: Pangea2_gcc8.3.0_release
     <<: *geosx_pangea_build


### PR DESCRIPTION
Unit tests were not activated for Pangea2.
There is not specific reason so let's reactivate them.