### PR TITLE
KGD input file fix: add Fracture into the targetRegions in the SolidM…

### DIFF
--- a/examples/hydraulicFracturing/KGD/KGD_ZeroToughness.xml
+++ b/examples/hydraulicFracturing/KGD/KGD_ZeroToughness.xml
@@ -35,7 +35,7 @@
       timeIntegrationOption="QuasiStatic"
       logLevel="0"
       discretization="FE1"
-      targetRegions="{ Region2 }"
+      targetRegions="{ Region2, Fracture }"
       solidMaterialNames="{ rock }"
       contactRelationName="fractureContact">
       <NonlinearSolverParameters

--- a/examples/hydraulicFracturing/KGD/KGD_ZeroViscosity.xml
+++ b/examples/hydraulicFracturing/KGD/KGD_ZeroViscosity.xml
@@ -35,7 +35,7 @@
       timeIntegrationOption="QuasiStatic"
       logLevel="0"
       discretization="FE1"
-      targetRegions="{ Region2 }"
+      targetRegions="{ Region2, Fracture }"
       solidMaterialNames="{ rock }"
       contactRelationName="fractureContact">
       <NonlinearSolverParameters


### PR DESCRIPTION
…echanicsLagrangianSSLE block

Without the modification, we would have the following error at the beginning of the simulation:
Running simulation
Time: 0s, dt:0.2s, Cycle: 0
***** ERROR
***** LOCATION: /usr/WS1/jin10/geosx_dev/GEOSX/src/coreComponents/linearAlgebra/DofManager.cpp:1676
***** Controlling expression (should be false): std::find( rowRegions.begin(), rowRegions.end(), regionName ) == rowRegions.end()
***** Rank 2: Region 'Fracture' does not belong to the domain of field 'TotalDisplacement'