### PR TITLE
Corbett/update lvarray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: minimal
 
 env:
   global:
-  - GEOSX_TPL_TAG=131-527
+  - GEOSX_TPL_TAG=133-539
   - secure: CGs2uH6efq1Me6xJWRr0BnwtwxoujzlowC4FHXHdWbNOkPsXf7nCgdaW5vthfD3bhnOeEUQSrfxdhTRtyU/NfcKLmKgGBnZOdUG4/JJK4gDSJ2Wp8LZ/mB0QEoODKVxbh+YtoAiHe3y4M9PGCs+wkNDw/3eEU00cK12DZ6gad0RbLjI3xkhEr/ZEZDZkcYg9yHAhl5bmpqoh/6QGnIg8mxIqdAtGDw+6tT0EgUqjeqc5bG5WwsamKzJItHSXD5zx8IJAlgDk4EzEGjZe0m56YnNfb9iwqqUsmL3Cuwgs7ByVDYw78JC5Kv42YqoxA5BxMT2mFsEe37TpYNXlzofU7ma2Duw9DGXWQd4IkTCcBxlyR0I0bfo0TmgO+y7PYG9lIyHPUkENemdozsZcWamqqkqegiEdRhDVYlSRo3mu7iCwTS6ZTALliVyEYjYxYb7oAnR3cNywXjblTCI8oKfgLSY+8WijM9SRl57JruIHLkLMCjmRI+cZBfv5tS2tYQTBPkygGrigrrN77ZiC7/TGyfggSN0+y0oYtOAgqEnBcKcreiibMW7tKcV2Z1RFD9ZvIkSc1EXLUPDP8FX1oyhmqBMqVo8LksrYLDJHQ05+F3YNgl2taSt7uMjQ4e8iZ3/IjFeMnbylDw+cj/RbS520HXsFPbWFm2Pb9pceA9n6GnY=
 
 # The integrated test repository contains large data (using git lfs) and we do not use them here.

--- a/host-configs/LLNL/lassen-base.cmake
+++ b/host-configs/LLNL/lassen-base.cmake
@@ -1,0 +1,52 @@
+###############################################################################
+#
+# Base configuration for LC Quartz builds
+# Calling configuration file must define the following CMAKE variables:
+#
+# MPI_HOME
+#
+###############################################################################
+
+# Fortran
+set(ENABLE_FORTRAN OFF CACHE BOOL "")
+
+# MPI
+set(ENABLE_MPI ON CACHE BOOL "")
+set(MPI_C_COMPILER ${MPI_HOME}/bin/mpicc CACHE PATH "")
+set(MPI_CXX_COMPILER ${MPI_HOME}/bin/mpicxx CACHE PATH "")
+set(MPIEXEC lrun CACHE STRING "")
+set(MPIEXEC_NUMPROC_FLAG -n CACHE STRING "")
+set(ENABLE_WRAP_ALL_TESTS_WITH_MPIEXEC ON CACHE BOOL "")
+
+# OpenMP
+set(ENABLE_OPENMP ON CACHE BOOL "" FORCE)
+
+# CUDA
+# LvArray sets this to the CMAKE_CXX_COMPILER.
+set(CMAKE_CUDA_HOST_COMPILER ${MPI_CXX_COMPILER} CACHE STRING "")
+
+# ESSL
+set(ENABLE_ESSL ON CACHE BOOL "")
+set(ESSL_INCLUDE_DIRS /usr/tcetmp/packages/essl/essl-6.2/include CACHE STRING "")
+set(ESSL_LIBRARIES /usr/tcetmp/packages/essl/essl-6.2/lib64/libesslsmpcuda.so
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlsmp.so
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlfmath.so
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlf90_r.so
+                   ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcublas.so
+                   ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcudart.so
+                   ${GEOSX_TPL_ROOT_DIR}/liblapackforesslgeosx.a
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxl.a
+                   CACHE PATH "")
+
+# TPL
+set(ENABLE_PAPI OFF CACHE BOOL "")
+set(SILO_BUILD_TYPE powerpc64-unknown-linux-gnu CACHE STRING "")
+
+# GEOSX specific options
+set(ENABLE_MATHPRESSO OFF CACHE BOOL "")
+set(GEOSX_BUILD_SHARED_LIBS OFF CACHE BOOL "")
+set(ENABLE_PAMELA ON CACHE BOOL "")
+set(ENABLE_PVTPackage ON CACHE BOOL "")
+set(ENABLE_GEOSX_PTP ON CACHE BOOL "")
+set(ENABLE_PETSC OFF CACHE BOOL "" FORCE )
+set(ENABLE_HYPRE OFF CACHE BOOL "" FORCE )

--- a/host-configs/LLNL/lassen-clang@upstream.cmake
+++ b/host-configs/LLNL/lassen-clang@upstream.cmake
@@ -1,37 +1,14 @@
 include(${CMAKE_CURRENT_LIST_DIR}/../../src/coreComponents/LvArray/host-configs/LLNL/lassen-clang@upstream.cmake)
 
-# asmjit doesn't work on PowerPC
-set(ENABLE_MATHPRESSO OFF CACHE BOOL "")
+# Fortran
+set(CMAKE_Fortran_COMPILER /usr/tce/packages/xl/xl-beta-2019.06.20/bin/xlf_r CACHE PATH "")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -DNDEBUG -qarch=pwr9 -qtune=pwr9" CACHE STRING "")
+set(FORTRAN_MANGLE_NO_UNDERSCORE ON CACHE BOOL "")
+set(OpenMP_Fortran_FLAGS "-qsmp=omp" CACHE STRING "")
+set(OpenMP_Fortran_LIB_NAMES "" CACHE STRING "")
 
-# Builds static libraries
-set(GEOSX_BUILD_SHARED_LIBS OFF CACHE BOOL "")
+# MPI
+set(MPI_HOME /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-upstream-2019.03.26 CACHE PATH "")
+set(MPI_Fortran_COMPILER /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-beta-2019.06.20/bin/mpifort CACHE PATH "")
 
-# Silo configure script doesn't recognize systype
-set(SILO_BUILD_TYPE powerpc64-unknown-linux-gnu CACHE STRING "")
-
-set(ENABLE_PAMELA ON CACHE BOOL "")
-set(ENABLE_PVTPackage ON CACHE BOOL "")
-set(ENABLE_GEOSX_PTP ON CACHE BOOL "")
-
-set(ENABLE_CALIPER ON CACHE BOOL "")
-set(ENABLE_PAPI OFF CACHE BOOL "")
-
-set(ENABLE_UNCRUSTIFY OFF CACHE BOOL "")
-set(ENABLE_DOXYGEN OFF CACHE BOOL "")
-
-set(ENABLE_ESSL ON CACHE BOOL "")
-set(ESSL_INCLUDE_DIRS /usr/tcetmp/packages/essl/essl-6.2/include CACHE STRING "")
-set(ESSL_LIBRARIES /usr/tcetmp/packages/essl/essl-6.2/lib64/libesslsmpcuda.so
-                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlsmp.so
-                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlfmath.so
-                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlf90_r.so
-                   ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcublas.so
-                   ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcudart.so
-                   ${GEOSX_TPL_ROOT_DIR}/liblapackforesslgeosx.a
-                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxl.a
-                   CACHE PATH "")
-
-# PETSc doesn't seem to work correctly with clang.
-set(ENABLE_PETSC OFF CACHE BOOL "" FORCE )
-#set(PETSC_OMP_DIR ${GEOSX_TPL_ROOT_DIR}/omp-links-for-petsc CACHE STRING "")
-set(ENABLE_HYPRE OFF CACHE BOOL "" FORCE )
+include(${CMAKE_CURRENT_LIST_DIR}/lassen-base.cmake)

--- a/host-configs/LLNL/lassen-gcc@8.3.1.cmake
+++ b/host-configs/LLNL/lassen-gcc@8.3.1.cmake
@@ -1,45 +1,17 @@
 include(${CMAKE_CURRENT_LIST_DIR}/../../src/coreComponents/LvArray/host-configs/LLNL/lassen-gcc@8.3.1.cmake)
 
-# asmjit doesn't work on PowerPC
-set(ENABLE_MATHPRESSO OFF CACHE BOOL "")
+# C++
+# The "-march=native -mtune=native" which LvArray adds breaks the PVT package.
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG" CACHE STRING "" FORCE)
+set(CMAKE_CUDA_FLAGS_RELEASE "-O3 -DNDEBUG -Xcompiler -DNDEBUG -Xcompiler -O3" CACHE STRING "" FORCE)
 
-# Builds static libraries
-set(GEOSX_BUILD_SHARED_LIBS OFF CACHE BOOL "")
+# Fortran
+set(CMAKE_Fortran_COMPILER /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran CACHE PATH "")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -DNDEBUG -mcpu=power9 -mtune=power9" CACHE STRING "")
+set(FORTRAN_MANGLE_NO_UNDERSCORE OFF CACHE BOOL "")
 
-# Silo configure script doesn't recognize systype
-set(SILO_BUILD_TYPE powerpc64-unknown-linux-gnu CACHE STRING "")
+# MPI
+set(MPI_HOME /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-8.3.1 CACHE PATH "")
+set(MPI_Fortran_COMPILER ${MPI_HOME}/bin/mpifort CACHE PATH "")
 
-set(ENABLE_PAMELA ON CACHE BOOL "")
-set(ENABLE_PVTPackage ON CACHE BOOL "")
-set(ENABLE_GEOSX_PTP ON CACHE BOOL "")
-
-set(ENABLE_CALIPER ON CACHE BOOL "")
-set(ENABLE_PAPI OFF CACHE BOOL "")
-
-set(ENABLE_UNCRUSTIFY OFF CACHE BOOL "")
-
-set(ENABLE_ESSL OFF CACHE BOOL "")
-
-if( ENABLE_ESSL )
-    set(ESSL_ROOT_DIR /usr/tcetmp/packages/essl/essl-6.2/ CACHE PATH "" FORCE )
-    set(ESSL_INCLUDE_DIRS ${ESSL_ROOT_DIR}/include CACHE PATH "" FORCE)
-    set(ESSL_LIB_DIRS ${ESSL_ROOT_DIR}/lib64 CACHE PATH "" FORCE)
-    set(ESSL_LIBRARIES /usr/tcetmp/packages/essl/essl-6.2/lib64/libesslsmpcuda.so
-                       /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlsmp.so
-                       /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlfmath.so
-                       /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlf90_r.so
-                       ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcublas.so
-                       ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcudart.so
-                       ${ESSL_LIB_DIRS}/liblapackforessl.a
-                       /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxl.a
-                       CACHE PATH "")
-else()
-    set( BLAS_LIBRARIES /usr/lib64/libblas.so CACHE PATH "")
-    set( LAPACK_LIBRARIES /usr/lib64/liblapack.so CACHE PATH "")
-endif()
-set(DOXYGEN_EXECUTABLE /usr/bin/doxygen CACHE PATH "")
-
-set(PETSC_OMP_DIR ${GEOSX_TPL_ROOT_DIR}/omp-links-for-petsc CACHE STRING "")
-
-# PETSc doesn't seem to work correctly with clang.
-set(ENABLE_PETSC OFF CACHE BOOL "")
+include(${CMAKE_CURRENT_LIST_DIR}/lassen-base.cmake)

--- a/host-configs/LLNL/quartz-base.cmake
+++ b/host-configs/LLNL/quartz-base.cmake
@@ -1,49 +1,32 @@
 ###############################################################################
 #
-# Base configuration for LC builds
+# Base configuration for LC Quartz builds
 # Calling configuration file must define the following CMAKE variables:
 #
-# CONFIG_NAME
-# CMAKE_C_COMPILER
-# CMAKE_CXX_COMPILER
-# CMAKE_Fortran_COMPILER
 # MPI_HOME
-# 
 #
 ###############################################################################
 
+# Fortran
 set(ENABLE_FORTRAN OFF CACHE BOOL "")
+
+# MPI
 set(ENABLE_MPI ON CACHE BOOL "")
-
-set(MPI_C_COMPILER       ${MPI_HOME}/bin/mpicc   CACHE PATH "")
-set(MPI_CXX_COMPILER     ${MPI_HOME}/bin/mpicxx  CACHE PATH "")
+set(MPI_C_COMPILER ${MPI_HOME}/bin/mpicc CACHE PATH "")
+set(MPI_CXX_COMPILER  ${MPI_HOME}/bin/mpicxx CACHE PATH "")
 set(MPI_Fortran_COMPILER ${MPI_HOME}/bin/mpifort CACHE PATH "")
-
-set(MPIEXEC              /usr/bin/srun CACHE PATH "")
+set(MPIEXEC /usr/bin/srun CACHE PATH "")
 set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
 
-set(GEOSX_TPL_ROOT_DIR /usr/gapps/GEOSX/thirdPartyLibs CACHE PATH "")
-set(GEOSX_TPL_DIR ${GEOSX_TPL_ROOT_DIR}/2020-09-18/install-${CONFIG_NAME}-release CACHE PATH "")
-
-set(SPHINX_EXECUTABLE /collab/usr/gapps/python/build/spack-toss3.2/opt/spack/linux-rhel7-x86_64/gcc-4.9.3/python-2.7.14-7rci3jkmuht2uiwp433afigveuf4ocnu/bin/sphinx-build CACHE PATH "")
-set(DOXYGEN_EXECUTABLE ${GEOSX_TPL_ROOT_DIR}/doxygen/bin/doxygen CACHE PATH "")
-
-set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
-
-set(ENABLE_PAMELA ON CACHE BOOL "")
-set(ENABLE_PVTPackage ON CACHE BOOL "")
-set(ENABLE_GEOSX_PTP ON CACHE BOOL "" FORCE)
-
-
-set(ENABLE_CALIPER ON CACHE BOOL "")
+# PAPI (For TPL caliper builds)
 set(ENABLE_PAPI ON CACHE BOOL "")
 set(PAPI_PREFIX /usr/tce/packages/papi/papi-5.4.3 CACHE PATH "")
 
-set(USE_ADDR2LINE ON CACHE BOOL "")
-
+# OpenMP
 set(ENABLE_OPENMP ON CACHE BOOL "")
-set(CUDA_ENABLED OFF CACHE BOOL "")
 
-set(ENABLE_TOTALVIEW_OUTPUT OFF CACHE BOOL "Enables Totalview custom view" FORCE)
-
+# GEOSX specific options
+set(ENABLE_PAMELA ON CACHE BOOL "")
+set(ENABLE_PVTPackage ON CACHE BOOL "")
+set(ENABLE_GEOSX_PTP ON CACHE BOOL "" FORCE)
 set(ENABLE_PETSC OFF CACHE BOOL "Enables PETSc." FORCE)

--- a/host-configs/LLNL/quartz-clang@10.0.0.cmake
+++ b/host-configs/LLNL/quartz-clang@10.0.0.cmake
@@ -1,15 +1,13 @@
-set(CONFIG_NAME "quartz-clang@10.0.0" CACHE PATH "")
+include(${CMAKE_CURRENT_LIST_DIR}/../../src/coreComponents/LvArray/host-configs/LLNL/quartz-clang@10.0.0.cmake)
 
-set(CMAKE_C_COMPILER /usr/tce/packages/clang/clang-10.0.0/bin/clang CACHE PATH "")
-set(CMAKE_CXX_COMPILER /usr/tce/packages/clang/clang-10.0.0/bin/clang++ CACHE PATH "")
+# Fortran
 set(CMAKE_Fortran_COMPILER /usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran CACHE PATH "")
-
-set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG -march=native -mtune=native" CACHE STRING "")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -march=native -mtune=native" CACHE STRING "")
 set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -DNDEBUG -march=native -mtune=native" CACHE STRING "")
 
-set(MPI_HOME             /usr/tce/packages/mvapich2/mvapich2-2.3-clang-10.0.0 CACHE PATH "")
+# MPI
+set(MPI_HOME /usr/tce/packages/mvapich2/mvapich2-2.3-clang-10.0.0 CACHE PATH "")
 
+# MKL
 set(ENABLE_MKL ON CACHE BOOL "")
 set(MKL_ROOT /usr/tce/packages/mkl/mkl-2019.0)
 set(MKL_INCLUDE_DIRS ${MKL_ROOT}/include CACHE STRING "")
@@ -18,4 +16,4 @@ set(MKL_LIBRARIES ${MKL_ROOT}/lib/libmkl_intel_lp64.so
                   ${MKL_ROOT}/lib/libmkl_core.so
                   CACHE STRING "")
 
-include(${CMAKE_CURRENT_LIST_DIR}/../../host-configs/LLNL/quartz-base.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/quartz-base.cmake)

--- a/host-configs/LLNL/quartz-clang@9.0.0.cmake
+++ b/host-configs/LLNL/quartz-clang@9.0.0.cmake
@@ -1,15 +1,13 @@
-set(CONFIG_NAME "quartz-clang@9.0.0" CACHE PATH "")
+include(${CMAKE_CURRENT_LIST_DIR}/../../src/coreComponents/LvArray/host-configs/LLNL/quartz-clang@9.0.0.cmake)
 
-set(CMAKE_C_COMPILER /usr/tce/packages/clang/clang-9.0.0/bin/clang CACHE PATH "")
-set(CMAKE_CXX_COMPILER /usr/tce/packages/clang/clang-9.0.0/bin/clang++ CACHE PATH "")
+# Fortran
 set(CMAKE_Fortran_COMPILER /usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran CACHE PATH "")
-
-set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG -march=native -mtune=native" CACHE STRING "")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -march=native -mtune=native" CACHE STRING "")
 set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -DNDEBUG -march=native -mtune=native" CACHE STRING "")
 
-set(MPI_HOME             /usr/tce/packages/mvapich2/mvapich2-2.3-clang-9.0.0 CACHE PATH "")
+# MPI
+set(MPI_HOME /usr/tce/packages/mvapich2/mvapich2-2.3-clang-9.0.0 CACHE PATH "")
 
+# MKL
 set(ENABLE_MKL ON CACHE BOOL "")
 set(MKL_ROOT /usr/tce/packages/mkl/mkl-2019.0)
 set(MKL_INCLUDE_DIRS ${MKL_ROOT}/include CACHE STRING "")
@@ -18,4 +16,4 @@ set(MKL_LIBRARIES ${MKL_ROOT}/lib/libmkl_intel_lp64.so
                   ${MKL_ROOT}/lib/libmkl_core.so
                   CACHE STRING "")
 
-include(${CMAKE_CURRENT_LIST_DIR}/../../host-configs/LLNL/quartz-base.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/quartz-base.cmake)

--- a/host-configs/LLNL/quartz-gcc@8.1.0.cmake
+++ b/host-configs/LLNL/quartz-gcc@8.1.0.cmake
@@ -1,17 +1,17 @@
-set(CONFIG_NAME "quartz-gcc@8.1.0" CACHE PATH "") 
+include(${CMAKE_CURRENT_LIST_DIR}/../../src/coreComponents/LvArray/host-configs/LLNL/quartz-gcc@8.1.0.cmake)
 
-set(CMAKE_C_COMPILER /usr/tce/packages/gcc/gcc-8.1.0/bin/gcc CACHE PATH "")
-set(CMAKE_CXX_COMPILER /usr/tce/packages/gcc/gcc-8.1.0/bin/g++ CACHE PATH "")
+# C++
+# The "-march=native -mtune=native" which LvArray adds breaks the PVT package.
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG" CACHE STRING "" FORCE)
+
+# Fortran
 set(CMAKE_Fortran_COMPILER /usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran CACHE PATH "")
-
-# These flags should be set for the TPL build but they break some of our numerically sensative code.
-# This needs to be fixed.
-set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG -march=native -mtune=native" CACHE STRING "")
-# set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -march=native -mtune=native" CACHE STRING "")
 set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -DNDEBUG -march=native -mtune=native" CACHE STRING "")
 
-set(MPI_HOME             /usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.1.0 CACHE PATH "")
+# MPI
+set(MPI_HOME /usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.1.0 CACHE PATH "")
 
+# MKL
 set(ENABLE_MKL ON CACHE BOOL "")
 set(MKL_ROOT /usr/tce/packages/mkl/mkl-2019.0)
 set(MKL_INCLUDE_DIRS ${MKL_ROOT}/include CACHE STRING "")
@@ -20,4 +20,4 @@ set(MKL_LIBRARIES ${MKL_ROOT}/lib/libmkl_intel_lp64.so
                   ${MKL_ROOT}/lib/libmkl_core.so
                   CACHE STRING "")
 
-include(${CMAKE_CURRENT_LIST_DIR}/../../host-configs/LLNL/quartz-base.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/quartz-base.cmake)

--- a/host-configs/LLNL/quartz-icc@19.0.4.cmake
+++ b/host-configs/LLNL/quartz-icc@19.0.4.cmake
@@ -1,19 +1,17 @@
-set(CONFIG_NAME "quartz-icc@19.0.4" CACHE PATH "")
+include(${CMAKE_CURRENT_LIST_DIR}/../../src/coreComponents/LvArray/host-configs/LLNL/quartz-icc@19.0.4.cmake)
 
-set(COMPILER_DIR /usr/tce/packages/intel/intel-19.0.4/compilers_and_libraries_2019.4.227/linux )
-set(CMAKE_C_COMPILER ${COMPILER_DIR}/bin/intel64/icc CACHE PATH "")
-set(CMAKE_CXX_COMPILER ${COMPILER_DIR}/bin/intel64/icpc CACHE PATH "")
+# Fortran
 set(CMAKE_Fortran_COMPILER ${COMPILER_DIR}/bin/intel64/ifort CACHE PATH "")
+set(CMAKE_Fortran_FLAGS_RELEASE "-DNDEBUG -march=native -mtune=native -qoverride-limits" CACHE STRING "")
+set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-g ${CMAKE_Fortran_FLAGS_RELEASE}" CACHE STRING "")
 
-set(CMAKE_C_FLAGS_DEBUG "-g -O0" CACHE STRING "" FORCE)
-set(CMAKE_C_FLAGS_RELEASE "-DNDEBUG -qoverride-limits" CACHE STRING "" FORCE)
-set(CMAKE_CXX_FLAGS_DEBUG "-g -O0" CACHE STRING "" FORCE)
-set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG -qoverride-limits" CACHE STRING "" FORCE)
+# MPI
+set(MPI_HOME /usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4 CACHE PATH "")
 
-set(MPI_HOME             /usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4 CACHE PATH "")
-
+# GEOSX specific options
 set(ENABLE_XML_UPDATES OFF CACHE BOOL "")
 
+# MKL
 set(ENABLE_MKL ON CACHE BOOL "")
 set(MKL_ROOT /usr/tce/packages/mkl/mkl-2019.0)
 set(MKL_INCLUDE_DIRS ${MKL_ROOT}/include CACHE STRING "")
@@ -23,4 +21,4 @@ set(MKL_LIBRARIES ${MKL_ROOT}/lib/libmkl_intel_lp64.so
                   ${COMPILER_DIR}/compiler/lib/intel64/libiomp5.so
                   CACHE STRING "")
 
-include(${CMAKE_CURRENT_LIST_DIR}/../../host-configs/LLNL/quartz-base.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/quartz-base.cmake)

--- a/src/cmake/thirdparty/SetupGeosxThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupGeosxThirdParty.cmake
@@ -104,21 +104,36 @@ else()
     set(RAJA_DIR ${GEOSX_TPL_DIR}/raja)
 endif()
 
-include(${CMAKE_SOURCE_DIR}/cmake/thirdparty/FindRAJA.cmake)
-if (NOT RAJA_FOUND)
-    message(FATAL_ERROR "RAJA not found in ${RAJA_DIR}. Maybe you need to build it")
-endif()    
-blt_register_library( NAME raja
-                      INCLUDES ${RAJA_INCLUDE_DIRS}
-                      LIBRARIES ${RAJA_LIBRARY}
-                      TREAT_INCLUDES_AS_SYSTEM ON )
+find_package(RAJA REQUIRED PATHS ${RAJA_DIR})
 
-set( thirdPartyLibs ${thirdPartyLibs} raja )
+get_target_property(RAJA_INCLUDE_DIRS RAJA INTERFACE_INCLUDE_DIRECTORIES)
+set_target_properties(RAJA
+                      PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${RAJA_INCLUDE_DIRS}")
+
+set( thirdPartyLibs ${thirdPartyLibs} RAJA )
 
 ################################
 # CHAI
 ################################
-include(${CMAKE_SOURCE_DIR}/cmake/thirdparty/FindCHAI.cmake)
+if( EXISTS ${CHAI_DIR})
+    message(STATUS "Using system CHAI found at ${CHAI_DIR}")
+else()
+    message(STATUS "Using CHAI from thirdPartyLibs")
+    set(CHAI_DIR ${GEOSX_TPL_DIR}/chai)
+endif()
+
+find_package(umpire REQUIRED
+             PATHS ${CHAI_DIR})
+
+find_package(chai REQUIRED
+             PATHS ${CHAI_DIR})
+
+
+get_target_property(CHAI_INCLUDE_DIRS chai INTERFACE_INCLUDE_DIRECTORIES)
+set_target_properties(chai
+                      PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${CHAI_INCLUDE_DIRS}")
+
+set( thirdPartyLibs ${thirdPartyLibs} chai umpire )
 
 ################################
 # FPARSER

--- a/src/coreComponents/codingUtilities/tests/CMakeLists.txt
+++ b/src/coreComponents/codingUtilities/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ set(testSources
     testGeosxTraits.cpp
    )
 
-set(dependencyList gtest codingUtilities raja)
+set(dependencyList gtest codingUtilities RAJA)
 
 if ( ENABLE_OPENMP )
   set( dependencyList ${dependencyList} openmp )

--- a/src/coreComponents/finiteElement/kernelInterface/KernelBase.hpp
+++ b/src/coreComponents/finiteElement/kernelInterface/KernelBase.hpp
@@ -483,8 +483,8 @@ real64 regionBasedKernelApplication( MeshLevel & mesh,
                                             elementSubRegion,
                                             finiteElement,
                                             castedConstitutiveRelation );
-        auto fullKernelComponentConstructorArgs = camp::tuple_cat_pair_forward( temp,
-                                                                                kernelConstructorParamsTuple );
+        auto fullKernelComponentConstructorArgs = camp::tuple_cat_pair( temp,
+                                                                        kernelConstructorParamsTuple );
         KERNEL_TYPE kernelComponent = camp::make_from_tuple< KERNEL_TYPE >( fullKernelComponentConstructorArgs );
 
 #endif

--- a/src/coreComponents/linearAlgebra/CMakeLists.txt
+++ b/src/coreComponents/linearAlgebra/CMakeLists.txt
@@ -47,9 +47,9 @@ set( linearAlgebra_sources
      DofManager.cpp )
 
 if( BUILD_OBJ_LIBS )
-  set( dependencyList common blas lapack raja managers)
+  set( dependencyList common blas lapack RAJA managers)
 else()
-  set( dependencyList common blas lapack raja )
+  set( dependencyList common blas lapack RAJA )
 endif()
 
 

--- a/src/coreComponents/managers/initialization.cpp
+++ b/src/coreComponents/managers/initialization.cpp
@@ -491,6 +491,19 @@ void finalizeLogger()
 ///////////////////////////////////////////////////////////////////////////////
 void setupCXXUtils()
 {
+  LvArray::system::setErrorHandler( []()
+  {
+  #if defined( GEOSX_USE_MPI )
+    int mpi = 0;
+    MPI_Initialized( &mpi );
+    if( mpi )
+    {
+      MPI_Abort( MPI_COMM_WORLD, EXIT_FAILURE );
+    }
+  #endif
+    std::abort();
+  } );
+
   LvArray::system::setSignalHandling( []( int const signal ) { LvArray::system::stackTraceHandler( signal, true ); } );
 
 #if defined(GEOSX_USE_FPE)

--- a/src/coreComponents/math/TensorT/R1TensorT.h
+++ b/src/coreComponents/math/TensorT/R1TensorT.h
@@ -119,10 +119,17 @@ public:
   }
 
   template< int USD >
-  GEOSX_HOST_DEVICE constexpr inline
+  GEOSX_HOST_DEVICE inline
   R1TensorT & operator+=( LvArray::ArraySlice< realT, 1, USD, std::ptrdiff_t > const & src )
   {
-    return (*this) += reinterpret_cast< LvArray::ArraySlice< realT const, 1, USD, std::ptrdiff_t > const & >( src );
+    GEOSX_ASSERT_EQ( src.size(), T_dim );
+
+    for( int i = 0; i < T_dim; ++i )
+    {
+      this->t_data[ i ] += src[ i ];
+    }
+
+    return *this;
   }
 
   using TensorBaseT< T_dim >::operator-=;


### PR DESCRIPTION
Mostly host config changes. The LvArray host configs now only specify what is required for LvArray, so no Fortran or MPI. The GEOSX host configs now all include the LvArray host config and build off it.

Related to:
https://github.com/GEOSX/LvArray/pull/203
https://github.com/GEOSX/thirdPartyLibs/pull/133