### PR TITLE
Modified well controls to match Intersect results

### DIFF
--- a/src/coreComponents/fileIO/schema/docs/WellControls.rst
+++ b/src/coreComponents/fileIO/schema/docs/WellControls.rst
@@ -1,21 +1,22 @@
 
 
-=============== ========================== ======== ==================================================================================== 
-Name            Type                       Default  Description                                                                          
-=============== ========================== ======== ==================================================================================== 
-control         geosx_WellControls_Control required | Well control. Valid options:                                                         
-                                                    | * BHP                                                                                
-                                                    | * gasRate                                                                            
-                                                    | * oilRate                                                                            
-                                                    | * waterRate                                                                          
-                                                    | * liquidRate                                                                         
-injectionStream real64_array               {-1}     Global component densities for the injection stream                                  
-name            string                     required A name is required for any non-unique nodes                                          
-targetBHP       real64                     required Target bottom-hole pressure                                                          
-targetRate      real64                     required Target rate                                                                          
-type            geosx_WellControls_Type    required | Well type. Valid options:                                                            
-                                                    | * producer                                                                           
-                                                    | * injector                                                                           
-=============== ========================== ======== ==================================================================================== 
+================== ========================== ======== ================================================================================== 
+Name               Type                       Default  Description                                                                        
+================== ========================== ======== ================================================================================== 
+control            geosx_WellControls_Control required | Well control. Valid options:                                                       
+                                                       | * BHP                                                                              
+                                                       | * oilVolRate                                                                       
+                                                       | * totalVolRate                                                                     
+                                                       | * totalMassRate                                                                    
+injectionStream    real64_array               {-1}     Global component densities for the injection stream                                
+name               string                     required A name is required for any non-unique nodes                                        
+referenceElevation real64                     required Reference elevation where BHP control is enforced                                  
+targetBHP          real64                     required Target bottom-hole pressure                                                        
+targetOilRate      real64                     1e+09    Target oil rate                                                                    
+targetRate         real64                     required Target rate                                                                        
+type               geosx_WellControls_Type    required | Well type. Valid options:                                                          
+                                                       | * producer                                                                         
+                                                       | * injector                                                                         
+================== ========================== ======== ================================================================================== 
 
 

--- a/src/coreComponents/fileIO/schema/schema.xsd
+++ b/src/coreComponents/fileIO/schema/schema.xsd
@@ -938,15 +938,18 @@ the relative residual norm satisfies:
 	<xsd:complexType name="WellControlsType">
 		<!--control => Well control. Valid options:
 * BHP
-* gasRate
-* oilRate
-* waterRate
-* liquidRate-->
+* oilVolRate
+* totalVolRate
+* totalMassRate-->
 		<xsd:attribute name="control" type="geosx_WellControls_Control" use="required" />
 		<!--injectionStream => Global component densities for the injection stream-->
 		<xsd:attribute name="injectionStream" type="real64_array" default="{-1}" />
+		<!--referenceElevation => Reference elevation where BHP control is enforced-->
+		<xsd:attribute name="referenceElevation" type="real64" use="required" />
 		<!--targetBHP => Target bottom-hole pressure-->
 		<xsd:attribute name="targetBHP" type="real64" use="required" />
+		<!--targetOilRate => Target oil rate-->
+		<xsd:attribute name="targetOilRate" type="real64" default="1e+09" />
 		<!--targetRate => Target rate-->
 		<xsd:attribute name="targetRate" type="real64" use="required" />
 		<!--type => Well type. Valid options:
@@ -958,7 +961,7 @@ the relative residual norm satisfies:
 	</xsd:complexType>
 	<xsd:simpleType name="geosx_WellControls_Control">
 		<xsd:restriction base="xsd:string">
-			<xsd:pattern value=".*[\[\]`$].*|BHP|gasRate|oilRate|waterRate|liquidRate" />
+			<xsd:pattern value=".*[\[\]`$].*|BHP|oilVolRate|totalVolRate|totalMassRate" />
 		</xsd:restriction>
 	</xsd:simpleType>
 	<xsd:simpleType name="geosx_WellControls_Type">

--- a/src/coreComponents/mesh/WellElementRegion.cpp
+++ b/src/coreComponents/mesh/WellElementRegion.cpp
@@ -101,10 +101,10 @@ void WellElementRegion::GenerateWell( MeshLevel & mesh,
 
 
   // 4) find out which rank is the owner of the top segment
-  localIndex const refElemIdLocal = subRegion->GetTopWellElementIndex();
+  localIndex const topElemIdLocal = subRegion->GetTopWellElementIndex();
 
   array1d< localIndex > allRankTopElem;
-  MpiWrapper::allGather( refElemIdLocal, allRankTopElem );
+  MpiWrapper::allGather( topElemIdLocal, allRankTopElem );
   int topRank = -1;
   for( int irank = 0; irank < allRankTopElem.size(); ++irank )
   {

--- a/src/coreComponents/mesh/WellElementSubRegion.hpp
+++ b/src/coreComponents/mesh/WellElementSubRegion.hpp
@@ -209,15 +209,6 @@ public:
   }
 
   /**
-   * @brief Get the MPI rank that owns this well (i.e. the top segment).
-   * @return MPI rank of the owner process
-   */
-  int GetTopRank() const
-  {
-    return m_topRank;
-  }
-
-  /**
    * @brief Check if well is owned by current rank
    * @return true if the well is owned by current rank, false otherwise
    */

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.hpp
@@ -145,20 +145,31 @@ public:
   void UpdateComponentFraction( WellElementSubRegion & subRegion ) const;
 
   /**
+   * @brief Recompute the reference pressure and volumetric rates that are used in the well constraints
+   * @param subRegion the well subregion containing all the primary and dependent fields
+   * @param targetIndex the targetIndex of the subRegion
+   */
+  void UpdateBHPAndVolRatesForConstraints( WellElementSubRegion & subRegion,
+                                           localIndex const targetIndex );
+
+  /**
    * @brief Update all relevant fluid models using current values of pressure and composition
    * @param subRegion the well subregion containing all the primary and dependent fields
+   * @param targetIndex the targetIndex of the subRegion
    */
   void UpdateFluidModel( WellElementSubRegion & subRegion, localIndex const targetIndex );
 
   /**
    * @brief Recompute phase volume fractions (saturations) from constitutive and primary variables
    * @param subRegion the well subregion containing all the primary and dependent fields
+   * @param targetIndex the targetIndex of the subRegion
    */
   void UpdatePhaseVolumeFraction( WellElementSubRegion & subRegion, localIndex const targetIndex ) const;
 
   /**
    * @brief Recompute all dependent quantities from primary variables (including constitutive models)
    * @param subRegion the well subregion containing all the primary and dependent fields
+   * @param targetIndex the targetIndex of the subRegion
    */
   virtual void UpdateState( WellElementSubRegion & subRegion, localIndex const targetIndex ) override;
 
@@ -234,6 +245,7 @@ public:
     static constexpr auto relPermNamesString  = CompositionalMultiphaseFlow::viewKeyStruct::relPermNamesString;
 
     static constexpr auto maxCompFracChangeString = CompositionalMultiphaseFlow::viewKeyStruct::maxCompFracChangeString;
+    static constexpr auto maxRelativePresChangeString = "maxRelativePressureChange";
     static constexpr auto allowLocalCompDensChoppingString = CompositionalMultiphaseFlow::viewKeyStruct::allowLocalCompDensChoppingString;
 
     // primary solution field
@@ -259,6 +271,21 @@ public:
     static constexpr auto compPerforationRateString = "compPerforationRate";
     static constexpr auto dCompPerforationRate_dPresString = "dCompPerforationRate_dPres";
     static constexpr auto dCompPerforationRate_dCompString = "dCompPerforationRate_dComp";
+
+    // control data
+    static constexpr auto currentBHPString = "currentBHP";
+    static constexpr auto dCurrentBHP_dPresString = "dCurrentBHP_dPres";
+    static constexpr auto dCurrentBHP_dCompDensString = "dCurrentBHP_dCompDens";
+
+    static constexpr auto currentPhaseVolRateString = "currentPhaseVolumetricRate";
+    static constexpr auto dCurrentPhaseVolRate_dPresString = "dCurrentPhaseVolumetricRate_dPres";
+    static constexpr auto dCurrentPhaseVolRate_dCompDensString = "dCurrentPhaseVolumetricRate_dCompDens";
+    static constexpr auto dCurrentPhaseVolRate_dRateString = "dCurrentPhaseVolumetricRate_dRate";
+
+    static constexpr auto currentTotalVolRateString = "currentTotalVolumetricRate";
+    static constexpr auto dCurrentTotalVolRate_dPresString = "dCurrentTotalVolumetricRate_dPres";
+    static constexpr auto dCurrentTotalVolRate_dCompDensString = "dCurrentTotalVolumetricRate_dCompDens";
+    static constexpr auto dCurrentTotalVolRate_dRateString = "dCurrentTotalVolumetricRate_dRate";
 
   } viewKeysCompMultiphaseWell;
 
@@ -333,11 +360,17 @@ private:
   /// maximum (absolute) change in a component fraction between two Newton iterations
   real64 m_maxCompFracChange;
 
+  /// maximum (relative) change in pressure between two Newton iterations
+  real64 m_maxRelativePresChange;
+
   /// minimum value of the scaling factor obtained by enforcing maxCompFracChange
   real64 m_minScalingFactor;
 
   /// flag indicating whether local (cell-wise) chopping of negative compositions is allowed
   integer m_allowCompDensChopping;
+
+  /// index of the oil phase, used to impose the oil phase constraint
+  localIndex m_oilPhaseIndex;
 
   /// views into reservoir primary variable fields
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/SinglePhaseWell.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/SinglePhaseWell.hpp
@@ -138,8 +138,17 @@ public:
   virtual localIndex NumFluidPhases() const override { return 1; }
 
   /**
+   * @brief Recompute the reference pressure and volumetric rates that are used in the well constraints
+   * @param subRegion the well subregion containing all the primary and dependent fields
+   * @param targetIndex the targetIndex of the subRegion
+   */
+  virtual void UpdateBHPAndVolRatesForConstraints( WellElementSubRegion & subRegion,
+                                                   localIndex const targetIndex );
+
+  /**
    * @brief Update fluid constitutive model state
    * @param dataGroup group that contains the fields
+   * @param targetIndex the targetIndex of the subRegion
    */
   virtual void UpdateFluidModel( WellElementSubRegion & subRegion, localIndex const targetIndex ) const;
 
@@ -147,6 +156,7 @@ public:
   /**
    * @brief Recompute all dependent quantities from primary variables (including constitutive models) on the well
    * @param subRegion the well subRegion containing the well elements and their associated fields
+   * @param targetIndex the targetIndex of the subRegion
    */
   virtual void UpdateState( WellElementSubRegion & subRegion, localIndex const targetIndex ) override;
 
@@ -207,6 +217,15 @@ public:
     // perforation rates
     static constexpr auto perforationRateString        = "perforationRate";
     static constexpr auto dPerforationRate_dPresString = "dPerforationRate_dPres";
+
+    // control data
+    static constexpr auto currentBHPString = "currentBHP";
+    static constexpr auto dCurrentBHP_dPresString = "dCurrentBHP_dPres";
+
+    static constexpr auto currentVolRateString = "currentVolumetricRate";
+    static constexpr auto dCurrentVolRate_dPresString = "dCurrentVolumetricRate_dPres";
+    static constexpr auto dCurrentVolRate_dRateString = "dCurrentVolumetricRate_dRate";
+
   } viewKeysSinglePhaseWell;
 
   struct groupKeyStruct : SolverBase::groupKeyStruct

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/SinglePhaseWellKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/SinglePhaseWellKernels.hpp
@@ -42,24 +42,24 @@ struct ControlEquationHelper
   Switch( WellControls::Type const & wellType,
           WellControls::Control const & currentControl,
           real64 const & targetBHP,
-          real64 const & targetConnRate,
-          real64 const & wellElemPressure,
-          real64 const & dWellElemPressure,
-          real64 const & connRate,
-          real64 const & dConnRate,
+          real64 const & targetRate,
+          real64 const & currentBHP,
+          real64 const & currentVolRate,
           WellControls::Control & newControl )
   {
     // if isViable is true at the end of the following checks, no need to switch
     bool controlIsViable = false;
 
-    real64 const refRate = connRate + dConnRate;
-    real64 const refPressure = wellElemPressure + dWellElemPressure;
+    // The limiting flow rates are treated as upper limits, while the pressure limits
+    // are treated as lower limits in production wells and upper limits in injectors.
+    // The well changes its mode of control whenever the existing control mode would
+    // violate one of these limits.
 
     // BHP control
     if( currentControl == WellControls::Control::BHP )
     {
       // the control is viable if the reference rate is below the max rate
-      controlIsViable = ( fabs( refRate ) <= fabs( targetConnRate ) );
+      controlIsViable = ( fabs( currentVolRate ) <= fabs( targetRate ) );
     }
     else // rate control
     {
@@ -67,12 +67,12 @@ struct ControlEquationHelper
       if( wellType == WellControls::Type::PRODUCER )
       {
         // targetBHP specifies a min pressure here
-        controlIsViable = ( refPressure >= targetBHP );
+        controlIsViable = ( currentBHP >= targetBHP );
       }
       else
       {
         // targetBHP specifies a max pressure here
-        controlIsViable = ( refPressure <= targetBHP );
+        controlIsViable = ( currentBHP <= targetBHP );
       }
     }
 
@@ -82,8 +82,10 @@ struct ControlEquationHelper
     }
     else
     {
+      // Note: if BHP control is not viable, we switch to TOTALVOLRATE
+      //       if TOTALVOLRATE are not viable, we switch to BHP
       newControl = ( currentControl == WellControls::Control::BHP )
-                 ? WellControls::Control::LIQUIDRATE
+                 ? WellControls::Control::TOTALVOLRATE
                  : WellControls::Control::BHP;
     }
   }
@@ -93,59 +95,61 @@ struct ControlEquationHelper
   Compute( globalIndex const rankOffset,
            WellControls::Control const currentControl,
            real64 const & targetBHP,
-           real64 const & targetConnRate,
+           real64 const & targetRate,
+           real64 const & currentBHP,
+           real64 const & dCurrentBHP_dPres,
+           real64 const & currentVolRate,
+           real64 const & dCurrentVolRate_dPres,
+           real64 const & dCurrentVolRate_dRate,
            globalIndex const wellElemDofNumber,
-           real64 const & wellElemPressure,
-           real64 const & dWellElemPressure,
-           real64 const & connRate,
-           real64 const & dConnRate,
            CRSMatrixView< real64, globalIndex const > const & localMatrix,
            arrayView1d< real64 > const & localRhs )
   {
-    globalIndex eqnRowIndex = 0;
-    globalIndex dofColIndex = 0;
+    localIndex const eqnRowIndex = wellElemDofNumber + SinglePhaseWell::RowOffset::CONTROL - rankOffset;
+    globalIndex const presDofColIndex = wellElemDofNumber + SinglePhaseWell::ColOffset::DPRES;
+    globalIndex const rateDofColIndex = wellElemDofNumber + SinglePhaseWell::ColOffset::DRATE;
+
     real64 controlEqn = 0;
-    real64 dControlEqn_dX = 0;
+    real64 dControlEqn_dRate = 0;
+    real64 dControlEqn_dPres = 0;
+
+    // Note: We assume in the computation of currentBHP that the reference elevation
+    //       is in the top well element. This is enforced by a check in the solver.
+    //       If we wanted to allow the reference elevation to be outside the top
+    //       well element, it would make more sense to check the BHP constraint in
+    //       the well element that contains the reference elevation.
 
     // BHP control
     if( currentControl == WellControls::Control::BHP )
     {
-      // get pressures and compute normalizer
-      real64 const currentBHP = wellElemPressure + dWellElemPressure;
-      real64 const normalizer = targetBHP > 1e-13
-                                ? 1.0 / targetBHP
-                                : 1.0;
-
-      // control equation is a normalized difference between current pressure and target pressure
-      controlEqn = ( currentBHP - targetBHP ) * normalizer;
-      dControlEqn_dX = normalizer;
-      dofColIndex = wellElemDofNumber + SinglePhaseWell::ColOffset::DPRES;
-      eqnRowIndex = wellElemDofNumber + SinglePhaseWell::RowOffset::CONTROL - rankOffset;
+      // control equation is a difference between current BHP and target BHP
+      controlEqn = currentBHP - targetBHP;
+      dControlEqn_dPres = dCurrentBHP_dPres;
     }
-    // rate control
+    // Total volumetric rate control
+    else if( currentControl == WellControls::Control::TOTALVOLRATE )
+    {
+      // control equation is the difference between volumetric current rate and target rate
+      controlEqn = currentVolRate - targetRate;
+      dControlEqn_dRate = dCurrentVolRate_dRate;
+      dControlEqn_dPres = dCurrentVolRate_dPres;
+    }
     else
     {
-
-      // get rates and compute normalizer
-      real64 const currentConnRate = connRate + dConnRate;
-      real64 const normalizer = fabs( targetConnRate ) > 1e-13
-                                ? 1.0 / ( 1e-2 * fabs( targetConnRate ) ) // hard-coded value comes from AD-GPRS
-                                : 1.0;
-
-      // for a producer, the actual (target) rate is negative
-
-      // control equation is a normalized difference between current rate and target rate
-      controlEqn = ( currentConnRate - targetConnRate ) * normalizer;
-      dControlEqn_dX = normalizer;
-      dofColIndex = wellElemDofNumber + SinglePhaseWell::ColOffset::DRATE;
-      eqnRowIndex = wellElemDofNumber + SinglePhaseWell::RowOffset::CONTROL - rankOffset;
+      GEOSX_ERROR_IF( ( currentControl != WellControls::Control::BHP )
+                      && ( currentControl != WellControls::Control::TOTALVOLRATE ),
+                      "This constraint is not supported in SinglePhaseWell" );
     }
 
-    localMatrix.addToRow< serialAtomic >( eqnRowIndex,
-                                          &dofColIndex,
-                                          &dControlEqn_dX,
-                                          1 );
     localRhs[eqnRowIndex] += controlEqn;
+    localMatrix.addToRow< serialAtomic >( eqnRowIndex,
+                                          &presDofColIndex,
+                                          &dControlEqn_dPres,
+                                          1 );
+    localMatrix.addToRow< serialAtomic >( eqnRowIndex,
+                                          &rateDofColIndex,
+                                          &dControlEqn_dRate,
+                                          1 );
   }
 };
 
@@ -259,12 +263,11 @@ struct PressureRelationKernel
   Launch( localIndex const size,
           globalIndex const rankOffset,
           bool const isLocallyOwned,
+          localIndex const iwelemControl,
           WellControls const & wellControls,
           arrayView1d< globalIndex const > const & wellElemDofNumber,
           arrayView1d< real64 const > const & wellElemGravCoef,
           arrayView1d< localIndex const > const & nextWellElemIndex,
-          arrayView1d< real64 const > const & connRate,
-          arrayView1d< real64 const > const & dConnRate,
           arrayView1d< real64 const > const & wellElemPressure,
           arrayView1d< real64 const > const & dWellElemPressure,
           arrayView2d< real64 const > const & wellElemDensity,
@@ -272,11 +275,24 @@ struct PressureRelationKernel
           CRSMatrixView< real64, globalIndex const > const & localMatrix,
           arrayView1d< real64 > const & localRhs )
   {
+    // static well control data
+    WellControls::Type const wellType = wellControls.GetType();
+    WellControls::Control const currentControl = wellControls.GetControl();
     real64 const targetBHP = wellControls.GetTargetBHP();
     real64 const targetRate = wellControls.GetTargetRate();
-    WellControls::Control const currentControl = wellControls.GetControl();
-    WellControls::Type const wellType = wellControls.GetType();
-    localIndex const iwelemControl = wellControls.GetReferenceWellElementIndex();
+
+    // dynamic well control data
+    real64 const & currentBHP =
+      wellControls.getReference< real64 >( SinglePhaseWell::viewKeyStruct::currentBHPString );
+    real64 const & dCurrentBHP_dPres =
+      wellControls.getReference< real64 >( SinglePhaseWell::viewKeyStruct::dCurrentBHP_dPresString );
+
+    real64 const & currentVolRate =
+      wellControls.getReference< real64 >( SinglePhaseWell::viewKeyStruct::currentVolRateString );
+    real64 const & dCurrentVolRate_dPres =
+      wellControls.getReference< real64 >( SinglePhaseWell::viewKeyStruct::dCurrentVolRate_dPresString );
+    real64 const & dCurrentVolRate_dRate =
+      wellControls.getReference< real64 >( SinglePhaseWell::viewKeyStruct::dCurrentVolRate_dRateString );
 
     RAJA::ReduceMax< REDUCE_POLICY, localIndex > switchControl( 0 );
 
@@ -293,10 +309,8 @@ struct PressureRelationKernel
                                        currentControl,
                                        targetBHP,
                                        targetRate,
-                                       wellElemPressure[iwelemControl],
-                                       dWellElemPressure[iwelemControl],
-                                       connRate[iwelemControl],
-                                       dConnRate[iwelemControl],
+                                       currentBHP,
+                                       currentVolRate,
                                        newControl );
         if( currentControl != newControl )
         {
@@ -307,11 +321,12 @@ struct PressureRelationKernel
                                         newControl,
                                         targetBHP,
                                         targetRate,
+                                        currentBHP,
+                                        dCurrentBHP_dPres,
+                                        currentVolRate,
+                                        dCurrentVolRate_dPres,
+                                        dCurrentVolRate_dRate,
                                         wellElemDofNumber[iwelemControl],
-                                        wellElemPressure[iwelemControl],
-                                        dWellElemPressure[iwelemControl],
-                                        connRate[iwelemControl],
-                                        dConnRate[iwelemControl],
                                         localMatrix,
                                         localRhs );
       }
@@ -334,15 +349,10 @@ struct PressureRelationKernel
         real64 const pressureCurrent = wellElemPressure[iwelem] + dWellElemPressure[iwelem];
         real64 const pressureNext = wellElemPressure[iwelemNext] + dWellElemPressure[iwelemNext];
 
-        // compute a coefficient to normalize the momentum equation
-        real64 const normalizer = targetBHP > 1e-13
-                                  ? 1.0 / targetBHP
-                                  : 1.0;
-
         // compute momentum flux and derivatives
-        real64 const localPresRel = ( pressureNext - pressureCurrent - avgDensity * gravD ) * normalizer;
-        localPresRelJacobian[SinglePhaseWell::ElemTag::NEXT] = ( 1 - dAvgDensity_dPresNext * gravD ) * normalizer;
-        localPresRelJacobian[SinglePhaseWell::ElemTag::CURRENT] = ( -1 - dAvgDensity_dPresCurrent * gravD ) * normalizer;
+        real64 const localPresRel = pressureNext - pressureCurrent - avgDensity * gravD;
+        localPresRelJacobian[SinglePhaseWell::ElemTag::NEXT] = 1 - dAvgDensity_dPresNext * gravD;
+        localPresRelJacobian[SinglePhaseWell::ElemTag::CURRENT] = -1 - dAvgDensity_dPresCurrent * gravD;
 
         // TODO: add friction and acceleration terms
 
@@ -522,8 +532,6 @@ struct PresInitializationKernel
   static void
   Launch( localIndex const perforationSize,
           localIndex const subRegionSize,
-          bool const isLocallyOwned,
-          int const topRank,
           localIndex const numPerforations,
           WellControls const & wellControls,
           ElementViewConst< arrayView1d< real64 const > > const & resPressure,
@@ -535,9 +543,9 @@ struct PresInitializationKernel
           arrayView1d< real64 > const & wellElemPressure )
   {
     real64 const targetBHP = wellControls.GetTargetBHP();
+    real64 const refWellElemGravCoef = wellControls.GetReferenceGravityCoef();
     WellControls::Control const currentControl = wellControls.GetControl();
     WellControls::Type const wellType = wellControls.GetType();
-    localIndex const iwelemControl = wellControls.GetReferenceWellElementIndex();
 
     // loop over all perforations to compute an average density
     RAJA::ReduceSum< parallelDeviceReduce, real64 > sumDensity( 0 );
@@ -561,29 +569,21 @@ struct PresInitializationKernel
     real64 const avgDensity = MpiWrapper::Sum( sumDensity.get() ) / numPerforations;
 
     real64 pressureControl = 0.0;
-    real64 gravCoefControl = 0.0;
-    if( isLocallyOwned )
+    real64 const gravCoefControl = refWellElemGravCoef;
+    // initialize the reference pressure
+    if( currentControl == WellControls::Control::BHP )
     {
-      // initialize the reference pressure
-      if( currentControl == WellControls::Control::BHP )
-      {
-        // if pressure constraint, set the ref pressure at the constraint
-        pressureControl = targetBHP;
-      }
-      else // rate control
-      {
-        // if rate constraint, set the ref pressure slightly
-        // above/below the target pressure depending on well type
-        pressureControl = ( wellType == WellControls::Type::PRODUCER )
-                        ? 0.5 * pres
-                        : 2.0 * pres;
-      }
-      gravCoefControl = wellElemGravCoef[iwelemControl];
-      wellElemPressure[iwelemControl] = pressureControl;
+      // if pressure constraint, set the ref pressure at the constraint
+      pressureControl = targetBHP;
     }
-
-    MpiWrapper::Broadcast( pressureControl, topRank );
-    MpiWrapper::Broadcast( gravCoefControl, topRank );
+    else // rate control
+    {
+      // if rate constraint, set the ref pressure slightly
+      // above/below the target pressure depending on well type
+      pressureControl = ( wellType == WellControls::Type::PRODUCER )
+                      ? 0.5 * pres
+                      : 2.0 * pres;
+    }
 
     GEOSX_ERROR_IF( pressureControl <= 0, "Invalid well initialization: negative pressure was found" );
 
@@ -606,6 +606,7 @@ struct RateInitializationKernel
   static void
   Launch( localIndex const subRegionSize,
           WellControls const & wellControls,
+          arrayView2d< real64 const > const & wellElemDens,
           arrayView1d< real64 > const & connRate )
   {
     real64 const targetRate = wellControls.GetTargetRate();
@@ -619,17 +620,44 @@ struct RateInitializationKernel
       {
         // if BHP constraint set rate below the absolute max rate
         // with the appropriate sign (negative for prod, positive for inj)
-        connRate[iwelem] = ( wellType == WellControls::Type::PRODUCER )
-                     ? LvArray::math::max( 0.1 * targetRate, -1e3 )
-             : LvArray::math::min( 0.1 * targetRate, 1e3 );
+        if( wellType == WellControls::Type::PRODUCER )
+        {
+          connRate[iwelem] = LvArray::math::max( 0.1 * targetRate * wellElemDens[iwelem][0], -1e3 );
+        }
+        else
+        {
+          connRate[iwelem] = LvArray::math::min( 0.1 * targetRate * wellElemDens[iwelem][0], 1e3 );
+        }
       }
       else
       {
-        connRate[iwelem] = targetRate;
+        connRate[iwelem] = targetRate * wellElemDens[iwelem][0];
       }
     } );
   }
 
+};
+
+
+/******************************** FluidUpdateAtTopElemKernel ********************************/
+
+struct FluidUpdateAtReferenceConditionsKernel
+{
+  template< typename FLUID_WRAPPER >
+  static void
+  Launch( arrayView1d< localIndex const > const & targetSet,
+          FLUID_WRAPPER const & fluidWrapper,
+          real64 const refPres )
+  {
+    forAll< parallelDevicePolicy<> >( targetSet.size(), [=] GEOSX_HOST_DEVICE ( localIndex const a )
+    {
+      localIndex const k = targetSet[a];
+      for( localIndex q = 0; q < fluidWrapper.numGauss(); ++q )
+      {
+        fluidWrapper.Update( k, q, refPres );
+      }
+    } );
+  }
 };
 
 
@@ -642,12 +670,20 @@ struct ResidualNormKernel
   static void
   Launch( LOCAL_VECTOR const localResidual,
           globalIndex const rankOffset,
+          bool const isLocallyOwned,
+          localIndex const iwelemControl,
+          WellControls const & wellControls,
           arrayView1d< globalIndex const > const & wellElemDofNumber,
           arrayView1d< integer const > const & wellElemGhostRank,
-          arrayView1d< real64 const > const & wellElemVolume,
-          arrayView2d< real64 const > const & wellElemDensity,
+          arrayView2d< real64 const > const & wellElemDens,
+          real64 const dt,
           real64 * localResidualNorm )
   {
+    WellControls::Control const currentControl = wellControls.GetControl();
+    real64 const targetBHP = wellControls.GetTargetBHP();
+    real64 const targetRate = wellControls.GetTargetRate();
+    real64 const absTargetRate = fabs( targetRate );
+
     RAJA::ReduceSum< REDUCE_POLICY, real64 > sumScaled( 0.0 );
 
     forAll< POLICY >( wellElemDofNumber.size(), [=] GEOSX_HOST_DEVICE ( localIndex const iwelem )
@@ -656,9 +692,31 @@ struct ResidualNormKernel
       {
         for( localIndex idof = 0; idof < 2; ++idof )
         {
-          real64 const normalizer = ( idof == SinglePhaseWell::RowOffset::MASSBAL )
-                                    ? wellElemDensity[iwelem][0] * wellElemVolume[iwelem]
-                                    : 1;
+          real64 normalizer = 0.0;
+          if( idof == SinglePhaseWell::RowOffset::CONTROL )
+          {
+            // for the top well element, normalize using the current control
+            if( isLocallyOwned && iwelem == iwelemControl )
+            {
+              if( currentControl == WellControls::Control::BHP )
+              {
+                normalizer = targetBHP;
+              }
+              else if( currentControl == WellControls::Control::TOTALVOLRATE )
+              {
+                normalizer = absTargetRate;
+              }
+            }
+            // for the pressure difference equation, always normalize by the BHP
+            else
+            {
+              normalizer = targetBHP;
+            }
+          }
+          else // SinglePhaseWell::RowOffset::MASSBAL
+          {
+            normalizer = dt * absTargetRate * wellElemDens[iwelem][0];
+          }
           localIndex const lid = wellElemDofNumber[iwelem] + idof - rankOffset;
           real64 const val = localResidual[lid] / normalizer;
           sumScaled += val * val;

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/WellControls.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/WellControls.hpp
@@ -58,10 +58,8 @@ public:
   enum class Control : integer
   {
     BHP,  /**< The well operates at a specified bottom hole pressure (BHP) */
-    GASRATE, /**< The well operates at a specified gas flow rate */
-    OILRATE, /**< The well operates at a specified oil flow rate */
-    WATERRATE, /**< The well operates at a specified water flow rate */
-    LIQUIDRATE /**< The well operates at a specified liquid flow rate (oil + water) */
+    OILVOLRATE, /**< The well operates at a specified oil volumetric flow rate */
+    TOTALVOLRATE, /**< The well operates at a specified total volumetric flow rate */
   };
 
 
@@ -118,24 +116,6 @@ public:
   ///@{
 
   /**
-   * @brief Set the reference well elem index where the control will be enforced.
-   * @param[in] refIndex reference well element index where the control will be enforced
-   */
-  void SetReferenceWellElementIndex( localIndex refIndex )
-  {
-    m_refWellElemIndex = refIndex;
-  }
-
-  /**
-   * @brief Get the reference well element index where the control will be enforced.
-   * @return a localIndex value representing the reference well element index where the control will be enforced
-   */
-  localIndex const & GetReferenceWellElementIndex() const
-  {
-    return m_refWellElemIndex;
-  }
-
-  /**
    * @brief Get the well type (injector or producer).
    * @return a well Type enum
    */
@@ -157,6 +137,23 @@ public:
    */
   Control GetControl() const { return m_currentControl; }
 
+  /**
+   * @brief Getter for the reference elevation where the BHP control is enforced
+   * @return the reference elevation
+   */
+  real64 GetReferenceElevation() const { return m_refElevation; }
+
+  /**
+   * @brief Getter for the reference gravity coefficient
+   * @return the reference gravity coefficient
+   */
+  real64 GetReferenceGravityCoef() const { return m_refGravCoef; }
+
+  /**
+   * @brief Setter for the reference gravity
+   */
+  void SetReferenceGravityCoef( real64 const & refGravCoef ) { m_refGravCoef = refGravCoef; }
+
 
   /**
    * @brief Get the target Bottom Hole Pressure value.
@@ -171,6 +168,11 @@ public:
    */
   const real64 & GetTargetRate() const { return m_targetRate; }
 
+  /**
+   * @brief Get the target oil rate
+   * @return the target oil rate
+   */
+  const real64 & GetTargetOilRate() const { return m_targetOilRate; }
 
   /**
    * @brief Const accessor for the composition of the injection rate
@@ -178,11 +180,8 @@ public:
    */
   arrayView1d< real64 const > GetInjectionStream() const { return m_injectionStream; }
 
-  ///@}
 
-  /// @cond DO_NOT_DOCUMENT
-  void Debug() const;
-  /// @endcond
+  ///@}
 
   /**
    * @brief Struct to serve as a container for variable strings and keys.
@@ -190,8 +189,8 @@ public:
    */
   struct viewKeyStruct
   {
-    /// String key for the reference index (currently unused)
-    static constexpr auto refWellElemIndexString = "referenceWellElementIndex";
+    /// String key for the well reference elevation (for BHP control)
+    static constexpr auto refElevString          = "referenceElevation";
     /// String key for the well type
     static constexpr auto typeString             = "type";
     /// String key for the well control
@@ -200,20 +199,24 @@ public:
     static constexpr auto targetBHPString        = "targetBHP";
     /// String key for the well target rate
     static constexpr auto targetRateString       = "targetRate";
+    /// String key for the well target oil rate for producers
+    static constexpr auto targetOilRateString    = "targetOilRate";
     /// String key for the well injection stream
     static constexpr auto injectionStreamString  = "injectionStream";
-    /// ViewKey for the reference index (currently unused)
-    dataRepository::ViewKey referenceIndex  = { refWellElemIndexString };
+    /// ViewKey for the reference elevation
+    dataRepository::ViewKey referenceElevation = { refElevString };
     /// ViewKey for the well type
-    dataRepository::ViewKey type            = { typeString };
+    dataRepository::ViewKey type               = { typeString };
     /// ViewKey for the well control
-    dataRepository::ViewKey control         = { controlString };
+    dataRepository::ViewKey control            = { controlString };
     /// ViewKey for the well target BHP
-    dataRepository::ViewKey targetBHP       = { targetBHPString };
+    dataRepository::ViewKey targetBHP          = { targetBHPString };
     /// ViewKey for the well target rate
-    dataRepository::ViewKey targetRate      = { targetRateString };
+    dataRepository::ViewKey targetRate         = { targetRateString };
+    /// ViewKey for the well target oil rate
+    dataRepository::ViewKey targetOilRate      = { targetOilRateString };
     /// ViewKey for the well injection stream
-    dataRepository::ViewKey injectionStream = { injectionStreamString };
+    dataRepository::ViewKey injectionStream    = { injectionStreamString };
   }
   /// ViewKey struct for the WellControls class
   viewKeysWellControls;
@@ -238,8 +241,11 @@ private:
   /// Well type (as Type enum)
   Type m_type;
 
-  /// Reference index (currently unused)
-  localIndex m_refWellElemIndex;
+  /// Reference elevation
+  real64 m_refElevation;
+
+  /// Gravity coefficient of the reference elevation
+  real64 m_refGravCoef;
 
   /// Well controls as a Control enum
   Control m_currentControl;
@@ -250,6 +256,9 @@ private:
   /// Target rate value
   real64 m_targetRate;
 
+  /// Target oil rate value
+  real64 m_targetOilRate;
+
   /// Vector with global component fractions at the injector
   array1d< real64 >  m_injectionStream;
 
@@ -257,7 +266,7 @@ private:
 
 ENUM_STRINGS( WellControls::Type, "producer", "injector" )
 
-ENUM_STRINGS( WellControls::Control, "BHP", "gasRate", "oilRate", "waterRate", "liquidRate" )
+ENUM_STRINGS( WellControls::Control, "BHP", "oilVolRate", "totalVolRate" )
 
 } //namespace geosx
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/WellSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/WellSolverBase.cpp
@@ -34,7 +34,8 @@ WellSolverBase::WellSolverBase( std::string const & name,
                                 Group * const parent )
   : SolverBase( name, parent ),
   m_numDofPerWellElement( 0 ),
-  m_numDofPerResElement( 0 )
+  m_numDofPerResElement( 0 ),
+  m_currentDt( 0 )
 {
   this->registerWrapper( viewKeyStruct::fluidNamesString, &m_fluidModelNames )->
     setInputFlag( InputFlags::REQUIRED )->
@@ -204,48 +205,35 @@ void WellSolverBase::PrecomputeData( DomainPartition & domain )
   forTargetSubRegions< WellElementSubRegion >( meshLevel, [&]( localIndex const,
                                                                WellElementSubRegion & subRegion )
   {
-    PerforationData * const perforationData = subRegion.GetPerforationData();
+    PerforationData & perforationData = *subRegion.GetPerforationData();
+    WellControls & wellControls = GetWellControls( subRegion );
+    real64 const refElev = wellControls.GetReferenceElevation();
 
     arrayView2d< real64 const > const wellElemLocation = subRegion.getElementCenter();
-
     arrayView1d< real64 > const wellElemGravCoef =
       subRegion.getReference< array1d< real64 > >( viewKeyStruct::gravityCoefString );
 
     arrayView1d< R1Tensor const > const perfLocation =
-      perforationData->getReference< array1d< R1Tensor > >( PerforationData::viewKeyStruct::locationString );
-
+      perforationData.getReference< array1d< R1Tensor > >( PerforationData::viewKeyStruct::locationString );
     arrayView1d< real64 > const perfGravCoef =
-      perforationData->getReference< array1d< real64 > >( viewKeyStruct::gravityCoefString );
+      perforationData.getReference< array1d< real64 > >( viewKeyStruct::gravityCoefString );
 
-    for( localIndex iwelem = 0; iwelem < subRegion.size(); ++iwelem )
+    forAll< serialPolicy >( perforationData.size(), [=]( localIndex const iperf )
     {
-      // precompute the depth of the well elements
-      wellElemGravCoef[iwelem] = wellElemLocation( iwelem, 0 ) * gravVector[ 0 ] + wellElemLocation( iwelem, 1 ) * gravVector[ 1 ] + wellElemLocation( iwelem,
-                                                                                                                                                       2 ) *
-                                 gravVector[ 2 ];
-    }
-
-    forAll< serialPolicy >( perforationData->size(), [=]( localIndex const iperf )
-    {
-      // precompute the depth of the perforations
       perfGravCoef[iperf] = Dot( perfLocation[iperf], gravVector );
     } );
 
-
-    // set the first well element of the well
-    if( subRegion.IsLocallyOwned() )
+    forAll< serialPolicy >( subRegion.size(), [=]( localIndex const iwelem )
     {
+      // precompute the depth of the well elements
+      wellElemGravCoef[iwelem] = wellElemLocation( iwelem, 0 ) * gravVector[ 0 ]
+                                 + wellElemLocation( iwelem, 1 ) * gravVector[ 1 ]
+                                 + wellElemLocation( iwelem, 2 ) * gravVector[ 2 ];
+    } );
 
-      localIndex const iwelemControl = subRegion.GetTopWellElementIndex();
+    // set the reference well element where the BHP control is applied
+    wellControls.SetReferenceGravityCoef( refElev * gravVector[ 2 ] );
 
-      GEOSX_ERROR_IF( iwelemControl < 0,
-                      "Invalid well definition: well " << subRegion.getName()
-                                                       << " has no well head" );
-
-      // save the index of reference well element (used to enforce constraints)
-      WellControls & wellControls = GetWellControls( subRegion );
-      wellControls.SetReferenceWellElementIndex( iwelemControl );
-    }
   } );
 }
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/WellSolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/WellSolverBase.hpp
@@ -303,6 +303,9 @@ protected:
   /// the number of Degrees of Freedom per reservoir element
   localIndex m_numDofPerResElement;
 
+  /// copy of the time step size saved in this class for residual normalization
+  real64 m_currentDt;
+
   /// views into reservoir constant data fields
   ElementRegionManager::ElementViewAccessor< arrayView1d< real64 const > >  m_resGravCoef;
 };


### PR DESCRIPTION
This PR implements some changes in the well controls to match a simulation result generated with Intersect:
- The pressure control now enforces the BHP at a user-specified reference elevation.
- The rate control now enforces a volumetric oil phase/total rate at reservoir or surface conditions (for individual wells, no group control implemented).

This PR also changes the scaling of the control/pressure difference equations because the previous scaling was creating issues with fgmres + MGR. 
