### PR TITLE
Fix gcc-10 warnings/crashes

### DIFF
--- a/src/coreComponents/dataRepository/wrapperHelpers.hpp
+++ b/src/coreComponents/dataRepository/wrapperHelpers.hpp
@@ -603,7 +603,7 @@ averageOverSecondDim( ArrayView< T const, NDIM, USD > const & var )
     } );
   } );
 
-  return std::move( ret );
+  return ret;
 }
 
 template< typename T >

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFlowKernels.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFlowKernels.cpp
@@ -1041,12 +1041,12 @@ FluxKernel::
 
   localIndex constexpr NUM_ELEMS   = STENCIL_TYPE::NUM_POINT_IN_FLUX;
   localIndex constexpr MAX_STENCIL = STENCIL_TYPE::MAX_STENCIL_SIZE;
-  localIndex constexpr NDOF = NC + 1;
 
   forAll< parallelDevicePolicy<> >( stencil.size(), [=] GEOSX_HOST_DEVICE ( localIndex const iconn )
   {
     // TODO: hack! for MPFA, etc. must obtain proper size from e.g. seri
     localIndex const stencilSize = MAX_STENCIL;
+    localIndex constexpr NDOF = NC + 1;
 
     stackArray1d< real64, NUM_ELEMS * NC >                      localFlux( NUM_ELEMS * NC );
     stackArray2d< real64, NUM_ELEMS * NC * MAX_STENCIL * NDOF > localFluxJacobian( NUM_ELEMS * NC, stencilSize * NDOF );


### PR DESCRIPTION
This PR fixes a few warnings-treated-as-errors and a compiler crash with gcc-10.2.
(Which reminds me, newer compilers are always better at catching things, we should be trying to add them to the CI matrix).

Thanks to @ishovkun for catching. You can try this branch out, or just wait until it's merged. I built with gcc-10 in both debug and release, so hopefully it builds for you.

Related: https://github.com/GEOSX/LvArray/pull/209