### PR TITLE
Fix MGR DoF labeling for 3 fields or more

### DIFF
--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreMGRStrategies.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreMGRStrategies.hpp
@@ -65,7 +65,7 @@ inline array1d< HYPRE_Int > computeLocalDofComponentLabels( arraySlice1d< localI
       {
         vectorLabels[k] = k + firstLabel;
       }
-      iend = istr + LvArray::integerConversion< HYPRE_Int >( numLocalDofsPerField[iFld] );;
+      iend = istr + LvArray::integerConversion< HYPRE_Int >( numLocalDofsPerField[iFld] );
       for( localIndex i = istr; i < iend; i += numComp )
       {
         for( integer k = 0; k < numComp; ++k )
@@ -73,7 +73,7 @@ inline array1d< HYPRE_Int > computeLocalDofComponentLabels( arraySlice1d< localI
           ret[i+k] = vectorLabels[k];
         }
       }
-      istr += iend;
+      istr = iend;
       firstLabel += numComp;
     }
   }


### PR DESCRIPTION
This PR fixes a small bug in the MGR DoF labeling when we have 3 fields or more in the function `computeLocalDofComponentLabels` of `HypreMGRStrategies.hpp`.

Consider three fields with `numLocalDofsPerField = { 1200, 1640, 24 }` (representing here cell-centered compositional reservoir vars, face Lagrange multipliers, and well compositional vars). We want to fill the vector `ret` from 0 to 1199 for the first field, from 1200 to 2839 for the second field, and from 2840 to 2863 for the third field. But, for the third field, we currently try to fill entries from 4040 to 4063 because `istr` is incremented twice.

To reproduce: use branch `feature/hamon/rsc` set up with Hypre using this [integrated test](https://github.com/GEOSX/GEOSX/blob/feature/hamon/rsc/src/coreComponents/physicsSolvers/fluidFlow/wells/integratedTests/compositionalMultiphaseWell/dead_oil_wells_hybrid_2d.xml).

Sorry I did not have an existing PR touching this area of the code and ready to merge so I did this 2-line PR.