### PR TITLE
LvArray update.

### DIFF
--- a/src/coreComponents/constitutive/unitTests/testLinearElasticAnisotropic.cpp
+++ b/src/coreComponents/constitutive/unitTests/testLinearElasticAnisotropic.cpp
@@ -40,7 +40,7 @@ TEST( LinearElasticAnisotropicTests, testAllocation )
 //  arrayView1d<LinearElasticAnisotropic::StiffnessTensor const> const &
 //  stiffness = cm.stiffness() ;
 
-  arrayView3d< real64 const, solid::STRESS_USD > const & stress = cm.getStress().toViewConst();
+  arrayView3d< real64 const, solid::STRESS_USD > const & stress = cm.getStress();
 
 //  EXPECT_EQ( stiffness.size(), numElems );
   EXPECT_EQ( stress.size( 0 ), numElems );

--- a/src/coreComponents/constitutive/unitTests/testLinearElasticIsotropic.cpp
+++ b/src/coreComponents/constitutive/unitTests/testLinearElasticIsotropic.cpp
@@ -37,9 +37,9 @@ TEST( LinearElasticIsotropicTests, testAllocation )
   EXPECT_EQ( cm.size(), numElems );
   EXPECT_EQ( cm.numQuadraturePoints(), numQuadraturePoints );
 
-  arrayView1d< real64 const > const bulkModulus = cm.bulkModulus().toViewConst();
-  arrayView1d< real64 const > const shearModulus = cm.shearModulus().toViewConst();
-  arrayView3d< real64 const, solid::STRESS_USD > const stress = cm.getStress().toViewConst();
+  arrayView1d< real64 const > const bulkModulus = cm.bulkModulus();
+  arrayView1d< real64 const > const shearModulus = cm.shearModulus();
+  arrayView3d< real64 const, solid::STRESS_USD > const stress = cm.getStress();
 
   EXPECT_EQ( bulkModulus.size(), numElems );
   EXPECT_EQ( shearModulus.size(), numElems );

--- a/src/coreComponents/finiteVolume/TwoPointFluxApproximation.cpp
+++ b/src/coreComponents/finiteVolume/TwoPointFluxApproximation.cpp
@@ -81,7 +81,7 @@ void TwoPointFluxApproximation::computeCellStencil( MeshLevel & mesh ) const
   ElementRegionManager::ElementViewAccessor< arrayView1d< integer const > > const elemGhostRank =
     elemManager.ConstructArrayViewAccessor< integer, 1 >( ObjectManagerBase::viewKeyStruct::ghostRankString );
 
-  ArrayOfArraysView< localIndex const > const & faceToNodes = faceManager.nodeList().toViewConst();
+  ArrayOfArraysView< localIndex const > const faceToNodes = faceManager.nodeList().toViewConst();
 
   // make a list of region indices to be included
   SortedArray< localIndex > regionFilter;
@@ -258,28 +258,28 @@ void TwoPointFluxApproximation::addToFractureStencil( MeshLevel & mesh,
 #endif
 #if SET_CREATION_DISPLACEMENT==1
   ArrayOfArraysView< localIndex const > const & faceToNodesMap = faceManager->nodeList();
-  arrayView2d< real64, nodes::INCR_DISPLACEMENT_USD > const & incrementalDisplacement = nodeManager->incrementalDisplacement();
-  arrayView2d< real64, nodes::TOTAL_DISPLACEMENT_USD > const & totalDisplacement = nodeManager->totalDisplacement();
-  arrayView1d< real64 > const & aperture = fractureSubRegion->getReference< array1d< real64 > >( "elementAperture" );
+  arrayView2d< real64, nodes::INCR_DISPLACEMENT_USD > const incrementalDisplacement = nodeManager->incrementalDisplacement();
+  arrayView2d< real64, nodes::TOTAL_DISPLACEMENT_USD > const totalDisplacement = nodeManager->totalDisplacement();
+  arrayView1d< real64 > const aperture = fractureSubRegion->getReference< array1d< real64 > >( "elementAperture" );
 #endif
 
 
 #ifdef GEOSX_USE_SEPARATION_COEFFICIENT
-  arrayView1d< real64 > const & apertureF = fractureSubRegion->getReference< array1d< real64 > >( "apertureAtFailure" );
+  arrayView1d< real64 > const apertureF = fractureSubRegion->getReference< array1d< real64 > >( "apertureAtFailure" );
 #endif
 
 #if !defined(ALLOW_CREATION_MASS)
   static_assert( true, "must have ALLOW_CREATION_MASS defined" );
 #endif
 #if ALLOW_CREATION_MASS==0
-  arrayView1d< real64 > const & dens = fractureSubRegion->getReference< array1d< real64 > >( "densityOld" );
+  arrayView1d< real64 > const dens = fractureSubRegion->getReference< array1d< real64 > >( "densityOld" );
 #endif
 
 
 #if SET_CREATION_PRESSURE==1
-  arrayView1d< real64 > const & fluidPressure = fractureSubRegion->getReference< array1d< real64 > >( "pressure" );
+  arrayView1d< real64 > const fluidPressure = fractureSubRegion->getReference< array1d< real64 > >( "pressure" );
   // Set the new face elements to some unphysical numbers to make sure they get set by the following routines.
-  SortedArrayView< localIndex const > const & newFaceElements = fractureSubRegion->m_newFaceElements.toViewConst();
+  SortedArrayView< localIndex const > const newFaceElements = fractureSubRegion->m_newFaceElements.toViewConst();
   forAll< serialPolicy >( fractureSubRegion->m_newFaceElements.size(), [=]( localIndex const k )
   {
     localIndex const kfe = newFaceElements[k];
@@ -310,7 +310,7 @@ void TwoPointFluxApproximation::addToFractureStencil( MeshLevel & mesh,
   SortedArray< localIndex > allNewElems;
   allNewElems.insert( fractureSubRegion->m_newFaceElements.begin(),
                       fractureSubRegion->m_newFaceElements.end() );
-  SortedArrayView< localIndex const > const &
+  SortedArrayView< localIndex const > const
   recalculateFractureConnectorEdges = edgeManager->m_recalculateFractureConnectorEdges.toViewConst();
 
   // add new connectors/connections between face elements to the fracture stencil
@@ -631,7 +631,7 @@ void TwoPointFluxApproximation::addEDFracToFractureStencil( MeshLevel & mesh,
                                                       EmbeddedSurfaceSubRegion >( "embeddedSurfaceSubRegion" ) );
 
   // arrayView1d< real64 const > const & fractureElemArea   = fractureSubRegion->getElementArea();
-  arrayView2d< real64 const > const fractureElemCenter = fractureSubRegion.getElementCenter().toViewConst();
+  arrayView2d< real64 const > const fractureElemCenter = fractureSubRegion.getElementCenter();
   arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const X = nodeManager.embSurfNodesPosition();
 
   EdgeManager::FaceMapType const & edgeToEmbSurfacesMap = embSurfEdgeManager.faceList();
@@ -704,7 +704,7 @@ void TwoPointFluxApproximation::addEDFracToFractureStencil( MeshLevel & mesh,
 
   FixedToManyElementRelation const & surfaceElementsToCells = fractureSubRegion.getToCellRelation();
 
-  arrayView1d< real64 const >     const & connectivityIndex = fractureSubRegion.getConnectivityIndex();
+  arrayView1d< real64 const > const connectivityIndex = fractureSubRegion.getConnectivityIndex();
 
   ElementRegionManager::ElementViewAccessor< arrayView1d< R1Tensor const > > const permeabilityTensor =
     elemManager.ConstructArrayViewAccessor< R1Tensor, 1 >( m_coeffName );
@@ -788,7 +788,7 @@ void TwoPointFluxApproximation::computeBoundaryStencil( MeshLevel & mesh,
   ElementRegionManager::ElementViewAccessor< arrayView1d< R1Tensor const > > const coefficient =
     elemManager.ConstructArrayViewAccessor< R1Tensor, 1 >( m_coeffName );
 
-  ArrayOfArraysView< localIndex const > const & faceToNodes = faceManager.nodeList().toViewConst();
+  ArrayOfArraysView< localIndex const > const faceToNodes = faceManager.nodeList().toViewConst();
 
   // make a list of region indices to be included
   SortedArray< localIndex > regionFilter;

--- a/src/coreComponents/linearAlgebra/unitTests/testLAIHelperFunctions.cpp
+++ b/src/coreComponents/linearAlgebra/unitTests/testLAIHelperFunctions.cpp
@@ -115,7 +115,7 @@ TEST_F( LAIHelperFunctionsTest, Test_NodalVectorPermutation )
   MeshLevel * const meshLevel = domain->getMeshBody( 0 )->getMeshLevel( 0 );
   NodeManager * const nodeManager = meshLevel->getNodeManager();
 
-  arrayView1d< globalIndex const > const nodeLocalToGlobal = nodeManager->localToGlobalMap().toViewConst();
+  arrayView1d< globalIndex const > const nodeLocalToGlobal = nodeManager->localToGlobalMap();
 
   DofManager dofManager( "test" );
   dofManager.setMesh( *domain, 0, 0 );

--- a/src/coreComponents/managers/unitTests/testMeshGeneration.cpp
+++ b/src/coreComponents/managers/unitTests/testMeshGeneration.cpp
@@ -190,8 +190,8 @@ TEST_F( MeshGenerationTest, nodePositions )
 
 TEST_F( MeshGenerationTest, elementCentersAndVolumes )
 {
-  arrayView2d< real64 const > const centers = m_subRegion->getElementCenter().toViewConst();
-  arrayView1d< real64 const > const volumes = m_subRegion->getElementVolume().toViewConst();
+  arrayView2d< real64 const > const centers = m_subRegion->getElementCenter();
+  arrayView1d< real64 const > const volumes = m_subRegion->getElementVolume();
 
   constexpr double VOLUME = dx * dy * dz;
 

--- a/src/coreComponents/mesh/CellElementRegion.cpp
+++ b/src/coreComponents/mesh/CellElementRegion.cpp
@@ -157,9 +157,9 @@ void CellElementRegion::GenerateAggregates( FaceManager const * const faceManage
   // Third, normalize the centers
   this->forElementSubRegions< CellElementSubRegion, FaceElementSubRegion >( [&]( ElementSubRegionBase & elementSubRegion )
   {
-    arrayView1d< integer const > const ghostRank = elementSubRegion.ghostRank().toViewConst();
+    arrayView1d< integer const > const ghostRank = elementSubRegion.ghostRank();
     localIndex const subRegionIndex = elementSubRegion.getIndexInParent();
-    arrayView2d< real64 const > const elemCenter = elementSubRegion.getElementCenter().toViewConst();
+    arrayView2d< real64 const > const elemCenter = elementSubRegion.getElementCenter();
 
     for( localIndex cellIndex = 0; cellIndex< elementSubRegion.size(); cellIndex++ )
     {

--- a/src/coreComponents/mesh/CellElementSubRegion.cpp
+++ b/src/coreComponents/mesh/CellElementSubRegion.cpp
@@ -48,7 +48,7 @@ void CellElementSubRegion::CopyFromCellBlock( CellBlock * source )
   this->resize( source->size());
   this->nodeList() = source->nodeList();
 
-  arrayView1d< globalIndex const > const sourceLocalToGlobal = source->localToGlobalMap().toViewConst();
+  arrayView1d< globalIndex const > const sourceLocalToGlobal = source->localToGlobalMap();
   this->m_localToGlobalMap.resize( sourceLocalToGlobal.size() );
   for( localIndex i = 0; i < localToGlobalMap().size(); ++i )
   {

--- a/src/coreComponents/mesh/EdgeManager.cpp
+++ b/src/coreComponents/mesh/EdgeManager.cpp
@@ -403,7 +403,7 @@ void EdgeManager::BuildEdges( FaceManager * const faceManager, NodeManager * con
 
   localIndex const numNodes = nodeManager->size();
 
-  ArrayOfArraysView< localIndex const > const & faceToNodeMap = faceManager->nodeList().toViewConst();
+  ArrayOfArraysView< localIndex const > const faceToNodeMap = faceManager->nodeList().toViewConst();
 
   faceManager->edgeList().SetRelatedObject( this );
   ArrayOfArrays< localIndex > & faceToEdgeMap = faceManager->edgeList();
@@ -444,7 +444,7 @@ void EdgeManager::BuildEdges( FaceManager * const faceManager, NodeManager * con
   {
     auto const & setWrapper = nodeSets[i];
     std::string const & setName = setWrapper->getName();
-    SortedArrayView< localIndex const > const & targetSet = nodeManager->sets().getReference< SortedArray< localIndex > >( setName ).toViewConst();
+    SortedArrayView< localIndex const > const targetSet = nodeManager->sets().getReference< SortedArray< localIndex > >( setName ).toViewConst();
     ConstructSetFromSetAndMap( targetSet, m_toNodesRelation, setName );
   } );
 
@@ -646,7 +646,7 @@ void EdgeManager::ExtractMapFromObjectForAssignGlobalIndexNumbers( ObjectManager
   localIndex const numEdges = size();
 
   arrayView2d< localIndex const > const edgeNodes = this->nodeList();
-  arrayView1d< integer const > const isDomainBoundary = this->getDomainBoundaryIndicator().toViewConst();
+  arrayView1d< integer const > const isDomainBoundary = this->getDomainBoundaryIndicator();
 
   globalEdgeNodes.resize( numEdges );
 
@@ -747,7 +747,7 @@ void EdgeManager::ConnectivityFromGlobalToLocal( const SortedArray< localIndex >
 void EdgeManager::AddToEdgeToFaceMap( FaceManager const * const faceManager,
                                       arrayView1d< localIndex const > const & newFaceIndices )
 {
-  ArrayOfArraysView< localIndex const > const & faceToEdgeMap = faceManager->edgeList().toViewConst();
+  ArrayOfArraysView< localIndex const > const faceToEdgeMap = faceManager->edgeList().toViewConst();
 
   // loop over all faces in list
   for( localIndex const newFaceIndex : newFaceIndices )

--- a/src/coreComponents/mesh/FaceManager.cpp
+++ b/src/coreComponents/mesh/FaceManager.cpp
@@ -653,7 +653,7 @@ void FaceManager::SetDomainBoundaryObjects( NodeManager * const nodeManager )
 
 void FaceManager::SetIsExternal()
 {
-  arrayView1d< integer const > const isDomainBoundary = this->getDomainBoundaryIndicator().toViewConst();
+  arrayView1d< integer const > const isDomainBoundary = this->getDomainBoundaryIndicator();
 
   m_isExternal.setValues< serialPolicy >( 0 );
   for( localIndex k=0; k<size(); ++k )
@@ -804,7 +804,7 @@ void FaceManager::ExtractMapFromObjectForAssignGlobalIndexNumbers( ObjectManager
   localIndex const numFaces = size();
 
   ArrayOfArraysView< localIndex const > const faceToNodeMap = this->nodeList().toViewConst();
-  arrayView1d< integer const > const isDomainBoundary = this->getDomainBoundaryIndicator().toViewConst();
+  arrayView1d< integer const > const isDomainBoundary = this->getDomainBoundaryIndicator();
 
   globalFaceNodes.resize( numFaces );
 

--- a/src/coreComponents/mesh/deprecated/FaceElementRegion.cpp
+++ b/src/coreComponents/mesh/deprecated/FaceElementRegion.cpp
@@ -81,7 +81,7 @@ localIndex FaceElementRegion::AddToFractureMesh( real64 const time_np1,
 
   arrayView2d< real64 const > const faceCenter = faceManager->faceCenter();
   arrayView2d< real64 > const elemCenter = subRegion->getElementCenter();
-  arrayView1d< real64 const > const elemArea = subRegion->getElementArea().toViewConst();
+  arrayView1d< real64 const > const elemArea = subRegion->getElementArea();
 
   arrayView1d< integer > const subRegionGhostRank = subRegion->ghostRank();
 

--- a/src/coreComponents/meshUtilities/unitTests/testPAMELAImport.cpp
+++ b/src/coreComponents/meshUtilities/unitTests/testPAMELAImport.cpp
@@ -72,7 +72,7 @@ void TestMeshImport( string const & inputStringMesh,
       [&]( localIndex const er, localIndex const esr, ElementRegionBase &, ElementSubRegionBase & elemSubRegion )
     {
       elemSubRegion.CalculateElementGeometricQuantities( nodeManager, faceManager );
-      arrayView2d< real64 const > const elemCenter = elemSubRegion.getElementCenter().toViewConst();
+      arrayView2d< real64 const > const elemCenter = elemSubRegion.getElementCenter();
       for( localIndex ei = 0; ei < elemSubRegion.size(); ei++ )
       {
         real64 center[ 3 ] = LVARRAY_TENSOROPS_INIT_LOCAL_3( elemCenter[ ei ] );

--- a/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBase.cpp
@@ -181,7 +181,7 @@ void FlowSolverBase::PrecomputeData( MeshLevel & mesh )
   forTargetSubRegions( mesh, [&]( localIndex const,
                                   ElementSubRegionBase & subRegion )
   {
-    arrayView2d< real64 const > const elemCenter = subRegion.getElementCenter().toViewConst();
+    arrayView2d< real64 const > const elemCenter = subRegion.getElementCenter();
 
     arrayView1d< real64 > const gravityCoef =
       subRegion.getReference< array1d< real64 > >( viewKeyStruct::gravityCoefString );

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/WellSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/WellSolverBase.cpp
@@ -206,7 +206,7 @@ void WellSolverBase::PrecomputeData( DomainPartition & domain )
   {
     PerforationData * const perforationData = subRegion.GetPerforationData();
 
-    arrayView2d< real64 const > const wellElemLocation = subRegion.getElementCenter().toViewConst();
+    arrayView2d< real64 const > const wellElemLocation = subRegion.getElementCenter();
 
     arrayView1d< real64 > const wellElemGravCoef =
       subRegion.getReference< array1d< real64 > >( viewKeyStruct::gravityCoefString );

--- a/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.cpp
@@ -282,7 +282,7 @@ void HydrofractureSolver::UpdateDeformationForCoupling( DomainPartition & domain
     arrayView1d< real64 > const effectiveAperture = subRegion.getReference< array1d< real64 > >( FlowSolverBase::viewKeyStruct::effectiveApertureString );
     arrayView1d< real64 const > const volume = subRegion.getElementVolume();
     arrayView1d< real64 > const deltaVolume = subRegion.getReference< array1d< real64 > >( FlowSolverBase::viewKeyStruct::deltaVolumeString );
-    arrayView1d< real64 const > const area = subRegion.getElementArea().toViewConst();
+    arrayView1d< real64 const > const area = subRegion.getElementArea();
     arrayView2d< localIndex const > const elemsToFaces = subRegion.faceList();
 
 #ifdef GEOSX_USE_SEPARATION_COEFFICIENT
@@ -889,7 +889,7 @@ HydrofractureSolver::
 
   globalIndex const rankOffset = m_dofManager.rankOffset();
 
-  CRSMatrixView< real64 const, localIndex const > const &
+  CRSMatrixView< real64 const, localIndex const > const
   dFluxResidual_dAperture = m_flowSolver->getDerivativeFluxResidual_dAperture().toViewConst();
 
   ContactRelationBase const * const

--- a/src/coreComponents/physicsSolvers/multiphysics/LagrangianContactSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/LagrangianContactSolver.cpp
@@ -256,9 +256,9 @@ void LagrangianContactSolver::ComputeTolerances( DomainPartition & domain ) cons
 
   // Get the "face to element" map (valid for the entire mesh)
   FaceManager::ElemMapType const & faceToElem = faceManager.toElementRelation();
-  arrayView2d< localIndex const > const & faceToElemRegion = faceToElem.m_toElementRegion.toViewConst();
-  arrayView2d< localIndex const > const & faceToElemSubRegion = faceToElem.m_toElementSubRegion.toViewConst();
-  arrayView2d< localIndex const > const & faceToElemIndex = faceToElem.m_toElementIndex.toViewConst();
+  arrayView2d< localIndex const > const & faceToElemRegion = faceToElem.m_toElementRegion;
+  arrayView2d< localIndex const > const & faceToElemSubRegion = faceToElem.m_toElementSubRegion;
+  arrayView2d< localIndex const > const & faceToElemIndex = faceToElem.m_toElementIndex;
 
   // Get the volume for all elements
   ElementRegionManager::ElementViewAccessor< arrayView1d< real64 const > > const elemVolume =
@@ -288,8 +288,8 @@ void LagrangianContactSolver::ComputeTolerances( DomainPartition & domain ) cons
     if( subRegion.hasWrapper( m_tractionKey ) )
     {
       arrayView1d< integer const > const & ghostRank = subRegion.ghostRank();
-      arrayView1d< real64 const > const & faceArea = subRegion.getElementArea().toViewConst();
-      arrayView3d< real64 const > const & faceRotationMatrix = subRegion.getElementRotationMatrix().toViewConst();
+      arrayView1d< real64 const > const & faceArea = subRegion.getElementArea();
+      arrayView3d< real64 const > const & faceRotationMatrix = subRegion.getElementRotationMatrix();
       arrayView2d< localIndex const > const & elemsToFaces = subRegion.faceList();
 
       arrayView1d< real64 > const & normalTractionTolerance =
@@ -454,7 +454,7 @@ void LagrangianContactSolver::UpdateDeformationForCoupling( DomainPartition & do
   FaceManager & faceManager = *meshLevel.getFaceManager();
   ElementRegionManager & elemManager = *meshLevel.getElemManager();
 
-  ArrayOfArraysView< localIndex const > const & faceToNodeMap = faceManager.nodeList().toViewConst();
+  ArrayOfArraysView< localIndex const > const faceToNodeMap = faceManager.nodeList().toViewConst();
 
   arrayView2d< real64 const, nodes::TOTAL_DISPLACEMENT_USD > const & u = nodeManager.totalDisplacement();
 
@@ -462,9 +462,9 @@ void LagrangianContactSolver::UpdateDeformationForCoupling( DomainPartition & do
   {
     if( subRegion.hasWrapper( m_tractionKey ) )
     {
-      arrayView3d< real64 const > const & rotationMatrix = subRegion.getElementRotationMatrix().toViewConst();
-      arrayView2d< localIndex const > const & elemsToFaces = subRegion.faceList();
-      arrayView2d< real64 > const & localJump = subRegion.getReference< array2d< real64 > >( viewKeyStruct::localJumpString );
+      arrayView3d< real64 const > const rotationMatrix = subRegion.getElementRotationMatrix();
+      arrayView2d< localIndex const > const elemsToFaces = subRegion.faceList();
+      arrayView2d< real64 > const localJump = subRegion.getReference< array2d< real64 > >( viewKeyStruct::localJumpString );
 
       forAll< parallelHostPolicy >( subRegion.size(), [=] ( localIndex const kfe )
       {
@@ -575,7 +575,7 @@ real64 LagrangianContactSolver::NonlinearImplicitStep( real64 const & time_n,
                         domain,
                         m_dofManager,
                         m_localMatrix.toViewConstSizes(),
-                        m_localRhs.toView() );
+                        m_localRhs );
 
         // apply boundary conditions to system
         ApplyBoundaryConditions( time_n,
@@ -583,7 +583,7 @@ real64 LagrangianContactSolver::NonlinearImplicitStep( real64 const & time_n,
                                  domain,
                                  m_dofManager,
                                  m_localMatrix.toViewConstSizes(),
-                                 m_localRhs.toView() );
+                                 m_localRhs );
 
         // TODO: maybe add scale function here?
         // Scale()
@@ -592,7 +592,7 @@ real64 LagrangianContactSolver::NonlinearImplicitStep( real64 const & time_n,
         // get residual norm
         if( computeResidual )
         {
-          residualNorm = CalculateResidualNorm( domain, m_dofManager, m_localRhs.toViewConst() );
+          residualNorm = CalculateResidualNorm( domain, m_dofManager, m_localRhs );
         }
         else
         {
@@ -630,7 +630,7 @@ real64 LagrangianContactSolver::NonlinearImplicitStep( real64 const & time_n,
 
         // Compose parallel LA matrix/rhs out of local LA matrix/rhs
         m_matrix.create( m_localMatrix.toViewConst(), MPI_COMM_GEOSX );
-        m_rhs.create( m_localRhs.toViewConst(), MPI_COMM_GEOSX );
+        m_rhs.create( m_localRhs, MPI_COMM_GEOSX );
         m_solution.createWithLocalSize( m_matrix.numLocalCols(), MPI_COMM_GEOSX );
 
         // Output the linear system matrix/rhs for debugging purposes
@@ -657,8 +657,8 @@ real64 LagrangianContactSolver::NonlinearImplicitStep( real64 const & time_n,
                                                domain,
                                                m_dofManager,
                                                m_localMatrix.toViewConstSizes(),
-                                               m_localRhs.toView(),
-                                               m_localSolution.toViewConst(),
+                                               m_localRhs,
+                                               m_localSolution,
                                                scaleFactor,
                                                residualNorm );
 
@@ -681,12 +681,12 @@ real64 LagrangianContactSolver::NonlinearImplicitStep( real64 const & time_n,
         else
         {
           // apply the system solution to the fields/variables
-          ApplySystemSolution( m_dofManager, m_localSolution.toViewConst(), scaleFactor, domain );
+          ApplySystemSolution( m_dofManager, m_localSolution, scaleFactor, domain );
           // Need to compute the residual norm
           computeResidual = true;
         }
 
-        if( !CheckSystemSolution( domain, m_dofManager, m_localSolution.toViewConst(), scaleFactor ) )
+        if( !CheckSystemSolution( domain, m_dofManager, m_localSolution, scaleFactor ) )
         {
           // TODO try chopping (similar to line search)
           GEOSX_LOG_RANK_0( "    Solution check failed. Newton loop terminated." );
@@ -1057,7 +1057,7 @@ void LagrangianContactSolver::
   NodeManager & nodeManager = *mesh.getNodeManager();
   ElementRegionManager const & elemManager = *mesh.getElemManager();
 
-  ArrayOfArraysView< localIndex const > const & faceToNodeMap = faceManager.nodeList().toViewConst();
+  ArrayOfArraysView< localIndex const > const faceToNodeMap = faceManager.nodeList().toViewConst();
 
   string const tracDofKey = dofManager.getKey( viewKeyStruct::tractionString );
   string const dispDofKey = dofManager.getKey( keys::TotalDisplacement );
@@ -1149,7 +1149,7 @@ void LagrangianContactSolver::
   ConstitutiveManager const * const constitutiveManager = domain.getConstitutiveManager();
   ContactRelationBase const * const contactRelation = constitutiveManager->GetGroup< ContactRelationBase const >( m_contactRelationName );
 
-  ArrayOfArraysView< localIndex const > const & faceToNodeMap = faceManager.nodeList().toViewConst();
+  ArrayOfArraysView< localIndex const > const faceToNodeMap = faceManager.nodeList().toViewConst();
 
   string const tracDofKey = dofManager.getKey( viewKeyStruct::tractionString );
   string const dispDofKey = dofManager.getKey( keys::TotalDisplacement );

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsSmallStrainQuasiStaticKernel.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsSmallStrainQuasiStaticKernel.hpp
@@ -113,7 +113,7 @@ public:
     m_disp( nodeManager.totalDisplacement()),
     m_uhat( nodeManager.incrementalDisplacement()),
     m_gravityVector{ inputGravityVector[0], inputGravityVector[1], inputGravityVector[2] },
-    m_density( inputConstitutiveType->getDensity().toViewConst() )
+    m_density( inputConstitutiveType->getDensity() )
   {}
 
 

--- a/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
@@ -2079,7 +2079,7 @@ void SurfaceGenerator::PerformFracture( const localIndex nodeID,
             localIndex elementIndex = faceToElementMap[iFace][0];
             CellElementSubRegion * elementSubRegion = elementManager.GetRegion( faceToRegionMap[iFace][0] )->
                                                         GetSubRegion< CellElementSubRegion >( faceToSubRegionMap[iFace][0] );
-            arrayView2d< real64 const > const subRegionElemCenter = elementSubRegion->getElementCenter().toViewConst();
+            arrayView2d< real64 const > const subRegionElemCenter = elementSubRegion->getElementCenter();
 
             faceManager.SortFaceNodes( X, subRegionElemCenter[ elementIndex ], faceToNodeMap[ iFace ], faceToNodeMap.sizeOfArray( iFace ) );
 
@@ -4468,8 +4468,7 @@ SurfaceGenerator::calculateRuptureRate( SurfaceElementRegion & faceElementRegion
   arrayView1d< real64 > const &
   ruptureRate = subRegion->getExtrinsicData< extrinsicMeshData::RuptureRate >();
 
-
-  arrayView2d< real64 const > const & elemCenter = subRegion->getElementCenter().toViewConst();
+  arrayView2d< real64 const > const & elemCenter = subRegion->getElementCenter();
 
   for( localIndex kfc=0; kfc<fractureConnectorEdgesToFaceElements.size(); ++kfc )
   {


### PR DESCRIPTION
No changes were necessary but I found a way to allow the UDC from `Array< T > const &` to `ArrayView< T const >` and from `ArrayView< T > &&` to `ArrayView< T const >` while disallowing `Array< T > &&` to `ArrayView< T const >` so I was able to get rid of some calls  to `toViewConst`.

Related to
https://github.com/GEOSX/LvArray/pull/215