### PR TITLE
Compile mathpresso targets iff mathpresso option is requested.

### DIFF
--- a/src/coreComponents/managers/CMakeLists.txt
+++ b/src/coreComponents/managers/CMakeLists.txt
@@ -21,9 +21,7 @@ set(managers_headers
     TimeHistory/HistoryDataSpec.hpp
     Outputs/BlueprintOutput.hpp
     Functions/FunctionBase.hpp
-    Functions/SymbolicFunction.hpp
     Functions/TableFunction.hpp
-    Functions/CompositeFunction.hpp
     Functions/FunctionManager.hpp
     ObjectManagerBase.hpp
     ProblemManager.hpp
@@ -57,9 +55,7 @@ set(managers_sources
     Tasks/TasksManager.cpp
     TimeHistory/PackCollection.cpp
     Functions/FunctionBase.cpp
-    Functions/SymbolicFunction.cpp
     Functions/TableFunction.cpp
-    Functions/CompositeFunction.cpp
     Functions/FunctionManager.cpp
     ObjectManagerBase.cpp
     ProblemManager.cpp
@@ -70,6 +66,15 @@ set(managers_sources
     FieldSpecification/SourceFluxBoundaryCondition.cpp
     initialization.cpp
    )
+
+if( ENABLE_MATHPRESSO )
+  list( APPEND managers_headers
+        Functions/SymbolicFunction.hpp
+        Functions/CompositeFunction.hpp )
+  list( APPEND managers_sources
+        Functions/SymbolicFunction.cpp
+        Functions/CompositeFunction.cpp )
+endif()
 
 if( ENABLE_MPI )
     list( APPEND managers_headers Outputs/ChomboIO.hpp )

--- a/src/coreComponents/managers/Functions/CompositeFunction.cpp
+++ b/src/coreComponents/managers/Functions/CompositeFunction.cpp
@@ -12,10 +12,6 @@
  * ------------------------------------------------------------------------------------------------------------
  */
 
-/**
- * @file CompositeFunction.cpp
- */
-
 #include "FunctionManager.hpp"
 #include "CompositeFunction.hpp"
 #include "common/DataTypes.hpp"
@@ -39,10 +35,8 @@ using namespace dataRepository;
 CompositeFunction::CompositeFunction( const std::string & name,
                                       Group * const parent ):
   FunctionBase( name, parent ),
-#ifdef GEOSX_USE_MATHPRESSO
   parserContext(),
   parserExpression(),
-#endif
   m_numSubFunctions(),
   m_subFunctions()
 {
@@ -59,14 +53,11 @@ CompositeFunction::CompositeFunction( const std::string & name,
     setDescription( "Composite math expression" );
 }
 
-
 CompositeFunction::~CompositeFunction()
 {}
 
-
 void CompositeFunction::InitializeFunction()
 {
-#ifdef GEOSX_USE_MATHPRESSO
   // Register variables
   for( localIndex ii=0; ii<m_variableNames.size(); ++ii )
   {
@@ -86,18 +77,13 @@ void CompositeFunction::InitializeFunction()
   {
     m_subFunctions.emplace_back( functionManager.GetGroup< FunctionBase >( m_functionNames[ii] ));
   }
-#else
-  GEOSX_ERROR( "GEOSX was not configured with mathpresso!" );
-#endif
 }
-
 
 void CompositeFunction::Evaluate( dataRepository::Group const * const group,
                                   real64 const time,
                                   SortedArrayView< localIndex const > const & set,
                                   real64_array & result ) const
 {
-#ifdef GEOSX_USE_MATHPRESSO
   // Evaluate each of the subFunctions independently and place the results into
   // a temporary field
   array1d< real64_array > subFunctionResults;
@@ -119,15 +105,10 @@ void CompositeFunction::Evaluate( dataRepository::Group const * const group,
     }
     result[ii] = parserExpression.evaluate( reinterpret_cast< void * >( functionResults ));
   } );
-#else
-  GEOSX_ERROR( "GEOSX was not configured with mathpresso!" );
-#endif
 }
-
 
 real64 CompositeFunction::Evaluate( real64 const * const input ) const
 {
-#ifdef GEOSX_USE_MATHPRESSO
   real64 functionResults[m_maxNumSubFunctions];
 
   for( localIndex ii=0; ii<m_numSubFunctions; ++ii )
@@ -136,13 +117,8 @@ real64 CompositeFunction::Evaluate( real64 const * const input ) const
   }
 
   return parserExpression.evaluate( reinterpret_cast< void * >( functionResults ));
-#else
-  GEOSX_ERROR( "GEOSX was not configured with mathpresso!" );
-  return 0;
-#endif
 }
-
 
 REGISTER_CATALOG_ENTRY( FunctionBase, CompositeFunction, std::string const &, Group * const )
 
-} /* namespace ANST */
+} // namespace geosx

--- a/src/coreComponents/managers/Functions/CompositeFunction.hpp
+++ b/src/coreComponents/managers/Functions/CompositeFunction.hpp
@@ -21,9 +21,7 @@
 
 #include "FunctionBase.hpp"
 
-#ifdef GEOSX_USE_MATHPRESSO
 #include <mathpresso/mathpresso.h>
-#endif
 
 namespace geosx
 {
@@ -81,10 +79,8 @@ private:
   string_array m_variableNames;
   string m_expression;
 
-#ifdef GEOSX_USE_MATHPRESSO
   mathpresso::Context parserContext;
   mathpresso::Expression parserExpression;
-#endif
 
   localIndex m_numSubFunctions;
   static constexpr localIndex m_maxNumSubFunctions = 10;

--- a/src/coreComponents/managers/Functions/SymbolicFunction.cpp
+++ b/src/coreComponents/managers/Functions/SymbolicFunction.cpp
@@ -33,15 +33,11 @@ std::string const expression = "expression";
 
 using namespace dataRepository;
 
-
-
 SymbolicFunction::SymbolicFunction( const std::string & name,
                                     Group * const parent ):
-  FunctionBase( name, parent )
-#ifdef GEOSX_USE_MATHPRESSO
-  , parserContext(),
+  FunctionBase( name, parent ),
+  parserContext(),
   parserExpression()
-#endif
 {
   registerWrapper( keys::variableNames, &m_variableNames )->
     setInputFlag( InputFlags::REQUIRED )->
@@ -60,7 +56,6 @@ SymbolicFunction::~SymbolicFunction()
 
 void SymbolicFunction::InitializeFunction()
 {
-#ifdef GEOSX_USE_MATHPRESSO
   // Register variables
   for( localIndex ii=0; ii<m_variableNames.size(); ++ii )
   {
@@ -72,11 +67,7 @@ void SymbolicFunction::InitializeFunction()
   parserContext.addBuiltIns();
   mathpresso::Error err = parserExpression.compile( parserContext, m_expression.c_str(), mathpresso::kNoOptions );
   GEOSX_ERROR_IF( err != mathpresso::kErrorOk, "JIT Compiler Error" );
-#else
-  GEOSX_ERROR( "GEOSX was not built with mathpresso!" );
-#endif
 }
-
 
 REGISTER_CATALOG_ENTRY( FunctionBase, SymbolicFunction, std::string const &, Group * const )
 

--- a/src/coreComponents/managers/Functions/SymbolicFunction.hpp
+++ b/src/coreComponents/managers/Functions/SymbolicFunction.hpp
@@ -11,19 +11,12 @@
  * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
  * ------------------------------------------------------------------------------------------------------------
  */
-
-/**
- * @file SymbolicFunction.hpp
- */
-
 #ifndef GEOSX_MANAGERS_FUNCTIONS_SYMBOLICFUNCTION_HPP_
 #define GEOSX_MANAGERS_FUNCTIONS_SYMBOLICFUNCTION_HPP_
 
 #include "FunctionBase.hpp"
 
-#ifdef GEOSX_USE_MATHPRESSO
 #include <mathpresso/mathpresso.h>
-#endif
 
 namespace geosx
 {
@@ -78,12 +71,7 @@ public:
    */
   inline real64 Evaluate( real64 const * const input ) const override final
   {
-#ifdef GEOSX_USE_MATHPRESSO
     return parserExpression.evaluate( reinterpret_cast< void * >( const_cast< real64 * >(input) ) );
-#else
-    GEOSX_ERROR( "GEOSX was not built with mathpresso!" );
-    return 0;
-#endif
   }
 
 
@@ -103,18 +91,14 @@ public:
 
 private:
   // Symbolic math driver objects
-#ifdef GEOSX_USE_MATHPRESSO
   mathpresso::Context parserContext;
   mathpresso::Expression parserExpression;
-#endif
-
 
   /// Symbolic expression variable names
   string_array m_variableNames;
 
   /// Symbolic expression
   string m_expression;
-
 };
 
 

--- a/src/coreComponents/managers/unitTests/testFunctions.cpp
+++ b/src/coreComponents/managers/unitTests/testFunctions.cpp
@@ -17,7 +17,10 @@
 #include "managers/Functions/FunctionManager.hpp"
 #include "managers/Functions/FunctionBase.hpp"
 #include "managers/Functions/TableFunction.hpp"
+#ifdef GEOSX_USE_MATHPRESSO
 #include "managers/Functions/SymbolicFunction.hpp"
+#endif
+
 #include <random>
 
 using namespace geosx;


### PR DESCRIPTION
Classes `SymbolicFunction` and `CompositeFunction` make no sense without `mathpresso` (They simply kill the simulation).
This PR removes those files from the compilation. Using these features without `mathpresso` will result in faster failure for the user (Simulation won't start).

Fixes https://github.com/GEOSX/GEOSX/issues/612
