### PR TITLE
Provide docker solution to docker restriction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ geosx_linux_build: &geosx_linux_build
     --cap-add=ALL
     -e CMAKE_BUILD_TYPE
     -e GEOSX_DIR=${GEOSX_DIR}
-    -e OMPI_MCA_btl_vader_single_copy_mechanism=none
     ${DOCKER_REPOSITORY}:${GEOSX_TPL_TAG}
     ${TRAVIS_BUILD_DIR_MOUNT_POINT}/scripts/travis_build_and_test.sh ${BUILD_AND_TEST_ARGS};
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ geosx_linux_build: &geosx_linux_build
   - docker run
     --name=${CONTAINER_NAME}
     --volume=${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR_MOUNT_POINT}
-    --cap-add=SYS_PTRACE
+    --cap-add=ALL
     -e CMAKE_BUILD_TYPE
     -e GEOSX_DIR=${GEOSX_DIR}
     ${DOCKER_REPOSITORY}:${GEOSX_TPL_TAG}

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ geosx_linux_build: &geosx_linux_build
   - docker run
     --name=${CONTAINER_NAME}
     --volume=${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR_MOUNT_POINT}
-    --cap-add=ALL
+    --cap-add=SYS_PTRACE
     -e CMAKE_BUILD_TYPE
     -e GEOSX_DIR=${GEOSX_DIR}
     ${DOCKER_REPOSITORY}:${GEOSX_TPL_TAG}

--- a/.travis.yml
+++ b/.travis.yml
@@ -189,7 +189,6 @@ jobs:
     env:
     - DOCKER_REPOSITORY=geosx/pangea2-gcc8.3.0-openmpi2.1.5-mkl2019.3
     - CMAKE_BUILD_TYPE=Release
-    - BUILD_AND_TEST_ARGS=--disable-unit-tests
   - stage: builds
     name: Mac_OSX
     <<: *geosx_osx_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ geosx_linux_build: &geosx_linux_build
   - docker run
     --name=${CONTAINER_NAME}
     --volume=${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR_MOUNT_POINT}
+    --cap-add=ALL
     -e CMAKE_BUILD_TYPE
     -e GEOSX_DIR=${GEOSX_DIR}
     -e OMPI_MCA_btl_vader_single_copy_mechanism=none

--- a/src/coreComponents/linearAlgebra/unitTests/testLAOperations.cpp
+++ b/src/coreComponents/linearAlgebra/unitTests/testLAOperations.cpp
@@ -506,6 +506,7 @@ LinearSolverParameters params_Direct()
 {
   LinearSolverParameters parameters;
   parameters.solverType = geosx::LinearSolverParameters::SolverType::direct;
+  parameters.direct.parallel = 0;
   return parameters;
 }
 

--- a/src/coreComponents/linearAlgebra/unitTests/testLAOperations.cpp
+++ b/src/coreComponents/linearAlgebra/unitTests/testLAOperations.cpp
@@ -506,7 +506,6 @@ LinearSolverParameters params_Direct()
 {
   LinearSolverParameters parameters;
   parameters.solverType = geosx::LinearSolverParameters::SolverType::direct;
-  parameters.direct.parallel = 0;
   return parameters;
 }
 


### PR DESCRIPTION
We were having bunch of error messages like
```
Read -1, expected 10824, errno = 1
```
which were coming from the fact that `openmpi` could not call `ptrace` inside our docker containers.
The environment variable solution (`OMPI_MCA_btl_vader_single_copy_mechanism=none` see [this thread](https://github.com/GEOSX/GEOSX/pull/1239#issue-524482520)) was modifying the `openmpi` behavior.

It seems however possible to grant [extra permissions](OMPI_MCA_btl_vader_single_copy_mechanism=none) to a docker container. Doing so we can get rid of the `openmpi` modification (probably less intrusive).

The `Pangea2` unit tests are working again (fixes #1245)... Not really sure why though 😢 

I've been running the tests 4 times in a row and everything is working.