### PR TITLE
Travis Cuda Clang Debug Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -174,13 +174,14 @@ jobs:
     - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
     - CMAKE_BUILD_TYPE=Release
     - BUILD_AND_TEST_ARGS=--disable-unit-tests
+  # Builds only the geosx executable (timeout when building tests)
   - stage: builds
     name: Ubuntu18.04_clang8.0.0_cuda10.1.243_debug
     <<: *geosx_linux_build
     env:
     - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
     - CMAKE_BUILD_TYPE=Debug
-    - BUILD_AND_TEST_ARGS=--disable-unit-tests
+    - BUILD_AND_TEST_ARGS="--disable-unit-tests --build-exe-only"
   - stage: builds
     name: Centos7.6_gcc8.3.1_cuda10.1.243_release
     <<: *geosx_linux_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -175,10 +175,10 @@ jobs:
     - CMAKE_BUILD_TYPE=Release
     - BUILD_AND_TEST_ARGS=--disable-unit-tests
   - stage: builds
-    name: Centos7.6_gcc8.3.1_cuda10.1.243_debug
+    name: Ubuntu18.04_clang8.0.0_cuda10.1.243_debug
     <<: *geosx_linux_build
     env:
-    - DOCKER_REPOSITORY=geosx/centos7.6.1810-gcc8.3.1-cuda10.1.243
+    - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
     - CMAKE_BUILD_TYPE=Debug
     - BUILD_AND_TEST_ARGS=--disable-unit-tests
   - stage: builds

--- a/scripts/travis_build_and_test.sh
+++ b/scripts/travis_build_and_test.sh
@@ -47,8 +47,13 @@ if [[ "$*" == *--test-documentation* ]]; then
   exit 0
 fi
 
-or_die make -j $(nproc) VERBOSE=1
-or_die make install VERBOSE=1
+# "Make" target check (builds geosx executable target only if true)
+if [[ "$*" == *--build-exe-only* ]]; then
+  or_die make -j $(nproc) geosx VERBOSE=1
+else
+  or_die make -j $(nproc) VERBOSE=1
+  or_die make install VERBOSE=1
+fi
 
 # Unit tests (excluding previously ran checks)
 if [[ "$*" != *--disable-unit-tests* ]]; then


### PR DESCRIPTION
This PR modifies the Debug gcc cuda job to use clang and build _only the geosx executable target_.
For both gcc and clang, the debug job has undefined behavior on Travis CI:

- [Timing out after 2 hours](https://travis-ci.com/github/GEOSX/GEOSX/builds/213214712)
- [Hanging when building unit tests](https://travis-ci.com/github/GEOSX/GEOSX/builds/213229238)
- [Passing in just under 2 hour time limit](https://travis-ci.com/github/GEOSX/GEOSX/builds/213233098)

Debug job was changed to build _only the geosx executable target_ , which runs in ~45 minutes and no longer builds unit tests which are causing Travis to hang. 
