### PR TITLE
Correct a typo: sparisty

### DIFF
--- a/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEM.cpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEM.cpp
@@ -187,10 +187,10 @@ void PhaseFieldDamageFEM::SetupSystem( DomainPartition & domain,
                                        CRSMatrix< real64, globalIndex > & localMatrix,
                                        array1d< real64 > & localRhs,
                                        array1d< real64 > & localSolution,
-                                       bool const setSparisty )
+                                       bool const setSparsity )
 {
   GEOSX_MARK_FUNCTION;
-  SolverBase::SetupSystem( domain, dofManager, localMatrix, localRhs, localSolution, setSparisty );
+  SolverBase::SetupSystem( domain, dofManager, localMatrix, localRhs, localSolution, setSparsity );
 }
 
 void PhaseFieldDamageFEM::ImplicitStepComplete(

--- a/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEM.hpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEM.hpp
@@ -76,7 +76,7 @@ public:
                             CRSMatrix< real64, globalIndex > & localMatrix,
                             array1d< real64 > & localRhs,
                             array1d< real64 > & localSolution,
-                            bool const setSparisty ) override;
+                            bool const setSparsity ) override;
 
   virtual void SetupDofs( DomainPartition const & domain,
                           DofManager & dofManager ) const override;

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
@@ -977,10 +977,10 @@ void SolidMechanicsLagrangianFEM::SetupSystem( DomainPartition & domain,
                                                CRSMatrix< real64, globalIndex > & localMatrix,
                                                array1d< real64 > & localRhs,
                                                array1d< real64 > & localSolution,
-                                               bool const setSparisty )
+                                               bool const setSparsity )
 {
   GEOSX_MARK_FUNCTION;
-  SolverBase::SetupSystem( domain, dofManager, localMatrix, localRhs, localSolution, setSparisty );
+  SolverBase::SetupSystem( domain, dofManager, localMatrix, localRhs, localSolution, setSparsity );
 
   MeshLevel & mesh = *(domain.getMeshBodies()->GetGroup< MeshBody >( 0 )->getMeshLevel( 0 ));
   NodeManager const & nodeManager = *(mesh.getNodeManager());


### PR DESCRIPTION
I corrected some typos in the variable naming