### PR TITLE
Bugfix/sytuan/camel case minor

### DIFF
--- a/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
@@ -633,9 +633,9 @@ int SurfaceGenerator::separationDriver( DomainPartition & domain,
 #else
 
     GEOSX_UNUSED_VAR( neighbors );
-    AssignNewGlobalIndicesSerial( nodeManager, modifiedObjects.newNodes );
-    AssignNewGlobalIndicesSerial( edgeManager, modifiedObjects.newEdges );
-    AssignNewGlobalIndicesSerial( faceManager, modifiedObjects.newFaces );
+    assignNewGlobalIndicesSerial( nodeManager, modifiedObjects.newNodes );
+    assignNewGlobalIndicesSerial( edgeManager, modifiedObjects.newEdges );
+    assignNewGlobalIndicesSerial( faceManager, modifiedObjects.newFaces );
 
 #endif
 


### PR DESCRIPTION
The build was fail if GEOSX_PTP is set to OFF. This is because of some remaining function names that were not changed with respect to the camelCase rule. This PR is to solve this issue. Should check also other precompilation filters.