### PR TITLE
Removed Doxygen warnings on Quartz

### DIFF
--- a/src/coreComponents/dataRepository/Group.hpp
+++ b/src/coreComponents/dataRepository/Group.hpp
@@ -377,7 +377,7 @@ public:
   }
 
   /**
-   * @copydoc GetGroup(localIndex)
+   * @copydoc getGroup(localIndex)
    */
   template< typename T = Group >
   T const * getGroup( localIndex index ) const
@@ -398,7 +398,7 @@ public:
   }
 
   /**
-   * @copydoc GetGroup(string const &)
+   * @copydoc getGroup(string const &)
    */
   template< typename T = Group >
   T const * getGroup( string const & name ) const
@@ -448,7 +448,7 @@ public:
   }
 
   /**
-   * @copydoc GetGroup(subGroupMap::KeyIndex const & key)
+   * @copydoc getGroup(subGroupMap::KeyIndex const & key)
    */
   template< typename T = Group >
   T const * getGroup( subGroupMap::KeyIndex const & key ) const
@@ -471,7 +471,7 @@ public:
   }
 
   /**
-   * @copydoc GetGroupByPath(string const &)
+   * @copydoc getGroupByPath(string const &)
    */
   template< typename T = Group >
   T const * getGroupByPath( string const & path ) const;

--- a/src/coreComponents/dataRepository/Wrapper.hpp
+++ b/src/coreComponents/dataRepository/Wrapper.hpp
@@ -293,7 +293,7 @@ public:
   }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  /// @copydoc geosx::WrapperBase::Pack
+  /// @copydoc geosx::WrapperBase::pack
   virtual
   localIndex pack( buffer_unit_type * & buffer, bool withMetadata, bool onDevice ) const override final
   {
@@ -318,7 +318,7 @@ public:
   }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  /// @copydoc geosx::WrapperBase::PackByIndex
+  /// @copydoc geosx::WrapperBase::packByIndex
   virtual
   localIndex packByIndex( buffer_unit_type * & buffer, arrayView1d< localIndex const > const & packList, bool withMetadata, bool onDevice ) const override final
   {
@@ -346,7 +346,7 @@ public:
   }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  /// @copydoc geosx::WrapperBase::PackSize
+  /// @copydoc geosx::WrapperBase::packSize
   virtual
   localIndex packSize( bool withMetadata, bool onDevice ) const override final
   {
@@ -372,7 +372,7 @@ public:
   }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  /// @copydoc geosx::WrapperBase::PackByIndexSize
+  /// @copydoc geosx::WrapperBase::packByIndexSize
   virtual
   localIndex packByIndexSize( arrayView1d< localIndex const > const & packList, bool withMetadata, bool onDevice ) const override final
   {
@@ -401,7 +401,7 @@ public:
   }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  /// @copydoc geosx::WrapperBase::Unpack
+  /// @copydoc geosx::WrapperBase::unpack
   virtual
   localIndex unpack( buffer_unit_type const * & buffer, bool withMetadata, bool onDevice ) override final
   {
@@ -431,7 +431,7 @@ public:
   }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  /// @copydoc geosx::WrapperBase::UnpackByIndex
+  /// @copydoc geosx::WrapperBase::unpackByIndex
   virtual
   localIndex unpackByIndex( buffer_unit_type const * & buffer, arrayView1d< localIndex const > const & unpackIndices, bool withMetadata, bool onDevice ) override final
   {

--- a/src/coreComponents/managers/DomainPartition.hpp
+++ b/src/coreComponents/managers/DomainPartition.hpp
@@ -82,7 +82,7 @@ public:
   ///@}
 
   /**
-   * @copydoc dataRepository::Group::RegisterDataOnMeshRecursive( Group * const )
+   * @copydoc dataRepository::Group::registerDataOnMeshRecursive( Group * const )
    */
   virtual void registerDataOnMeshRecursive( Group * const meshBodies ) override final;
 

--- a/src/coreComponents/managers/Events/EventBase.hpp
+++ b/src/coreComponents/managers/Events/EventBase.hpp
@@ -87,7 +87,7 @@ public:
              dataRepository::Group * domain );
 
   /**
-   * @copydoc dataRepository::Group::CreateChild()
+   * @copydoc dataRepository::Group::createChild()
    *
    * An event may have an arbitrary number of sub-events defined as children in the input xml.
    * e.g.:

--- a/src/coreComponents/managers/Events/HaltEvent.hpp
+++ b/src/coreComponents/managers/Events/HaltEvent.hpp
@@ -51,7 +51,7 @@ public:
   static string catalogName() { return "HaltEvent"; }
 
   /**
-   * @copydoc EventBase::EstimateEventTiming()
+   * @copydoc EventBase::estimateEventTiming()
    * @note This event is designed to look at the external clock. Currently,
    * if the event is triggered it will set a flag, which will
    * instruct the code to exit.  This is useful for managing walltime

--- a/src/coreComponents/managers/Events/PeriodicEvent.hpp
+++ b/src/coreComponents/managers/Events/PeriodicEvent.hpp
@@ -47,7 +47,7 @@ public:
   static string catalogName() { return "PeriodicEvent"; }
 
   /**
-   * @copydoc EventBase::EstimateEventTiming()
+   * @copydoc EventBase::estimateEventTiming()
    * @note Estimate the expected number of cycles until an event is expected to trigger.
    *       The event frequency can be specified in terms of:
    *        - time (timeFrequency > 0, units = seconds)
@@ -87,14 +87,14 @@ public:
                                        dataRepository::Group * domain );
 
   /**
-   * @copydoc EventBase::GetEventTypeDtRequest()
+   * @copydoc EventBase::getEventTypeDtRequest()
    * Grab the next time-step.  If requested, then limit the requested
    * dt to exactly match the time frequency
    */
   virtual real64 getEventTypeDtRequest( real64 const time ) override;
 
   /**
-   * @copydoc ExecutableGroup::Cleanup()
+   * @copydoc ExecutableGroup::cleanup()
    */
   virtual void cleanup( real64 const time_n,
                         integer const cycleNumber,

--- a/src/coreComponents/managers/Events/SoloEvent.hpp
+++ b/src/coreComponents/managers/Events/SoloEvent.hpp
@@ -47,7 +47,7 @@ public:
   static string catalogName() { return "SoloEvent"; }
 
   /**
-   * @copydoc EventBase::EstimateEventTiming()
+   * @copydoc EventBase::estimateEventTiming()
    */
   virtual void estimateEventTiming( real64 const time,
                                     real64 const dt,
@@ -55,7 +55,7 @@ public:
                                     dataRepository::Group * domain ) override;
 
   /**
-   * @copydoc EventBase::GetEventTypeDtRequest()
+   * @copydoc EventBase::getEventTypeDtRequest()
    */
   virtual real64 getEventTypeDtRequest( real64 const time ) override;
 

--- a/src/coreComponents/managers/Outputs/BlueprintOutput.hpp
+++ b/src/coreComponents/managers/Outputs/BlueprintOutput.hpp
@@ -70,7 +70,7 @@ public:
 
   /**
    * @brief Writes out a Blueprint plot file at the end of the simulation.
-   * @copydetails ExecutableGroup::Cleanup()
+   * @copydetails ExecutableGroup::cleanup()
    */
   virtual void cleanup( real64 const time_n,
                         integer const cycleNumber,

--- a/src/coreComponents/managers/Outputs/ChomboIO.hpp
+++ b/src/coreComponents/managers/Outputs/ChomboIO.hpp
@@ -59,7 +59,7 @@ public:
 
   /**
    * @brief Writes out a Chombo plot file at the end of the simulation.
-   * @copydetails ExecutableGroup::Cleanup()
+   * @copydetails ExecutableGroup::cleanup()
    */
   virtual void cleanup( real64 const time_n,
                         integer const cycleNumber,

--- a/src/coreComponents/managers/Outputs/OutputManager.hpp
+++ b/src/coreComponents/managers/Outputs/OutputManager.hpp
@@ -45,7 +45,7 @@ public:
   /// Destructor
   virtual ~OutputManager() override;
 
-  /// @copydoc geosx::dataRepository::Group::CreateChild( string const & childKey, string const & childName )
+  /// @copydoc geosx::dataRepository::Group::createChild( string const & childKey, string const & childName )
   virtual Group * createChild( string const & childKey, string const & childName ) override;
 
   /// This function is used to expand any catalogs in the data structure

--- a/src/coreComponents/managers/Outputs/RestartOutput.hpp
+++ b/src/coreComponents/managers/Outputs/RestartOutput.hpp
@@ -60,7 +60,7 @@ public:
 
   /**
    * @brief Write one final restart file as the code exits
-   * @copydetails ExecutableGroup::Cleanup()
+   * @copydetails ExecutableGroup::cleanup()
    */
   virtual void cleanup( real64 const time_n,
                         integer const cycleNumber,

--- a/src/coreComponents/managers/Outputs/SiloOutput.hpp
+++ b/src/coreComponents/managers/Outputs/SiloOutput.hpp
@@ -59,7 +59,7 @@ public:
 
   /**
    * @brief Writes out a Silo plot file at the end of the simulation.
-   * @copydoc ExecutableGroup::Cleanup()
+   * @copydoc ExecutableGroup::cleanup()
    */
   virtual void cleanup( real64 const time_n,
                         integer const cycleNumber,

--- a/src/coreComponents/managers/Outputs/TimeHistoryOutput.hpp
+++ b/src/coreComponents/managers/Outputs/TimeHistoryOutput.hpp
@@ -73,7 +73,7 @@ public:
                         dataRepository::Group * domain ) override;
   /**
    * @brief Writes out a time history file at the end of the simulation.
-   * @copydoc ExecutableGroup::Cleanup()
+   * @copydoc ExecutableGroup::cleanup()
    */
   virtual void cleanup( real64 const time_n,
                         integer const cycleNumber,

--- a/src/coreComponents/managers/Outputs/VTKOutput.hpp
+++ b/src/coreComponents/managers/Outputs/VTKOutput.hpp
@@ -60,7 +60,7 @@ public:
 
   /**
    * @brief Write one final set of vtk files as the code exits
-   * @copydoc ExecutableGroup::Cleanup()
+   * @copydoc ExecutableGroup::cleanup()
    */
   virtual void cleanup( real64 const time_n,
                         integer const cycleNumber,

--- a/src/coreComponents/managers/Tasks/TasksManager.hpp
+++ b/src/coreComponents/managers/Tasks/TasksManager.hpp
@@ -37,7 +37,7 @@ public:
   /// Destructor
   virtual ~TasksManager() override;
 
-  /// @copydoc geosx::dataRepository::Group::CreateChild
+  /// @copydoc geosx::dataRepository::Group::createChild
   virtual Group * createChild( string const & childKey, string const & childName ) override;
 
   /// This function is used to expand any catalogs in the data structure

--- a/src/coreComponents/managers/TimeHistory/PackCollection.hpp
+++ b/src/coreComponents/managers/TimeHistory/PackCollection.hpp
@@ -43,7 +43,7 @@ public:
    */
   static string catalogName() { return "PackCollection"; }
 
-  /// @copydoc dataRepository::Group::InitializePostSubGroups
+  /// @copydoc dataRepository::Group::initializePostSubGroups
   void initializePostSubGroups( Group * const group ) override;
 
   /// @copydoc geosx::HistoryCollection::getMetadata

--- a/src/coreComponents/mesh/ElementRegionBase.hpp
+++ b/src/coreComponents/mesh/ElementRegionBase.hpp
@@ -93,84 +93,84 @@ public:
   ///@{
 
   /**
-   * @copydoc GetSubRegions() const
+   * @copydoc getSubRegions() const
    */
   subGroupMap & getSubRegions()
   {
     return getGroup( viewKeyStruct::elementSubRegions )->getSubGroups();
   }
 
-/**
- * @brief Get a collection of the subregions.
- * @return a collection of the subregions
- */
+  /**
+   * @brief Get a collection of the subregions.
+   * @return a collection of the subregions
+   */
   subGroupMap const & getSubRegions() const
   {
     return getGroup( viewKeyStruct::elementSubRegions )->getSubGroups();
   }
 
 
-/**
- * @brief Get a pointer to a subregion by specifying its name.
- * @tparam SUBREGIONTYPE the type that will be used to attempt casting the subregion
- * @param regionName the name of the subregion
- * @return a pointer to the subregion
- * @note
- */
+  /**
+   * @brief Get a pointer to a subregion by specifying its name.
+   * @tparam SUBREGIONTYPE the type that will be used to attempt casting the subregion
+   * @param regionName the name of the subregion
+   * @return a pointer to the subregion
+   * @note
+   */
   template< typename SUBREGIONTYPE=ElementSubRegionBase >
   SUBREGIONTYPE const * getSubRegion( string const & regionName ) const
   {
     return this->getGroup( viewKeyStruct::elementSubRegions )->getGroup< SUBREGIONTYPE >( regionName );
   }
 
-/**
- * @copydoc GetSubRegion( string const & regionName ) const
- */
+  /**
+   * @copydoc getSubRegion( string const & regionName ) const
+   */
   template< typename SUBREGIONTYPE=ElementSubRegionBase >
   SUBREGIONTYPE * getSubRegion( string const & regionName )
   {
     return this->getGroup( viewKeyStruct::elementSubRegions )->getGroup< SUBREGIONTYPE >( regionName );
   }
 
-/**
- * @brief Get a pointer to a subregion by specifying its index.
- * @tparam SUBREGIONTYPE the type that will be used to attempt casting the subregion
- * @param index the index of the subregion
- * @return a pointer to the subregion
- */
+  /**
+   * @brief Get a pointer to a subregion by specifying its index.
+   * @tparam SUBREGIONTYPE the type that will be used to attempt casting the subregion
+   * @param index the index of the subregion
+   * @return a pointer to the subregion
+   */
   template< typename SUBREGIONTYPE=ElementSubRegionBase >
   SUBREGIONTYPE const * getSubRegion( localIndex const & index ) const
   {
     return this->getGroup( viewKeyStruct::elementSubRegions )->getGroup< SUBREGIONTYPE >( index );
   }
 
-/**
- * @copydoc GetSubRegion( localIndex const & index ) const
- */
+  /**
+   * @copydoc getSubRegion( localIndex const & index ) const
+   */
   template< typename SUBREGIONTYPE=ElementSubRegionBase >
   SUBREGIONTYPE * getSubRegion( localIndex const & index )
   {
     return this->getGroup( viewKeyStruct::elementSubRegions )->getGroup< SUBREGIONTYPE >( index );
   }
 
-/**
- * @brief Get the number of subregions in the region.
- * @return the number of subregions  in the region
- */
+  /**
+   * @brief Get the number of subregions in the region.
+   * @return the number of subregions  in the region
+   */
   localIndex numSubRegions() const
   {
     return this->getGroup( viewKeyStruct::elementSubRegions )->getSubGroups().size();
   }
 
-/**
- * @brief Get the number of elements  in the region
- *        for specific subregion types provided as template arguments.
- * @tparam SUBREGIONTYPE  the first type that will be used in the attempted casting of the subregion
- * @tparam SUBREGIONTYPES a variadic list of types that will be used in the attempted casting of the subregion
- * @return the number of elements contained in the element region
- * @note This function requires that the subRegion types specified
- *       in the variadic template argument can be casted to ElementSubRegionBase
- */
+  /**
+   * @brief Get the number of elements  in the region
+   *        for specific subregion types provided as template arguments.
+   * @tparam SUBREGIONTYPE  the first type that will be used in the attempted casting of the subregion
+   * @tparam SUBREGIONTYPES a variadic list of types that will be used in the attempted casting of the subregion
+   * @return the number of elements contained in the element region
+   * @note This function requires that the subRegion types specified
+   *       in the variadic template argument can be casted to ElementSubRegionBase
+   */
   template< typename SUBREGIONTYPE = ElementSubRegionBase, typename ... SUBREGIONTYPES >
   localIndex getNumberOfElements() const
   {

--- a/src/coreComponents/mesh/ElementRegionManager.hpp
+++ b/src/coreComponents/mesh/ElementRegionManager.hpp
@@ -939,7 +939,7 @@ public:
             string_array const & wrapperNames,
             ElementViewAccessor< arrayView1d< localIndex > > const & packList ) const;
 
-  /// @copydoc dataRepository::Group::Unpack
+  /// @copydoc dataRepository::Group::unpack
   using ObjectManagerBase::unpack;
 
   /**

--- a/src/coreComponents/mesh/WellElementSubRegion.hpp
+++ b/src/coreComponents/mesh/WellElementSubRegion.hpp
@@ -192,7 +192,7 @@ public:
   }
 
   /**
-   * @copydoc GetPerforationData()
+   * @copydoc getPerforationData()
    */
   PerforationData const * getPerforationData() const
   {

--- a/src/coreComponents/mesh/deprecated/FaceElementRegion.hpp
+++ b/src/coreComponents/mesh/deprecated/FaceElementRegion.hpp
@@ -85,7 +85,9 @@ public:
    */
   ///@{
 
+  /// @cond DO_NOT_DOCUMENT
   virtual void GenerateMesh( Group * ) override {}
+  /// @endcond
 
   /**
    * @brief This function generates and adds entries to the face/fracture mesh.


### PR DESCRIPTION
This PR removes the `copydoc` Doxygen warnings on Quartz. It only contains modifications to the Doxygen comments, not actual code changes.

Fixes #1292 