### PR TITLE
Minor cameBack correction

### DIFF
--- a/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
@@ -633,9 +633,9 @@ int SurfaceGenerator::separationDriver( DomainPartition & domain,
 #else
 
     GEOSX_UNUSED_VAR( neighbors );
-    AssignNewGlobalIndicesSerial( nodeManager, modifiedObjects.newNodes );
-    AssignNewGlobalIndicesSerial( edgeManager, modifiedObjects.newEdges );
-    AssignNewGlobalIndicesSerial( faceManager, modifiedObjects.newFaces );
+    assignNewGlobalIndicesSerial( nodeManager, modifiedObjects.newNodes );
+    assignNewGlobalIndicesSerial( edgeManager, modifiedObjects.newEdges );
+    assignNewGlobalIndicesSerial( faceManager, modifiedObjects.newFaces );
 
 #endif
 


### PR DESCRIPTION
The build was fail if GEOSX_PTP is set to OFF. `clang-tidy` did not travel though this defines.

Replaces https://github.com/GEOSX/GEOSX/pull/1291 from @sytuannguyen so we are done fast.