### PR TITLE
Replace std::string with string

### DIFF
--- a/examples/ObjectCatalog/main.cpp
+++ b/examples/ObjectCatalog/main.cpp
@@ -13,7 +13,7 @@
  */
 
 
-#include <string>
+
 #include <iostream>
 
 #include "common/Logger.hpp"

--- a/src/coreComponents/codingUtilities/StringUtilities.cpp
+++ b/src/coreComponents/codingUtilities/StringUtilities.cpp
@@ -29,7 +29,7 @@ namespace stringutilities
 /**
  * String tokenizing function
  **/
-string_array Tokenize( const std::string & str, const std::string & delimiters )
+string_array Tokenize( const string & str, const string & delimiters )
 {
   string_array tokens;
 
@@ -41,7 +41,7 @@ string_array Tokenize( const std::string & str, const std::string & delimiters )
   {
 
     bool usesNonWhitespaceDelimiters = false;
-    std::string::size_type i =0;
+    string::size_type i =0;
     while( delimiters[i] && !usesNonWhitespaceDelimiters )
     {
       usesNonWhitespaceDelimiters |= !isspace( int(delimiters[i]) );
@@ -54,7 +54,7 @@ string_array Tokenize( const std::string & str, const std::string & delimiters )
       size_t lastPos = 0;
 
       size_t newPos = lastPos;
-      while( (newPos=str.find_first_of( delimiters, lastPos )) != std::string::npos )
+      while( (newPos=str.find_first_of( delimiters, lastPos )) != string::npos )
       {
         tokens.emplace_back( str.substr( lastPos, newPos-lastPos ));
         lastPos = newPos + 1;
@@ -66,15 +66,15 @@ string_array Tokenize( const std::string & str, const std::string & delimiters )
       // whitespace delimiters
       // skip multiple adjacent delimiters
       size_t lastPos = str.find_first_not_of( delimiters, 0 );
-      lastPos = (lastPos == std::string::npos) ? 0 : lastPos;
+      lastPos = (lastPos == string::npos) ? 0 : lastPos;
 
       size_t newPos = lastPos;
-      while( (newPos=str.find_first_of( delimiters, lastPos )) != std::string::npos )
+      while( (newPos=str.find_first_of( delimiters, lastPos )) != string::npos )
       {
         tokens.emplace_back( str.substr( lastPos, newPos-lastPos ));
         lastPos = str.find_first_not_of( delimiters, newPos );
       }
-      if( lastPos!= std::string::npos )
+      if( lastPos!= string::npos )
         tokens.emplace_back( str.substr( lastPos, str.length()-lastPos ));
 
     }

--- a/src/coreComponents/codingUtilities/StringUtilities.hpp
+++ b/src/coreComponents/codingUtilities/StringUtilities.hpp
@@ -38,13 +38,13 @@ namespace stringutilities
 
 /// Overloaded function to check equality between strings and char arrays
 /// Mainly used to avoid char*==char* mistakes
-inline bool streq( std::string const & strA, std::string const & strB )
+inline bool streq( string const & strA, string const & strB )
 { return strA == strB; }
 
-inline bool streq( std::string const & strA, char const * const strB )
+inline bool streq( string const & strA, char const * const strB )
 { return strA == strB; }
 
-inline bool streq( char const * const strA, std::string const & strB )
+inline bool streq( char const * const strA, string const & strB )
 { return strA == strB; }
 
 inline bool streq( char const * const strA, char const * const strB )
@@ -52,7 +52,7 @@ inline bool streq( char const * const strA, char const * const strB )
 
 /**
  * @brief Join strings or other printable objects with a delimiter.
- * @tparam S    type of delimiter, usually char, char const * or std::string
+ * @tparam S    type of delimiter, usually char, char const * or string
  * @tparam IT   type of iterator into the range of objects to join
  * @param delim delimiter used to glue together strings
  * @param first iterator to start of the range
@@ -60,7 +60,7 @@ inline bool streq( char const * const strA, char const * const strB )
  * @return a new string containing input strings concatenated with a delimiter
  */
 template< typename IT, typename S = char >
-std::string strjoin( IT first, IT last, S const & delim = S() )
+string strjoin( IT first, IT last, S const & delim = S() )
 {
   std::ostringstream oss;
   if( first != last )
@@ -75,7 +75,7 @@ std::string strjoin( IT first, IT last, S const & delim = S() )
 }
 
 /// Subdivide string by delimiters
-string_array Tokenize( std::string const & str, std::string const & delimiters );
+string_array Tokenize( string const & str, string const & delimiters );
 
 /**
  * @brief Retuns a string containing a padded value

--- a/src/coreComponents/codingUtilities/tests/testGeosxTraits.cpp
+++ b/src/coreComponents/codingUtilities/tests/testGeosxTraits.cpp
@@ -27,7 +27,7 @@ IS_VALID_EXPRESSION( HasOperatorPlusEquals, T, std::declval< T & >() += T() );
 TEST( testGeosxTraits, HasOperatorPlusEquals )
 {
   static_assert( HasOperatorPlusEquals< int >, "Should be true." );
-  static_assert( HasOperatorPlusEquals< std::string >, "Should be true." );
+  static_assert( HasOperatorPlusEquals< string >, "Should be true." );
 
   static_assert( !HasOperatorPlusEquals< int const >, "Should be false." );
   static_assert( !HasOperatorPlusEquals< std::vector< int > >, "Should be false." );
@@ -38,24 +38,24 @@ TEST( testGeosxTraits, HasOperatorPlusEquals2 )
 {
   static_assert( HasOperatorPlusEquals2< double, int >, "Should be true." );
   static_assert( HasOperatorPlusEquals2< double, int const >, "Should be true." );
-  static_assert( HasOperatorPlusEquals2< std::string, std::string >, "Should be true." );
+  static_assert( HasOperatorPlusEquals2< string, string >, "Should be true." );
 
   static_assert( !HasOperatorPlusEquals2< double const, int >, "Should be false." );
-  static_assert( !HasOperatorPlusEquals2< R1Tensor, std::string >, "Should be false." );
+  static_assert( !HasOperatorPlusEquals2< R1Tensor, string >, "Should be false." );
   static_assert( !HasOperatorPlusEquals2< std::vector< int >, int >, "Should be false." );
 }
 
 HAS_MEMBER_FUNCTION_NO_RTYPE( at, 55 );
 TEST( testGeosxTraits, HasMemberFunction_at )
 {
-  static_assert( HasMemberFunction_at< std::string >, "Should be true." );
+  static_assert( HasMemberFunction_at< string >, "Should be true." );
   static_assert( HasMemberFunction_at< std::vector< int > >, "Should be true." );
   static_assert( HasMemberFunction_at< std::vector< double > >, "Should be true." );
-  static_assert( HasMemberFunction_at< std::map< int, std::string > >, "Should be true." );
-  static_assert( HasMemberFunction_at< std::unordered_map< int, std::string > >, "Should be true." );
+  static_assert( HasMemberFunction_at< std::map< int, string > >, "Should be true." );
+  static_assert( HasMemberFunction_at< std::unordered_map< int, string > >, "Should be true." );
 
   static_assert( !HasMemberFunction_at< int >, "Should be false." );
-  static_assert( !HasMemberFunction_at< std::map< std::string, std::string > >, "Should be false." );
+  static_assert( !HasMemberFunction_at< std::map< string, string > >, "Should be false." );
   static_assert( !HasMemberFunction_at< array1d< localIndex > >, "Should be false." );
 }
 
@@ -65,7 +65,7 @@ HAS_MEMBER_FUNCTION_NO_RTYPE( insert,
 TEST( testGeosxTraits, HasMemberFunction_insert )
 {
   static_assert( HasMemberFunction_insert< std::vector< int > >, "Should be true." );
-  static_assert( HasMemberFunction_insert< std::map< std::string, int > >, "Should be true." );
+  static_assert( HasMemberFunction_insert< std::map< string, int > >, "Should be true." );
   static_assert( HasMemberFunction_insert< std::list< std::vector< int > > >, "Should be true." );
 
   static_assert( !HasMemberFunction_insert< int >, "Should be false." );
@@ -90,15 +90,15 @@ TEST( testGeosxTraits, Pointer )
   static_assert( std::is_same< Pointer< int >, int * >::value, "Should be true." );
   static_assert( std::is_same< Pointer< R1Tensor >, R1Tensor * >::value, "Should be true." );
   static_assert( std::is_same< Pointer< std::vector< double > >, double * >::value, "Should be true." );
-  static_assert( std::is_same< Pointer< std::string >, char const * >::value, "Should be true." );
-  static_assert( std::is_same< Pointer< array3d< std::string > >, std::string * >::value, "Should be true." );
+  static_assert( std::is_same< Pointer< string >, char const * >::value, "Should be true." );
+  static_assert( std::is_same< Pointer< array3d< string > >, string * >::value, "Should be true." );
   static_assert( std::is_same< Pointer< SortedArray< float > >, float const * >::value, "Should be true." );
 
   static_assert( std::is_same< ConstPointer< int >, int const * >::value, "Should be true." );
   static_assert( std::is_same< ConstPointer< R1Tensor >, R1Tensor const * >::value, "Should be true." );
   static_assert( std::is_same< ConstPointer< std::vector< double > >, double const * >::value, "Should be true." );
-  static_assert( std::is_same< ConstPointer< std::string >, char const * >::value, "Should be true." );
-  static_assert( std::is_same< ConstPointer< array3d< std::string > >, std::string const * >::value, "Should be true." );
+  static_assert( std::is_same< ConstPointer< string >, char const * >::value, "Should be true." );
+  static_assert( std::is_same< ConstPointer< array3d< string > >, string const * >::value, "Should be true." );
   static_assert( std::is_same< ConstPointer< SortedArray< float > >, float const * >::value, "Should be true." );
 }
 
@@ -145,7 +145,7 @@ TEST( testGeosxTraits, CanStreamInto )
 {
   static_assert( CanStreamInto< std::istringstream, int >, "Should be true." );
   static_assert( CanStreamInto< std::istringstream, double >, "Should be true." );
-  static_assert( CanStreamInto< std::istringstream, std::string >, "Should be true." );
+  static_assert( CanStreamInto< std::istringstream, string >, "Should be true." );
 
   static_assert( !CanStreamInto< std::istringstream, array1d< double > >, "Should be false." );
   static_assert( !CanStreamInto< std::istringstream, std::vector< int > >, "Should be false." );

--- a/src/coreComponents/codingUtilities/traits.hpp
+++ b/src/coreComponents/codingUtilities/traits.hpp
@@ -51,10 +51,10 @@ static constexpr bool HasMemberFunction_move = LvArray::bufferManipulation::HasM
 
 /**
  * @brief Defines a static constexpr bool HasMemberFunction_setName< @p CLASS >
- *        that is true iff the method @p CLASS ::setName( std::string ) exists.
+ *        that is true iff the method @p CLASS ::setName( string ) exists.
  * @tparam CLASS The type to test.
  */
-HAS_MEMBER_FUNCTION_NO_RTYPE( setName, std::string() );
+HAS_MEMBER_FUNCTION_NO_RTYPE( setName, string() );
 
 /**
  * @brief Defines a static constexpr bool HasMemberFunction_size< @p CLASS >
@@ -142,9 +142,9 @@ using ViewType = LvArray::typeManipulation::ViewType< T >;
 template< typename T >
 using ViewTypeConst = LvArray::typeManipulation::ViewTypeConst< T >;
 
-/// True if T is or inherits from std::string.
+/// True if T is or inherits from string.
 template< typename T >
-constexpr bool is_string = std::is_base_of< std::string, T >::value;
+constexpr bool is_string = std::is_base_of< string, T >::value;
 
 /// True if T is an instantiation of LvArray::Array.
 template< typename T >

--- a/src/coreComponents/common/DataTypes.hpp
+++ b/src/coreComponents/common/DataTypes.hpp
@@ -498,9 +498,9 @@ public:
    * @param key the std::type_index of the type
    * @return a hard coded string that is related to the std::type_index
    */
-  static std::string typeNames( std::type_index const key )
+  static string typeNames( std::type_index const key )
   {
-    const std::unordered_map< std::type_index, std::string > type_names =
+    const std::unordered_map< std::type_index, string > type_names =
     {
       {std::type_index( typeid(integer)), "integer"},
       {std::type_index( typeid(real32)), "real32"},
@@ -650,7 +650,7 @@ public:
 public:
 
     /// The type of map used to store the map of type parsing regular expressions
-    using regexMapType = std::map< std::string, std::string >;
+    using regexMapType = std::map< string, string >;
 
     /**
      * @brief Get an iterator to the beginning of regex map.
@@ -689,14 +689,14 @@ private:
      *       axes are given as a comma-separated list enclosed in a curly brace.
      *       For example, a 2D string array would look like: {{"a", "b"}, {"c", "d"}}
      */
-    std::string constructArrayRegex( std::string subPattern, integer dimension )
+    string constructArrayRegex( string subPattern, integer dimension )
     {
       if( dimension > 1 )
       {
         subPattern = constructArrayRegex( subPattern, dimension-1 );
       }
 
-      std::string arrayPattern;
+      string arrayPattern;
       if( dimension == 1 )
       {
         // Allow the bottom-level to be empty
@@ -712,10 +712,10 @@ private:
 
     // Define the component regexes:
     // Regex to match an unsigned int (123, etc.)
-    std::string ru = "[\\d]+";
+    string ru = "[\\d]+";
 
     // Regex to match an signed int (-123, 455, +789, etc.)
-    std::string ri = "[+-]?[\\d]+";
+    string ri = "[+-]?[\\d]+";
 
     // Regex to match a float (1, +2.3, -.4, 5.6e7, 8E-9, etc.)
     // Explanation of parts:
@@ -724,13 +724,13 @@ private:
     // [\\d]*  matches any number of numbers following the decimal
     // ([eE][-+]?[\\d]+|\\s*)  matches an optional scientific notation number
     // Note: the xsd regex implementation does not allow an empty branch, so use allow whitespace at the end
-    std::string rr = "[+-]?[\\d]*([\\d]\\.?|\\.[\\d])[\\d]*([eE][-+]?[\\d]+|\\s*)";
+    string rr = "[+-]?[\\d]*([\\d]\\.?|\\.[\\d])[\\d]*([eE][-+]?[\\d]+|\\s*)";
 
     // Regex to match a string that does not contain the characters  ,{}
-    std::string rs = "[^,\\{\\}]*";
+    string rs = "[^,\\{\\}]*";
 
     // Regex to match a R1Tensor
-    std::string r1 = "\\s*(" + rr + ",\\s*){2}" + rr;
+    string r1 = "\\s*(" + rr + ",\\s*){2}" + rr;
 
     // Build master list of regexes
     regexMapType regexMap =

--- a/src/coreComponents/common/EnumStrings.hpp
+++ b/src/coreComponents/common/EnumStrings.hpp
@@ -170,7 +170,7 @@ struct TypeRegex< ENUM, std::enable_if_t< internal::HasEnumStrings< ENUM > > >
   /**
    * @brief @return Regex for validating enumeration inputs for @p ENUM type.
    */
-  static std::string get()
+  static string get()
   {
     return EnumStrings< ENUM >::concat( "|" );
   }

--- a/src/coreComponents/common/unitTests/testDataTypes.cpp
+++ b/src/coreComponents/common/unitTests/testDataTypes.cpp
@@ -15,7 +15,7 @@
 #include <gtest/gtest.h>
 
 #include "common/DataTypes.hpp"
-#include <string>
+
 #include <typeindex>
 
 using namespace geosx;

--- a/src/coreComponents/constitutive/ConstitutiveBase.cpp
+++ b/src/coreComponents/constitutive/ConstitutiveBase.cpp
@@ -43,7 +43,7 @@ using namespace dataRepository;
 namespace constitutive
 {
 
-ConstitutiveBase::ConstitutiveBase( std::string const & name,
+ConstitutiveBase::ConstitutiveBase( string const & name,
                                     Group * const parent ):
   Group( name, parent ),
   m_numQuadraturePoints( 1 ),

--- a/src/coreComponents/constitutive/ConstitutiveBase.hpp
+++ b/src/coreComponents/constitutive/ConstitutiveBase.hpp
@@ -76,7 +76,7 @@ public:
   ///@{
 
   /// @typedef An alias for the ConstitutiveBase catalog
-  using CatalogInterface = dataRepository::CatalogInterface< ConstitutiveBase, std::string const &, Group * const >;
+  using CatalogInterface = dataRepository::CatalogInterface< ConstitutiveBase, string const &, Group * const >;
 
   /**
    * @brief Singleton accessor for catalog

--- a/src/coreComponents/constitutive/NullModel.cpp
+++ b/src/coreComponents/constitutive/NullModel.cpp
@@ -27,7 +27,7 @@ NullModel::NullModel( string const & name,
 NullModel::~NullModel()
 {}
 
-REGISTER_CATALOG_ENTRY( ConstitutiveBase, NullModel, std::string const &, dataRepository::Group * const )
+REGISTER_CATALOG_ENTRY( ConstitutiveBase, NullModel, string const &, dataRepository::Group * const )
 
 } // constitutive
 } /* namespace geosx */

--- a/src/coreComponents/constitutive/NullModel.hpp
+++ b/src/coreComponents/constitutive/NullModel.hpp
@@ -42,7 +42,7 @@ public:
   /**
    * @return A string that is used to register/lookup this class in the registry
    */
-  static std::string catalogName() { return m_catalogNameString; }
+  static string catalogName() { return m_catalogNameString; }
 
   virtual string getCatalogName() const override { return catalogName(); }
 

--- a/src/coreComponents/constitutive/capillaryPressure/BrooksCoreyCapillaryPressure.cpp
+++ b/src/coreComponents/constitutive/capillaryPressure/BrooksCoreyCapillaryPressure.cpp
@@ -29,7 +29,7 @@ namespace constitutive
 {
 
 
-BrooksCoreyCapillaryPressure::BrooksCoreyCapillaryPressure( std::string const & name,
+BrooksCoreyCapillaryPressure::BrooksCoreyCapillaryPressure( string const & name,
                                                             Group * const parent )
   : CapillaryPressureBase( name, parent )
 {
@@ -121,7 +121,7 @@ BrooksCoreyCapillaryPressure::KernelWrapper BrooksCoreyCapillaryPressure::create
                         m_dPhaseCapPressure_dPhaseVolFrac );
 }
 
-REGISTER_CATALOG_ENTRY( ConstitutiveBase, BrooksCoreyCapillaryPressure, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ConstitutiveBase, BrooksCoreyCapillaryPressure, string const &, Group * const )
 } // namespace constitutive
 
 } // namespace geosx

--- a/src/coreComponents/constitutive/capillaryPressure/BrooksCoreyCapillaryPressure.hpp
+++ b/src/coreComponents/constitutive/capillaryPressure/BrooksCoreyCapillaryPressure.hpp
@@ -105,12 +105,12 @@ class BrooksCoreyCapillaryPressure : public CapillaryPressureBase
 {
 public:
 
-  BrooksCoreyCapillaryPressure( std::string const & name,
+  BrooksCoreyCapillaryPressure( string const & name,
                                 dataRepository::Group * const parent );
 
   virtual ~BrooksCoreyCapillaryPressure() override;
 
-  static std::string catalogName() { return "BrooksCoreyCapillaryPressure"; }
+  static string catalogName() { return "BrooksCoreyCapillaryPressure"; }
 
   virtual string getCatalogName() const override { return catalogName(); }
 

--- a/src/coreComponents/constitutive/capillaryPressure/CapillaryPressureBase.cpp
+++ b/src/coreComponents/constitutive/capillaryPressure/CapillaryPressureBase.cpp
@@ -42,7 +42,7 @@ std::unordered_map< string, integer > const phaseDict =
 
 }
 
-CapillaryPressureBase::CapillaryPressureBase( std::string const & name,
+CapillaryPressureBase::CapillaryPressureBase( string const & name,
                                               Group * const parent )
   : ConstitutiveBase( name, parent )
 {

--- a/src/coreComponents/constitutive/capillaryPressure/CapillaryPressureBase.hpp
+++ b/src/coreComponents/constitutive/capillaryPressure/CapillaryPressureBase.hpp
@@ -111,7 +111,7 @@ public:
   // choose the reference pressure to be the oil pressure for all models
   static constexpr integer REFERENCE_PHASE = PhaseType::OIL;
 
-  CapillaryPressureBase( std::string const & name,
+  CapillaryPressureBase( string const & name,
                          dataRepository::Group * const parent );
 
   virtual ~CapillaryPressureBase() override;

--- a/src/coreComponents/constitutive/capillaryPressure/VanGenuchtenCapillaryPressure.cpp
+++ b/src/coreComponents/constitutive/capillaryPressure/VanGenuchtenCapillaryPressure.cpp
@@ -28,7 +28,7 @@ using namespace dataRepository;
 namespace constitutive
 {
 
-VanGenuchtenCapillaryPressure::VanGenuchtenCapillaryPressure( std::string const & name,
+VanGenuchtenCapillaryPressure::VanGenuchtenCapillaryPressure( string const & name,
                                                               Group * const parent )
   : CapillaryPressureBase( name, parent )
 {
@@ -120,7 +120,7 @@ VanGenuchtenCapillaryPressure::KernelWrapper VanGenuchtenCapillaryPressure::crea
                         m_dPhaseCapPressure_dPhaseVolFrac );
 }
 
-REGISTER_CATALOG_ENTRY( ConstitutiveBase, VanGenuchtenCapillaryPressure, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ConstitutiveBase, VanGenuchtenCapillaryPressure, string const &, Group * const )
 } // namespace constitutive
 
 } // namespace geosx

--- a/src/coreComponents/constitutive/capillaryPressure/VanGenuchtenCapillaryPressure.hpp
+++ b/src/coreComponents/constitutive/capillaryPressure/VanGenuchtenCapillaryPressure.hpp
@@ -105,12 +105,12 @@ class VanGenuchtenCapillaryPressure : public CapillaryPressureBase
 {
 public:
 
-  VanGenuchtenCapillaryPressure( std::string const & name,
+  VanGenuchtenCapillaryPressure( string const & name,
                                  dataRepository::Group * const parent );
 
   virtual ~VanGenuchtenCapillaryPressure() override;
 
-  static std::string catalogName() { return "VanGenuchtenCapillaryPressure"; }
+  static string catalogName() { return "VanGenuchtenCapillaryPressure"; }
 
   virtual string getCatalogName() const override { return catalogName(); }
 

--- a/src/coreComponents/constitutive/contact/Coulomb.cpp
+++ b/src/coreComponents/constitutive/contact/Coulomb.cpp
@@ -24,7 +24,7 @@ using namespace dataRepository;
 namespace constitutive
 {
 
-Coulomb::Coulomb( std::string const & name, Group * const parent ):
+Coulomb::Coulomb( string const & name, Group * const parent ):
   ContactRelationBase( name, parent ),
   m_postProcessed( false ),
   m_cohesion(),
@@ -105,6 +105,6 @@ void Coulomb::postProcessInput()
   m_postProcessed = true;
 }
 
-REGISTER_CATALOG_ENTRY( ConstitutiveBase, Coulomb, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ConstitutiveBase, Coulomb, string const &, Group * const )
 }
 } /* namespace geosx */

--- a/src/coreComponents/constitutive/contact/Coulomb.hpp
+++ b/src/coreComponents/constitutive/contact/Coulomb.hpp
@@ -62,7 +62,7 @@ public:
   /**
    * @return A string that is used to register/lookup this class in the registry
    */
-  static std::string catalogName() { return m_catalogNameString; }
+  static string catalogName() { return m_catalogNameString; }
 
   virtual string getCatalogName() const override { return catalogName(); }
 

--- a/src/coreComponents/constitutive/fluid/BlackOilFluid.cpp
+++ b/src/coreComponents/constitutive/fluid/BlackOilFluid.cpp
@@ -31,7 +31,7 @@ using namespace dataRepository;
 namespace constitutive
 {
 
-BlackOilFluid::BlackOilFluid( std::string const & name, Group * const parent )
+BlackOilFluid::BlackOilFluid( string const & name, Group * const parent )
   : MultiFluidPVTPackageWrapper( name, parent )
 {
   getWrapperBase( viewKeyStruct::componentMolarWeightString )->setInputFlag( InputFlags::REQUIRED );
@@ -93,7 +93,7 @@ void BlackOilFluid::postProcessInput()
 void BlackOilFluid::createFluid()
 {
   std::vector< pvt::PHASE_TYPE > phases( m_phaseTypes.begin(), m_phaseTypes.end() );
-  std::vector< std::string > tableFiles( m_tableFiles.begin(), m_tableFiles.end() );
+  std::vector< string > tableFiles( m_tableFiles.begin(), m_tableFiles.end() );
   std::vector< double > densities( m_surfaceDensities.begin(), m_surfaceDensities.end() );
   std::vector< double > molarWeights( m_componentMolarWeight.begin(), m_componentMolarWeight.end() );
 
@@ -116,7 +116,7 @@ void BlackOilFluid::createFluid()
   }
 }
 
-REGISTER_CATALOG_ENTRY( ConstitutiveBase, BlackOilFluid, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ConstitutiveBase, BlackOilFluid, string const &, Group * const )
 } // namespace constitutive
 
 } // namespace geosx

--- a/src/coreComponents/constitutive/fluid/BlackOilFluid.hpp
+++ b/src/coreComponents/constitutive/fluid/BlackOilFluid.hpp
@@ -38,7 +38,7 @@ public:
     LiveOil
   };
 
-  BlackOilFluid( std::string const & name, Group * const parent );
+  BlackOilFluid( string const & name, Group * const parent );
 
   virtual ~BlackOilFluid() override;
 
@@ -46,7 +46,7 @@ public:
   deliverClone( string const & name,
                 Group * const parent ) const override;
 
-  static std::string catalogName() { return "BlackOilFluid"; }
+  static string catalogName() { return "BlackOilFluid"; }
 
   virtual string getCatalogName() const override { return catalogName(); }
 

--- a/src/coreComponents/constitutive/fluid/CompositionalMultiphaseFluid.cpp
+++ b/src/coreComponents/constitutive/fluid/CompositionalMultiphaseFluid.cpp
@@ -49,7 +49,7 @@ pvt::EOS_TYPE getCompositionalEosType( string const & name )
 
 } // namespace
 
-CompositionalMultiphaseFluid::CompositionalMultiphaseFluid( std::string const & name, Group * const parent )
+CompositionalMultiphaseFluid::CompositionalMultiphaseFluid( string const & name, Group * const parent )
   : MultiFluidPVTPackageWrapper( name, parent )
 {
   getWrapperBase( viewKeyStruct::componentNamesString )->setInputFlag( InputFlags::REQUIRED );
@@ -140,7 +140,7 @@ void CompositionalMultiphaseFluid::createFluid()
   std::transform( m_equationsOfState.begin(), m_equationsOfState.end(), eos.begin(), getCompositionalEosType );
 
   std::vector< pvt::PHASE_TYPE > phases( m_phaseTypes.begin(), m_phaseTypes.end() );
-  std::vector< std::string > const components( m_componentNames.begin(), m_componentNames.end() );
+  std::vector< string > const components( m_componentNames.begin(), m_componentNames.end() );
   std::vector< double > const Mw( m_componentMolarWeight.begin(), m_componentMolarWeight.end() );
   std::vector< double > const Tc( m_componentCriticalTemperature.begin(), m_componentCriticalTemperature.end() );
   std::vector< double > const Pc( m_componentCriticalPressure.begin(), m_componentCriticalPressure.end() );
@@ -151,7 +151,7 @@ void CompositionalMultiphaseFluid::createFluid()
 
 }
 
-REGISTER_CATALOG_ENTRY( ConstitutiveBase, CompositionalMultiphaseFluid, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ConstitutiveBase, CompositionalMultiphaseFluid, string const &, Group * const )
 } // namespace constitutive
 
 } // namespace geosx

--- a/src/coreComponents/constitutive/fluid/CompositionalMultiphaseFluid.hpp
+++ b/src/coreComponents/constitutive/fluid/CompositionalMultiphaseFluid.hpp
@@ -30,7 +30,7 @@ class CompositionalMultiphaseFluid : public MultiFluidPVTPackageWrapper
 {
 public:
 
-  CompositionalMultiphaseFluid( std::string const & name, Group * const parent );
+  CompositionalMultiphaseFluid( string const & name, Group * const parent );
 
   virtual ~CompositionalMultiphaseFluid() override;
 
@@ -38,7 +38,7 @@ public:
   deliverClone( string const & name,
                 Group * const parent ) const override;
 
-  static std::string catalogName() { return "CompositionalMultiphaseFluid"; }
+  static string catalogName() { return "CompositionalMultiphaseFluid"; }
 
   virtual string getCatalogName() const override { return catalogName(); }
 

--- a/src/coreComponents/constitutive/fluid/CompressibleSinglePhaseFluid.cpp
+++ b/src/coreComponents/constitutive/fluid/CompressibleSinglePhaseFluid.cpp
@@ -26,7 +26,7 @@ using namespace dataRepository;
 namespace constitutive
 {
 
-CompressibleSinglePhaseFluid::CompressibleSinglePhaseFluid( std::string const & name, Group * const parent ):
+CompressibleSinglePhaseFluid::CompressibleSinglePhaseFluid( string const & name, Group * const parent ):
   SingleFluidBase( name, parent ),
   m_densityModelType( ExponentApproximationType::Linear ),
   m_viscosityModelType( ExponentApproximationType::Linear )
@@ -123,7 +123,7 @@ CompressibleSinglePhaseFluid::createKernelWrapper()
                         m_dViscosity_dPressure );
 }
 
-REGISTER_CATALOG_ENTRY( ConstitutiveBase, CompressibleSinglePhaseFluid, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ConstitutiveBase, CompressibleSinglePhaseFluid, string const &, Group * const )
 
 } /* namespace constitutive */
 

--- a/src/coreComponents/constitutive/fluid/CompressibleSinglePhaseFluid.hpp
+++ b/src/coreComponents/constitutive/fluid/CompressibleSinglePhaseFluid.hpp
@@ -113,11 +113,11 @@ class CompressibleSinglePhaseFluid : public SingleFluidBase
 {
 public:
 
-  CompressibleSinglePhaseFluid( std::string const & name, Group * const parent );
+  CompressibleSinglePhaseFluid( string const & name, Group * const parent );
 
   virtual ~CompressibleSinglePhaseFluid() override;
 
-  static std::string catalogName() { return "CompressibleSinglePhaseFluid"; }
+  static string catalogName() { return "CompressibleSinglePhaseFluid"; }
 
   virtual string getCatalogName() const override { return catalogName(); }
 

--- a/src/coreComponents/constitutive/fluid/MultiFluidBase.cpp
+++ b/src/coreComponents/constitutive/fluid/MultiFluidBase.cpp
@@ -26,7 +26,7 @@ using namespace dataRepository;
 namespace constitutive
 {
 
-MultiFluidBase::MultiFluidBase( std::string const & name, Group * const parent )
+MultiFluidBase::MultiFluidBase( string const & name, Group * const parent )
   : ConstitutiveBase( name, parent ),
   m_useMass( false )
 {

--- a/src/coreComponents/constitutive/fluid/MultiFluidBase.hpp
+++ b/src/coreComponents/constitutive/fluid/MultiFluidBase.hpp
@@ -213,7 +213,7 @@ class MultiFluidBase : public ConstitutiveBase
 {
 public:
 
-  MultiFluidBase( std::string const & name, Group * const parent );
+  MultiFluidBase( string const & name, Group * const parent );
 
   virtual ~MultiFluidBase() override;
 

--- a/src/coreComponents/constitutive/fluid/MultiFluidPVTPackageWrapper.cpp
+++ b/src/coreComponents/constitutive/fluid/MultiFluidPVTPackageWrapper.cpp
@@ -28,7 +28,7 @@ using namespace dataRepository;
 namespace constitutive
 {
 
-MultiFluidPVTPackageWrapper::MultiFluidPVTPackageWrapper( std::string const & name,
+MultiFluidPVTPackageWrapper::MultiFluidPVTPackageWrapper( string const & name,
                                                           Group * const parent )
   :
   MultiFluidBase( name, parent ),

--- a/src/coreComponents/constitutive/fluid/MultiFluidPVTPackageWrapper.hpp
+++ b/src/coreComponents/constitutive/fluid/MultiFluidPVTPackageWrapper.hpp
@@ -203,7 +203,7 @@ class MultiFluidPVTPackageWrapper : public MultiFluidBase
 {
 public:
 
-  MultiFluidPVTPackageWrapper( std::string const & name, Group * const parent );
+  MultiFluidPVTPackageWrapper( string const & name, Group * const parent );
 
   virtual ~MultiFluidPVTPackageWrapper() override;
 

--- a/src/coreComponents/constitutive/fluid/MultiPhaseMultiComponentFluid.cpp
+++ b/src/coreComponents/constitutive/fluid/MultiPhaseMultiComponentFluid.cpp
@@ -34,7 +34,7 @@ using namespace stringutilities;
 namespace constitutive
 {
 
-MultiPhaseMultiComponentFluid::MultiPhaseMultiComponentFluid( std::string const & name, Group * const parent ):
+MultiPhaseMultiComponentFluid::MultiPhaseMultiComponentFluid( string const & name, Group * const parent ):
   MultiFluidBase( name, parent )
 {
 
@@ -107,7 +107,7 @@ void MultiPhaseMultiComponentFluid::initializePostSubGroups( Group * const group
 
 void MultiPhaseMultiComponentFluid::createPVTModels()
 {
-  for( std::string & filename : m_phasePVTParaFiles )
+  for( string & filename : m_phasePVTParaFiles )
   {
     std::ifstream is( filename );
 
@@ -116,7 +116,7 @@ void MultiPhaseMultiComponentFluid::createPVTModels()
 
     while( is.getline( buf, buf_size ))
     {
-      std::string const str( buf );
+      string const str( buf );
       string_array const strs = Tokenize( str, " " );
 
       if( strs[0] == "DensityFun" )
@@ -150,7 +150,7 @@ void MultiPhaseMultiComponentFluid::createPVTModels()
 
     while( is.getline( buf, buf_size ))
     {
-      std::string const str( buf );
+      string const str( buf );
       string_array const strs = Tokenize( str, " " );
 
       if( strs[0] == "FlashModel" )
@@ -171,7 +171,7 @@ void MultiPhaseMultiComponentFluid::createPVTModels()
   }
 }
 
-REGISTER_CATALOG_ENTRY( ConstitutiveBase, MultiPhaseMultiComponentFluid, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ConstitutiveBase, MultiPhaseMultiComponentFluid, string const &, Group * const )
 
 void MultiPhaseMultiComponentFluidUpdate::compute( real64 pressure,
                                                    real64 temperature,

--- a/src/coreComponents/constitutive/fluid/MultiPhaseMultiComponentFluid.hpp
+++ b/src/coreComponents/constitutive/fluid/MultiPhaseMultiComponentFluid.hpp
@@ -210,7 +210,7 @@ class MultiPhaseMultiComponentFluid : public MultiFluidBase
 {
 public:
 
-  MultiPhaseMultiComponentFluid( std::string const & name, Group * const parent );
+  MultiPhaseMultiComponentFluid( string const & name, Group * const parent );
 
   virtual ~MultiPhaseMultiComponentFluid() override;
 
@@ -219,7 +219,7 @@ public:
                 Group * const parent ) const override;
 
 
-  static std::string catalogName() { return dataRepository::keys::multiPhaseMultiComponentFluid; }
+  static string catalogName() { return dataRepository::keys::multiPhaseMultiComponentFluid; }
 
   virtual string getCatalogName() const override { return catalogName(); }
 

--- a/src/coreComponents/constitutive/fluid/PVTFunctions/BrineCO2DensityFunction.cpp
+++ b/src/coreComponents/constitutive/fluid/PVTFunctions/BrineCO2DensityFunction.cpp
@@ -103,7 +103,7 @@ void BrineCO2DensityFunction::makeTable( string_array const & inputPara )
   catch( const std::invalid_argument & e )
   {
 
-    GEOSX_ERROR( "Invalid BrineCO2Density argument:" + std::string( e.what()));
+    GEOSX_ERROR( "Invalid BrineCO2Density argument:" + string( e.what()));
 
   }
 

--- a/src/coreComponents/constitutive/fluid/PVTFunctions/BrineViscosityFunction.cpp
+++ b/src/coreComponents/constitutive/fluid/PVTFunctions/BrineViscosityFunction.cpp
@@ -61,7 +61,7 @@ void BrineViscosityFunction::makeCoef( string_array const & inputPara )
   catch( const std::invalid_argument & e )
   {
 
-    GEOSX_ERROR( "Invalid BrineViscosity argument:" + std::string( e.what()));
+    GEOSX_ERROR( "Invalid BrineViscosity argument:" + string( e.what()));
 
   }
 

--- a/src/coreComponents/constitutive/fluid/PVTFunctions/CO2SolubilityFunction.cpp
+++ b/src/coreComponents/constitutive/fluid/PVTFunctions/CO2SolubilityFunction.cpp
@@ -280,7 +280,7 @@ void CO2SolubilityFunction::makeTable( string_array const & inputPara )
   catch( const std::invalid_argument & e )
   {
 
-    GEOSX_ERROR( "Invalid CO2Solubility argument:" + std::string( e.what()));
+    GEOSX_ERROR( "Invalid CO2Solubility argument:" + string( e.what()));
 
   }
 

--- a/src/coreComponents/constitutive/fluid/PVTFunctions/FenghourCO2ViscosityFunction.cpp
+++ b/src/coreComponents/constitutive/fluid/PVTFunctions/FenghourCO2ViscosityFunction.cpp
@@ -70,7 +70,7 @@ void FenghourCO2ViscosityFunction::makeTable( string_array const & inputPara )
   catch( const std::invalid_argument & e )
   {
 
-    GEOSX_ERROR( "Invalid FenghourCO2Viscosity argument:" + std::string( e.what()));
+    GEOSX_ERROR( "Invalid FenghourCO2Viscosity argument:" + string( e.what()));
 
   }
 

--- a/src/coreComponents/constitutive/fluid/PVTFunctions/SpanWagnerCO2DensityFunction.cpp
+++ b/src/coreComponents/constitutive/fluid/PVTFunctions/SpanWagnerCO2DensityFunction.cpp
@@ -183,7 +183,7 @@ void SpanWagnerCO2DensityFunction::makeTable( string_array const & inputPara )
   catch( const std::invalid_argument & e )
   {
 
-    GEOSX_ERROR( "Invalid SpanWagnerCO2Density argument:" + std::string( e.what()));
+    GEOSX_ERROR( "Invalid SpanWagnerCO2Density argument:" + string( e.what()));
 
   }
 

--- a/src/coreComponents/constitutive/fluid/PVTFunctions/UtilityFunctions.hpp
+++ b/src/coreComponents/constitutive/fluid/PVTFunctions/UtilityFunctions.hpp
@@ -437,7 +437,7 @@ class XYTable : public TableFunctionBase
 {
 public:
 
-  XYTable( std::string const & tableName, real64_array const & x, real64_array const & y, real64_array2d const & value ): m_tableName( tableName ), m_x( x ),
+  XYTable( string const & tableName, real64_array const & x, real64_array const & y, real64_array2d const & value ): m_tableName( tableName ), m_x( x ),
     m_y( y ), m_value( value ) {}
 
   ~XYTable(){}
@@ -481,7 +481,7 @@ public:
 
 private:
 
-  std::string m_tableName;
+  string m_tableName;
   real64_array m_x;
   real64_array m_y;
   real64_array2d m_value;

--- a/src/coreComponents/constitutive/fluid/ParticleFluid.cpp
+++ b/src/coreComponents/constitutive/fluid/ParticleFluid.cpp
@@ -26,7 +26,7 @@ using namespace dataRepository;
 namespace constitutive
 {
 
-ParticleFluid::ParticleFluid( std::string const & name, Group * const parent ):
+ParticleFluid::ParticleFluid( string const & name, Group * const parent ):
   ParticleFluidBase( name, parent )
 {
 
@@ -125,7 +125,7 @@ ParticleFluid::createKernelWrapper() const
                         m_proppantPackPermeability );
 }
 
-REGISTER_CATALOG_ENTRY( ConstitutiveBase, ParticleFluid, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ConstitutiveBase, ParticleFluid, string const &, Group * const )
 
 } /* namespace constitutive */
 

--- a/src/coreComponents/constitutive/fluid/ParticleFluid.hpp
+++ b/src/coreComponents/constitutive/fluid/ParticleFluid.hpp
@@ -185,13 +185,13 @@ class ParticleFluid : public ParticleFluidBase
 {
 public:
 
-  ParticleFluid( std::string const & name, Group * const parent );
+  ParticleFluid( string const & name, Group * const parent );
 
   virtual ~ParticleFluid() override;
 
   // *** ConstitutiveBase interface
 
-  static std::string catalogName() { return "ParticleFluid"; }
+  static string catalogName() { return "ParticleFluid"; }
 
   virtual string getCatalogName() const override { return catalogName(); }
 

--- a/src/coreComponents/constitutive/fluid/ParticleFluidBase.cpp
+++ b/src/coreComponents/constitutive/fluid/ParticleFluidBase.cpp
@@ -26,7 +26,7 @@ using namespace dataRepository;
 namespace constitutive
 {
 
-ParticleFluidBase::ParticleFluidBase( std::string const & name, Group * const parent )
+ParticleFluidBase::ParticleFluidBase( string const & name, Group * const parent )
   : ConstitutiveBase( name, parent )
 {
 

--- a/src/coreComponents/constitutive/fluid/ParticleFluidBase.hpp
+++ b/src/coreComponents/constitutive/fluid/ParticleFluidBase.hpp
@@ -144,7 +144,7 @@ class ParticleFluidBase : public ConstitutiveBase
 {
 public:
 
-  ParticleFluidBase( std::string const & name, Group * const parent );
+  ParticleFluidBase( string const & name, Group * const parent );
 
   virtual ~ParticleFluidBase() override;
 

--- a/src/coreComponents/constitutive/fluid/ProppantSlurryFluid.cpp
+++ b/src/coreComponents/constitutive/fluid/ProppantSlurryFluid.cpp
@@ -26,7 +26,7 @@ using namespace dataRepository;
 namespace constitutive
 {
 
-ProppantSlurryFluid::ProppantSlurryFluid( std::string const & name, Group * const parent ):
+ProppantSlurryFluid::ProppantSlurryFluid( string const & name, Group * const parent ):
   SlurryFluidBase( name, parent )
 {
   registerWrapper( viewKeyStruct::compressibilityString, &m_compressibility )->
@@ -128,7 +128,7 @@ ProppantSlurryFluid::createKernelWrapper()
 }
 
 
-REGISTER_CATALOG_ENTRY( ConstitutiveBase, ProppantSlurryFluid, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ConstitutiveBase, ProppantSlurryFluid, string const &, Group * const )
 
 } /* namespace constitutive */
 

--- a/src/coreComponents/constitutive/fluid/ProppantSlurryFluid.hpp
+++ b/src/coreComponents/constitutive/fluid/ProppantSlurryFluid.hpp
@@ -285,12 +285,12 @@ class ProppantSlurryFluid : public SlurryFluidBase
 {
 public:
 
-  ProppantSlurryFluid( std::string const & name, Group * const parent );
+  ProppantSlurryFluid( string const & name, Group * const parent );
 
   virtual ~ProppantSlurryFluid() override;
 
   // *** ConstitutiveBase interface
-  static std::string catalogName() { return "ProppantSlurryFluid"; }
+  static string catalogName() { return "ProppantSlurryFluid"; }
 
   virtual string getCatalogName() const override { return catalogName(); }
 

--- a/src/coreComponents/constitutive/fluid/SingleFluidBase.cpp
+++ b/src/coreComponents/constitutive/fluid/SingleFluidBase.cpp
@@ -26,7 +26,7 @@ using namespace dataRepository;
 namespace constitutive
 {
 
-SingleFluidBase::SingleFluidBase( std::string const & name, Group * const parent )
+SingleFluidBase::SingleFluidBase( string const & name, Group * const parent )
   : ConstitutiveBase( name, parent )
 {
 

--- a/src/coreComponents/constitutive/fluid/SingleFluidBase.hpp
+++ b/src/coreComponents/constitutive/fluid/SingleFluidBase.hpp
@@ -154,7 +154,7 @@ public:
    * @param name name of the group
    * @param parent pointer to parent group
    */
-  SingleFluidBase( std::string const & name, Group * const parent );
+  SingleFluidBase( string const & name, Group * const parent );
 
   /**
    * @brief Destructor.

--- a/src/coreComponents/constitutive/fluid/SlurryFluidBase.cpp
+++ b/src/coreComponents/constitutive/fluid/SlurryFluidBase.cpp
@@ -26,7 +26,7 @@ using namespace dataRepository;
 namespace constitutive
 {
 
-SlurryFluidBase::SlurryFluidBase( std::string const & name, Group * const parent ):
+SlurryFluidBase::SlurryFluidBase( string const & name, Group * const parent ):
   ConstitutiveBase( name, parent ),
   m_isNewtonianFluid( true )
 {

--- a/src/coreComponents/constitutive/fluid/SlurryFluidBase.hpp
+++ b/src/coreComponents/constitutive/fluid/SlurryFluidBase.hpp
@@ -242,7 +242,7 @@ class SlurryFluidBase : public ConstitutiveBase
 {
 public:
 
-  SlurryFluidBase( std::string const & name, Group * const parent );
+  SlurryFluidBase( string const & name, Group * const parent );
 
   virtual ~SlurryFluidBase() override;
 

--- a/src/coreComponents/constitutive/relativePermeability/BrooksCoreyBakerRelativePermeability.cpp
+++ b/src/coreComponents/constitutive/relativePermeability/BrooksCoreyBakerRelativePermeability.cpp
@@ -29,7 +29,7 @@ namespace constitutive
 {
 
 
-BrooksCoreyBakerRelativePermeability::BrooksCoreyBakerRelativePermeability( std::string const & name,
+BrooksCoreyBakerRelativePermeability::BrooksCoreyBakerRelativePermeability( string const & name,
                                                                             Group * const parent )
   : RelativePermeabilityBase( name, parent )
 {
@@ -155,7 +155,7 @@ BrooksCoreyBakerRelativePermeability::KernelWrapper BrooksCoreyBakerRelativePerm
                         m_dPhaseRelPerm_dPhaseVolFrac );
 }
 
-REGISTER_CATALOG_ENTRY( ConstitutiveBase, BrooksCoreyBakerRelativePermeability, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ConstitutiveBase, BrooksCoreyBakerRelativePermeability, string const &, Group * const )
 } // namespace constitutive
 
 } // namespace geosx

--- a/src/coreComponents/constitutive/relativePermeability/BrooksCoreyBakerRelativePermeability.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/BrooksCoreyBakerRelativePermeability.hpp
@@ -149,11 +149,11 @@ class BrooksCoreyBakerRelativePermeability : public RelativePermeabilityBase
 {
 public:
 
-  BrooksCoreyBakerRelativePermeability( std::string const & name, dataRepository::Group * const parent );
+  BrooksCoreyBakerRelativePermeability( string const & name, dataRepository::Group * const parent );
 
   virtual ~BrooksCoreyBakerRelativePermeability() override;
 
-  static std::string catalogName() { return "BrooksCoreyBakerRelativePermeability"; }
+  static string catalogName() { return "BrooksCoreyBakerRelativePermeability"; }
 
   virtual string getCatalogName() const override { return catalogName(); }
 

--- a/src/coreComponents/constitutive/relativePermeability/BrooksCoreyRelativePermeability.cpp
+++ b/src/coreComponents/constitutive/relativePermeability/BrooksCoreyRelativePermeability.cpp
@@ -30,7 +30,7 @@ namespace constitutive
 
 //START_SPHINX_INCLUDE_00
 
-BrooksCoreyRelativePermeability::BrooksCoreyRelativePermeability( std::string const & name,
+BrooksCoreyRelativePermeability::BrooksCoreyRelativePermeability( string const & name,
                                                                   Group * const parent )
   : RelativePermeabilityBase( name, parent )
 {
@@ -111,7 +111,7 @@ BrooksCoreyRelativePermeability::KernelWrapper BrooksCoreyRelativePermeability::
 }
 
 //START_SPHINX_INCLUDE_01
-REGISTER_CATALOG_ENTRY( ConstitutiveBase, BrooksCoreyRelativePermeability, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ConstitutiveBase, BrooksCoreyRelativePermeability, string const &, Group * const )
 
 } // namespace constitutive
 

--- a/src/coreComponents/constitutive/relativePermeability/BrooksCoreyRelativePermeability.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/BrooksCoreyRelativePermeability.hpp
@@ -89,12 +89,12 @@ class BrooksCoreyRelativePermeability : public RelativePermeabilityBase
 {
 public:
 
-  BrooksCoreyRelativePermeability( std::string const & name, dataRepository::Group * const parent );
+  BrooksCoreyRelativePermeability( string const & name, dataRepository::Group * const parent );
 
   virtual ~BrooksCoreyRelativePermeability() override;
 
 //START_SPHINX_INCLUDE_00
-  static std::string catalogName() { return "BrooksCoreyRelativePermeability"; }
+  static string catalogName() { return "BrooksCoreyRelativePermeability"; }
 
   virtual string getCatalogName() const override { return catalogName(); }
 

--- a/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityBase.cpp
+++ b/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityBase.cpp
@@ -43,7 +43,7 @@ std::unordered_map< string, integer > const phaseDict =
 }
 
 
-RelativePermeabilityBase::RelativePermeabilityBase( std::string const & name, Group * const parent )
+RelativePermeabilityBase::RelativePermeabilityBase( string const & name, Group * const parent )
   : ConstitutiveBase( name, parent )
 {
   registerWrapper( viewKeyStruct::phaseNamesString, &m_phaseNames )->

--- a/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityBase.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityBase.hpp
@@ -122,7 +122,7 @@ public:
     static constexpr integer OIL   = 1; // second oil phase property
   };
 
-  RelativePermeabilityBase( std::string const & name, dataRepository::Group * const parent );
+  RelativePermeabilityBase( string const & name, dataRepository::Group * const parent );
 
   virtual ~RelativePermeabilityBase() override;
 

--- a/src/coreComponents/constitutive/relativePermeability/VanGenuchtenBakerRelativePermeability.cpp
+++ b/src/coreComponents/constitutive/relativePermeability/VanGenuchtenBakerRelativePermeability.cpp
@@ -29,7 +29,7 @@ namespace constitutive
 {
 
 
-VanGenuchtenBakerRelativePermeability::VanGenuchtenBakerRelativePermeability( std::string const & name,
+VanGenuchtenBakerRelativePermeability::VanGenuchtenBakerRelativePermeability( string const & name,
                                                                               Group * const parent )
   : RelativePermeabilityBase( name, parent )
 {
@@ -157,7 +157,7 @@ VanGenuchtenBakerRelativePermeability::KernelWrapper VanGenuchtenBakerRelativePe
                         m_dPhaseRelPerm_dPhaseVolFrac );
 }
 
-REGISTER_CATALOG_ENTRY( ConstitutiveBase, VanGenuchtenBakerRelativePermeability, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ConstitutiveBase, VanGenuchtenBakerRelativePermeability, string const &, Group * const )
 } // namespace constitutive
 
 } // namespace geosx

--- a/src/coreComponents/constitutive/relativePermeability/VanGenuchtenBakerRelativePermeability.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/VanGenuchtenBakerRelativePermeability.hpp
@@ -150,11 +150,11 @@ class VanGenuchtenBakerRelativePermeability : public RelativePermeabilityBase
 {
 public:
 
-  VanGenuchtenBakerRelativePermeability( std::string const & name, dataRepository::Group * const parent );
+  VanGenuchtenBakerRelativePermeability( string const & name, dataRepository::Group * const parent );
 
   virtual ~VanGenuchtenBakerRelativePermeability() override;
 
-  static std::string catalogName() { return "VanGenuchtenBakerRelativePermeability"; }
+  static string catalogName() { return "VanGenuchtenBakerRelativePermeability"; }
 
   virtual string getCatalogName() const override { return catalogName(); }
 

--- a/src/coreComponents/constitutive/solid/Damage.hpp
+++ b/src/coreComponents/constitutive/solid/Damage.hpp
@@ -260,7 +260,7 @@ public:
   virtual ~Damage() override = default;
 
 
-  static std::string catalogName() { return string( "Damage" ) + BASE::m_catalogNameString; }
+  static string catalogName() { return string( "Damage" ) + BASE::m_catalogNameString; }
   virtual string getCatalogName() const override { return catalogName(); }
 
   virtual void postProcessInput() override;

--- a/src/coreComponents/constitutive/solid/DamageSpectral.hpp
+++ b/src/coreComponents/constitutive/solid/DamageSpectral.hpp
@@ -312,7 +312,7 @@ public:
   virtual ~DamageSpectral() override;
 
 
-  static std::string catalogName() { return string( "DamageSpectral" ) + BASE::m_catalogNameString; }
+  static string catalogName() { return string( "DamageSpectral" ) + BASE::m_catalogNameString; }
   virtual string getCatalogName() const override { return catalogName(); }
 
 

--- a/src/coreComponents/constitutive/solid/DamageVolDev.hpp
+++ b/src/coreComponents/constitutive/solid/DamageVolDev.hpp
@@ -244,7 +244,7 @@ public:
   virtual ~DamageVolDev() override;
 
 
-  static std::string catalogName() { return string( "DamageVolDev" ) + BASE::m_catalogNameString; }
+  static string catalogName() { return string( "DamageVolDev" ) + BASE::m_catalogNameString; }
   virtual string getCatalogName() const override { return catalogName(); }
 
 

--- a/src/coreComponents/constitutive/solid/LinearElasticAnisotropic.cpp
+++ b/src/coreComponents/constitutive/solid/LinearElasticAnisotropic.cpp
@@ -26,7 +26,7 @@ namespace constitutive
 
 
 
-LinearElasticAnisotropic::LinearElasticAnisotropic( std::string const & name, Group * const parent ):
+LinearElasticAnisotropic::LinearElasticAnisotropic( string const & name, Group * const parent ):
   SolidBase( name, parent ),
   m_defaultStiffness( 6, 6 )
 {
@@ -88,6 +88,6 @@ void LinearElasticAnisotropic::setDefaultStiffness( real64 const c[6][6] )
 }
 
 
-REGISTER_CATALOG_ENTRY( ConstitutiveBase, LinearElasticAnisotropic, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ConstitutiveBase, LinearElasticAnisotropic, string const &, Group * const )
 }
 } /* namespace geosx */

--- a/src/coreComponents/constitutive/solid/LinearElasticAnisotropic.hpp
+++ b/src/coreComponents/constitutive/solid/LinearElasticAnisotropic.hpp
@@ -258,7 +258,7 @@ public:
   /**
    * @return A string that is used to register/lookup this class in the registry
    */
-  static std::string catalogName() { return m_catalogNameString; }
+  static string catalogName() { return m_catalogNameString; }
 
   virtual string getCatalogName() const override { return catalogName(); }
   ///@}

--- a/src/coreComponents/constitutive/solid/LinearElasticIsotropic.cpp
+++ b/src/coreComponents/constitutive/solid/LinearElasticIsotropic.cpp
@@ -24,7 +24,7 @@ using namespace dataRepository;
 namespace constitutive
 {
 
-LinearElasticIsotropic::LinearElasticIsotropic( std::string const & name, Group * const parent ):
+LinearElasticIsotropic::LinearElasticIsotropic( string const & name, Group * const parent ):
   SolidBase( name, parent ),
   m_defaultBulkModulus(),
   m_defaultShearModulus(),
@@ -160,6 +160,6 @@ void LinearElasticIsotropic::postProcessInput()
     setApplyDefaultValue( m_defaultShearModulus );
 }
 
-REGISTER_CATALOG_ENTRY( ConstitutiveBase, LinearElasticIsotropic, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ConstitutiveBase, LinearElasticIsotropic, string const &, Group * const )
 }
 } /* namespace geosx */

--- a/src/coreComponents/constitutive/solid/LinearElasticIsotropic.hpp
+++ b/src/coreComponents/constitutive/solid/LinearElasticIsotropic.hpp
@@ -355,7 +355,7 @@ public:
   /**
    * @return A string that is used to register/lookup this class in the registry
    */
-  static std::string catalogName() { return m_catalogNameString; }
+  static string catalogName() { return m_catalogNameString; }
 
   virtual string getCatalogName() const override { return catalogName(); }
 

--- a/src/coreComponents/constitutive/solid/LinearElasticTransverseIsotropic.cpp
+++ b/src/coreComponents/constitutive/solid/LinearElasticTransverseIsotropic.cpp
@@ -26,7 +26,7 @@ namespace constitutive
 
 
 
-LinearElasticTransverseIsotropic::LinearElasticTransverseIsotropic( std::string const & name, Group * const parent ):
+LinearElasticTransverseIsotropic::LinearElasticTransverseIsotropic( string const & name, Group * const parent ):
   SolidBase( name, parent ),
   m_defaultYoungsModulusTransverse(),
   m_defaultYoungsModulusAxial(),
@@ -127,6 +127,6 @@ void LinearElasticTransverseIsotropic::postProcessInput()
 }
 
 
-REGISTER_CATALOG_ENTRY( ConstitutiveBase, LinearElasticTransverseIsotropic, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ConstitutiveBase, LinearElasticTransverseIsotropic, string const &, Group * const )
 }
 } /* namespace geosx */

--- a/src/coreComponents/constitutive/solid/LinearElasticTransverseIsotropic.hpp
+++ b/src/coreComponents/constitutive/solid/LinearElasticTransverseIsotropic.hpp
@@ -282,7 +282,7 @@ public:
   /**
    * @return A string that is used to register/lookup this class in the registry
    */
-  static std::string catalogName() { return m_catalogNameString; }
+  static string catalogName() { return m_catalogNameString; }
 
   virtual string getCatalogName() const override { return catalogName(); }
   ///@}

--- a/src/coreComponents/constitutive/solid/PoreVolumeCompressibleSolid.cpp
+++ b/src/coreComponents/constitutive/solid/PoreVolumeCompressibleSolid.cpp
@@ -27,7 +27,7 @@ namespace constitutive
 {
 
 
-PoreVolumeCompressibleSolid::PoreVolumeCompressibleSolid( std::string const & name, Group * const parent ):
+PoreVolumeCompressibleSolid::PoreVolumeCompressibleSolid( string const & name, Group * const parent ):
   ConstitutiveBase( name, parent )
 {
   registerWrapper( viewKeyStruct::compressibilityString, &m_compressibility )->
@@ -112,6 +112,6 @@ void PoreVolumeCompressibleSolid::stateUpdateBatchPressure( arrayView1d< real64 
   } );
 }
 
-REGISTER_CATALOG_ENTRY( ConstitutiveBase, PoreVolumeCompressibleSolid, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ConstitutiveBase, PoreVolumeCompressibleSolid, string const &, Group * const )
 }
 } /* namespace geosx */

--- a/src/coreComponents/constitutive/solid/PoreVolumeCompressibleSolid.hpp
+++ b/src/coreComponents/constitutive/solid/PoreVolumeCompressibleSolid.hpp
@@ -32,7 +32,7 @@ namespace constitutive
 class PoreVolumeCompressibleSolid : public ConstitutiveBase
 {
 public:
-  PoreVolumeCompressibleSolid( std::string const & name, Group * const parent );
+  PoreVolumeCompressibleSolid( string const & name, Group * const parent );
 
   virtual ~PoreVolumeCompressibleSolid() override;
 
@@ -43,7 +43,7 @@ public:
                                          localIndex const numConstitutivePointsPerParentIndex ) override;
 
 
-  static std::string catalogName() { return "PoreVolumeCompressibleSolid"; }
+  static string catalogName() { return "PoreVolumeCompressibleSolid"; }
 
   virtual string getCatalogName() const override { return catalogName(); }
 

--- a/src/coreComponents/constitutive/solid/PoroElastic.hpp
+++ b/src/coreComponents/constitutive/solid/PoroElastic.hpp
@@ -75,7 +75,7 @@ public:
   virtual ~PoroElastic() override;
 
 
-  static std::string catalogName() { return string( "Poro" ) + BASE::m_catalogNameString; }
+  static string catalogName() { return string( "Poro" ) + BASE::m_catalogNameString; }
   virtual string getCatalogName() const override { return catalogName(); }
 
   virtual void postProcessInput() override;

--- a/src/coreComponents/constitutive/unitTests/testMultiFluid.cpp
+++ b/src/coreComponents/constitutive/unitTests/testMultiFluid.cpp
@@ -422,7 +422,7 @@ MultiFluidBase * makeDeadOilFluid( string const & name, Group * parent )
   return fluid;
 }
 
-void writeTableToFile( std::string const & filename, char const * str )
+void writeTableToFile( string const & filename, char const * str )
 {
   std::ofstream os( filename );
   ASSERT_TRUE( os.is_open() );
@@ -430,7 +430,7 @@ void writeTableToFile( std::string const & filename, char const * str )
   os.close();
 }
 
-void removeFile( std::string const & filename )
+void removeFile( string const & filename )
 {
   int const ret = std::remove( filename.c_str() );
   ASSERT_TRUE( ret == 0 );

--- a/src/coreComponents/dataRepository/BufferOps_inline.hpp
+++ b/src/coreComponents/dataRepository/BufferOps_inline.hpp
@@ -81,7 +81,7 @@ Unpack( buffer_unit_type const * & buffer, T * const GEOSX_RESTRICT var, INDEX_T
 }
 
 template< bool DO_PACKING >
-localIndex Pack( buffer_unit_type * & buffer, const std::string & var )
+localIndex Pack( buffer_unit_type * & buffer, const string & var )
 {
   const string::size_type varSize = var.size();
   localIndex sizeOfPackedChars = Pack< DO_PACKING >( buffer, varSize );

--- a/src/coreComponents/dataRepository/ConduitRestart.cpp
+++ b/src/coreComponents/dataRepository/ConduitRestart.cpp
@@ -33,9 +33,9 @@ namespace dataRepository
 conduit::Node rootConduitNode;
 
 
-std::string writeRootFile( conduit::Node & root, std::string const & rootPath )
+string writeRootFile( conduit::Node & root, string const & rootPath )
 {
-  std::string rootDirName, rootFileName;
+  string rootDirName, rootFileName;
   splitPath( rootPath, rootDirName, rootFileName );
 
   if( MpiWrapper::commRank() == 0 )
@@ -62,9 +62,9 @@ std::string writeRootFile( conduit::Node & root, std::string const & rootPath )
 }
 
 
-std::string readRootNode( std::string const & rootPath )
+string readRootNode( string const & rootPath )
 {
-  std::string rankFilePattern;
+  string rankFilePattern;
   if( MpiWrapper::commRank() == 0 )
   {
     conduit::Node node;
@@ -73,9 +73,9 @@ std::string readRootNode( std::string const & rootPath )
     int const nFiles = node.fetch_child( "number_of_files" ).value();
     GEOSX_ERROR_IF_NE( nFiles, MpiWrapper::commSize() );
 
-    std::string const filePattern = node.fetch_child( "file_pattern" ).as_string();
+    string const filePattern = node.fetch_child( "file_pattern" ).as_string();
 
-    std::string rootDirName, rootFileName;
+    string rootDirName, rootFileName;
     splitPath( rootPath, rootDirName, rootFileName );
 
     rankFilePattern = rootDirName + "/" + filePattern;
@@ -90,21 +90,21 @@ std::string readRootNode( std::string const & rootPath )
 }
 
 /* Write out a restart file. */
-void writeTree( std::string const & path )
+void writeTree( string const & path )
 {
   GEOSX_MARK_FUNCTION;
 
   conduit::Node root;
-  std::string const filePathForRank = writeRootFile( root, path );
+  string const filePathForRank = writeRootFile( root, path );
   GEOSX_LOG_RANK( "Writing out restart file at " << filePathForRank );
   conduit::relay::io::save( rootConduitNode, filePathForRank, "hdf5" );
 }
 
 
-void loadTree( std::string const & path )
+void loadTree( string const & path )
 {
   GEOSX_MARK_FUNCTION;
-  std::string const filePathForRank = readRootNode( path );
+  string const filePathForRank = readRootNode( path );
   GEOSX_LOG_RANK( "Reading in restart file at " << filePathForRank );
   conduit::relay::io::load( filePathForRank, "hdf5", rootConduitNode );
 }

--- a/src/coreComponents/dataRepository/ConduitRestart.hpp
+++ b/src/coreComponents/dataRepository/ConduitRestart.hpp
@@ -88,11 +88,11 @@ using conduitTypeInfo = internal::conduitTypeInfo< std::remove_const_t< std::rem
 
 extern conduit::Node rootConduitNode;
 
-std::string writeRootFile( conduit::Node & root, std::string const & rootPath );
+string writeRootFile( conduit::Node & root, string const & rootPath );
 
-void writeTree( std::string const & path );
+void writeTree( string const & path );
 
-void loadTree( std::string const & path );
+void loadTree( string const & path );
 
 } // namespace dataRepository
 } // namespace geosx

--- a/src/coreComponents/dataRepository/ConduitRestart.hpp
+++ b/src/coreComponents/dataRepository/ConduitRestart.hpp
@@ -27,7 +27,7 @@
 #include <conduit.hpp>
 
 // System includes
-#include <string>
+
 
 /// @cond DO_NOT_DOCUMENT
 

--- a/src/coreComponents/dataRepository/Group.cpp
+++ b/src/coreComponents/dataRepository/Group.cpp
@@ -36,7 +36,7 @@ conduit::Node & conduitNodeFromParent( string const & name, Group * const parent
   }
 }
 
-Group::Group( std::string const & name,
+Group::Group( string const & name,
               Group * const parent ):
   m_parent( parent ),
   m_sizedFromParent( 0 ),
@@ -133,7 +133,7 @@ void Group::processInputFileRecursive( xmlWrapper::xmlNode & targetNode )
   for( xmlWrapper::xmlNode childNode=targetNode.first_child(); childNode; childNode=childNode.next_sibling())
   {
     // Get the child tag and name
-    std::string childName = childNode.attribute( "name" ).value();
+    string childName = childNode.attribute( "name" ).value();
     if( childName.empty())
     {
       childName = childNode.name();
@@ -159,7 +159,7 @@ void Group::processInputFile( xmlWrapper::xmlNode const & targetNode )
 {
 
   std::set< string > processedXmlNodes;
-  for( std::pair< std::string const, WrapperBase * > & pair : m_wrappers )
+  for( std::pair< string const, WrapperBase * > & pair : m_wrappers )
   {
     if( pair.second->processInputFile( targetNode ) )
     {
@@ -241,7 +241,7 @@ string Group::dumpInputOptions() const
   return rval;
 }
 
-void Group::deregisterGroup( std::string const & name )
+void Group::deregisterGroup( string const & name )
 {
   GEOSX_ERROR_IF( !hasGroup( name ), "Group " << name << " doesn't exist." );
   m_subGroups.erase( name );

--- a/src/coreComponents/dataRepository/Group.hpp
+++ b/src/coreComponents/dataRepository/Group.hpp
@@ -89,7 +89,7 @@ public:
    * @param[in] name the name of this object manager
    * @param[in] parent the parent Group
    */
-  explicit Group( std::string const & name,
+  explicit Group( string const & name,
                   Group * const parent );
 
 
@@ -142,7 +142,7 @@ public:
   /**
    * @brief Type alias for catalog interface used by this class. See CatalogInterface.
    */
-  using CatalogInterface = dataRepository::CatalogInterface< Group, std::string const &, Group * const >;
+  using CatalogInterface = dataRepository::CatalogInterface< Group, string const &, Group * const >;
 
   /**
    * @brief Get the singleton catalog for this class.
@@ -206,10 +206,10 @@ public:
    * Registers a Group or class derived from Group as a subgroup of this Group and takes ownership.
    */
   template< typename T = Group >
-  T * registerGroup( std::string const & name, std::unique_ptr< T > newObject );
+  T * registerGroup( string const & name, std::unique_ptr< T > newObject );
 
   /**
-   * @brief @copybrief registerGroup(std::string const &,std::unique_ptr<T>)
+   * @brief @copybrief registerGroup(string const &,std::unique_ptr<T>)
    *
    * @tparam T The type of the Group to add/register. This should be a type that derives from Group.
    * @param[in] name          The name of the group to use as a string key.
@@ -219,11 +219,11 @@ public:
    * Registers a Group or class derived from Group as a subgroup of this Group but does not take ownership.
    */
   template< typename T = Group >
-  T * registerGroup( std::string const & name,
+  T * registerGroup( string const & name,
                      T * newObject );
 
   /**
-   * @brief @copybrief registerGroup(std::string const &,std::unique_ptr<T>)
+   * @brief @copybrief registerGroup(string const &,std::unique_ptr<T>)
    *
    * @tparam T The type of the Group to add/register. This should be a type that derives from Group.
    * @param[in] name The name of the group to use as a string key.
@@ -232,13 +232,13 @@ public:
    * Creates and registers a Group or class derived from Group as a subgroup of this Group.
    */
   template< typename T = Group >
-  T * registerGroup( std::string const & name )
+  T * registerGroup( string const & name )
   {
     return registerGroup< T >( name, std::move( std::make_unique< T >( name, this )) );
   }
 
   /**
-   * @brief @copybrief registerGroup(std::string const &,std::unique_ptr<T>)
+   * @brief @copybrief registerGroup(string const &,std::unique_ptr<T>)
    *
    * @tparam T The type of the Group to add/register. This should be a type that derives from Group.
    * @param[in,out] keyIndex A KeyIndexT object that will be used to specify the name of
@@ -256,7 +256,7 @@ public:
   }
 
   /**
-   * @brief @copybrief registerGroup(std::string const &,std::unique_ptr<T>)
+   * @brief @copybrief registerGroup(string const &,std::unique_ptr<T>)
    *
    * @tparam T The type of the Group to add/register. This should be a type that derives from Group.
    * @tparam TBASE The type whose type catalog will be used to look up the new sub-group type
@@ -267,7 +267,7 @@ public:
    * Creates and registers a Group or class derived from Group as a subgroup of this Group.
    */
   template< typename T = Group, typename TBASE = Group >
-  T * registerGroup( std::string const & name, std::string const & catalogName )
+  T * registerGroup( string const & name, string const & catalogName )
   {
     std::unique_ptr< TBASE > newGroup = TBASE::CatalogInterface::Factory( catalogName, name, this );
     return registerGroup< T >( name, std::move( newGroup ) );
@@ -277,7 +277,7 @@ public:
    * @brief Removes a child group from this group.
    * @param name the name of the child group to remove from this group.
    */
-  void deregisterGroup( std::string const & name );
+  void deregisterGroup( string const & name );
 
   /**
    * @brief Creates a new sub-Group using the ObjectCatalog functionality.
@@ -507,7 +507,7 @@ public:
    * @param name the name of sub-group to search for
    * @return @p true if sub-group exists, @p false otherwise
    */
-  bool hasGroup( std::string const & name ) const
+  bool hasGroup( string const & name ) const
   {
     return (m_subGroups[name] != nullptr);
   }
@@ -831,11 +831,11 @@ public:
    * @return     a pointer to the newly registered/created Wrapper
    */
   template< typename T, typename TBASE=T >
-  Wrapper< TBASE > * registerWrapper( std::string const & name,
+  Wrapper< TBASE > * registerWrapper( string const & name,
                                       wrapperMap::KeyIndex::index_type * const rkey = nullptr );
 
   /**
-   * @copybrief registerWrapper(std::string const &,wrapperMap::KeyIndex::index_type * const)
+   * @copybrief registerWrapper(string const &,wrapperMap::KeyIndex::index_type * const)
    * @tparam     T the type of the wrapped object
    * @tparam TBASE the base type to cast the returned wrapper to
    * @param[in] viewKey The KeyIndex that contains the name of the new Wrapper.
@@ -852,7 +852,7 @@ public:
    * @return              a pointer to the newly registered/created Wrapper
    */
   template< typename T >
-  Wrapper< T > * registerWrapper( std::string const & name,
+  Wrapper< T > * registerWrapper( string const & name,
                                   std::unique_ptr< T > newObject );
 
   /**
@@ -863,7 +863,7 @@ public:
    * @return                  a pointer to the newly registered/created Wrapper
    */
   template< typename T >
-  Wrapper< T > * registerWrapper( std::string const & name,
+  Wrapper< T > * registerWrapper( string const & name,
                                   T * newObject );
 
   /**
@@ -896,7 +896,7 @@ public:
   void generateDataStructureSkeleton( integer const level )
   {
     expandObjectCatalogs();
-    std::string indent( level*2, ' ' );
+    string indent( level*2, ' ' );
 
     for( auto const & subGroupIter : m_subGroups )
     {
@@ -1069,13 +1069,13 @@ public:
    * @param[in] name a string lookup value used to search the collection of wrappers.
    * @return         a pointer to the WrapperBase that resulted from the lookup.
    */
-  WrapperBase const * getWrapperBase( std::string const & name ) const
+  WrapperBase const * getWrapperBase( string const & name ) const
   { return m_wrappers[name]; }
 
   /**
-   * @copydoc getWrapperBase(std::string const &) const
+   * @copydoc getWrapperBase(string const &) const
    */
-  WrapperBase * getWrapperBase( std::string const & name )
+  WrapperBase * getWrapperBase( string const & name )
   { return m_wrappers[name]; }
 
   /**
@@ -1097,7 +1097,7 @@ public:
    * @param name
    * @return
    */
-  indexType getWrapperIndex( std::string const & name ) const
+  indexType getWrapperIndex( string const & name ) const
   {
     return m_wrappers.getIndex( name );
   }
@@ -1547,7 +1547,7 @@ using ViewKey = Group::wrapperMap::KeyIndex;
 
 
 template< typename T >
-T * Group::registerGroup( std::string const & name,
+T * Group::registerGroup( string const & name,
                           std::unique_ptr< T > newObject )
 {
   newObject->m_parent = this;
@@ -1556,7 +1556,7 @@ T * Group::registerGroup( std::string const & name,
 
 
 template< typename T >
-T * Group::registerGroup( std::string const & name,
+T * Group::registerGroup( string const & name,
                           T * newObject )
 {
   return dynamicCast< T * >( m_subGroups.insert( name, newObject, false ) );
@@ -1565,7 +1565,7 @@ T * Group::registerGroup( std::string const & name,
 // Doxygen bug - sees this as a separate function
 /// @cond DO_NOT_DOCUMENT
 template< typename T, typename TBASE >
-Wrapper< TBASE > * Group::registerWrapper( std::string const & name,
+Wrapper< TBASE > * Group::registerWrapper( string const & name,
                                            ViewKey::index_type * const rkey )
 {
   std::unique_ptr< TBASE > newObj = std::make_unique< T >();
@@ -1599,7 +1599,7 @@ Wrapper< TBASE > * Group::registerWrapper( ViewKey const & viewKey )
 
 
 template< typename T >
-Wrapper< T > * Group::registerWrapper( std::string const & name,
+Wrapper< T > * Group::registerWrapper( string const & name,
                                        std::unique_ptr< T > newObject )
 {
   m_wrappers.insert( name,
@@ -1617,7 +1617,7 @@ Wrapper< T > * Group::registerWrapper( std::string const & name,
 
 
 template< typename T >
-Wrapper< T > * Group::registerWrapper( std::string const & name,
+Wrapper< T > * Group::registerWrapper( string const & name,
                                        T * newObject )
 {
   m_wrappers.insert( name,
@@ -1643,7 +1643,7 @@ T const * Group::getGroupByPath( string const & path ) const
 
   size_t directoryMarker = path.find( '/' );
 
-  if( directoryMarker == std::string::npos )
+  if( directoryMarker == string::npos )
   {
     // Target should be a child of this group
     return this->getGroup< T >( path );

--- a/src/coreComponents/dataRepository/InputFlags.hpp
+++ b/src/coreComponents/dataRepository/InputFlags.hpp
@@ -93,9 +93,9 @@ inline int InputFlagToInt( InputFlags const val )
  * @param[in] val The value of the input flag that will be converted to a string
  * @return The string equivalent of the input @p val.
  */
-inline std::string InputFlagToString( InputFlags const val )
+inline string InputFlagToString( InputFlags const val )
 {
-  std::string rval;
+  string rval;
   switch( val )
   {
     case InputFlags::INVALID:

--- a/src/coreComponents/dataRepository/KeyIndexT.hpp
+++ b/src/coreComponents/dataRepository/KeyIndexT.hpp
@@ -19,7 +19,7 @@
 #ifndef GEOSX_DATAREPOSITORY_KEYINDEXT_HPP_
 #define GEOSX_DATAREPOSITORY_KEYINDEXT_HPP_
 
-#include <string>
+
 #include <ostream>
 
 /**

--- a/src/coreComponents/dataRepository/MappedVector.hpp
+++ b/src/coreComponents/dataRepository/MappedVector.hpp
@@ -43,7 +43,7 @@ namespace geosx
  */
 template< typename T,
           typename T_PTR=T *,
-          typename KEY_TYPE=std::string,
+          typename KEY_TYPE=string,
           typename INDEX_TYPE = int >
 class MappedVector
 {

--- a/src/coreComponents/dataRepository/ObjectCatalog.hpp
+++ b/src/coreComponents/dataRepository/ObjectCatalog.hpp
@@ -29,7 +29,7 @@
 #include "LvArray/src/system.hpp"
 
 #include <unordered_map>
-#include <string>
+
 #include <iostream>
 #include <memory>
 

--- a/src/coreComponents/dataRepository/Wrapper.hpp
+++ b/src/coreComponents/dataRepository/Wrapper.hpp
@@ -72,7 +72,7 @@ public:
    * @param name name of the object
    * @param parent parent group which owns the Wrapper
    */
-  explicit Wrapper( std::string const & name,
+  explicit Wrapper( string const & name,
                     Group * const parent ):
     WrapperBase( name, parent ),
     m_ownsData( true ),
@@ -93,7 +93,7 @@ public:
    * @param parent parent group that owns the Wrapper
    * @param object object that is being wrapped by the Wrapper
    */
-  explicit Wrapper( std::string const & name,
+  explicit Wrapper( string const & name,
                     Group * const parent,
                     std::unique_ptr< T > object ):
     WrapperBase( name, parent ),
@@ -115,7 +115,7 @@ public:
    * @param parent parent group that owns the Wrapper
    * @param object object that is being wrapped by the Wrapper
    */
-  explicit Wrapper( std::string const & name,
+  explicit Wrapper( string const & name,
                     Group * const parent,
                     T * object ):
     WrapperBase( name, parent ),
@@ -711,20 +711,20 @@ public:
   /**
    * @copydoc WrapperBase::getDefaultValueString()
    */
-  virtual std::string getDefaultValueString() const override
+  virtual string getDefaultValueString() const override
   {
     // Find the dimensionality of the wrapper value
-    std::string wrapper_type = rtTypes::typeNames( std::type_index( getTypeId()));
+    string wrapper_type = rtTypes::typeNames( std::type_index( getTypeId()));
     integer value_dim = 0;
-    if( wrapper_type.find( "array3d" ) != std::string::npos )
+    if( wrapper_type.find( "array3d" ) != string::npos )
     {
       value_dim = 3;
     }
-    else if( wrapper_type.find( "array2d" ) != std::string::npos )
+    else if( wrapper_type.find( "array2d" ) != string::npos )
     {
       value_dim = 2;
     }
-    else if( wrapper_type.find( "array" ) != std::string::npos )
+    else if( wrapper_type.find( "array" ) != string::npos )
     {
       value_dim = 1;
     }
@@ -781,7 +781,7 @@ public:
 
   /**
    * @brief Associate the path to this wrapper with the object being held.
-   * @note This calls T::setName( std::string ) if it exists and is a no-op if not.
+   * @note This calls T::setName( string ) if it exists and is a no-op if not.
    *       LvArray objects implement this method.
    */
   void setName()
@@ -790,17 +790,17 @@ public:
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////
   void addBlueprintField( conduit::Node & fields,
-                          std::string const & name,
-                          std::string const & topology,
-                          std::vector< std::string > const & componentNames = {} ) const override
+                          string const & name,
+                          string const & topology,
+                          std::vector< string > const & componentNames = {} ) const override
   { wrapperHelpers::addBlueprintField( reference(), fields, name, topology, componentNames ); }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  void populateMCArray( conduit::Node & node, std::vector< std::string > const & componentNames = {} ) const override
+  void populateMCArray( conduit::Node & node, std::vector< string > const & componentNames = {} ) const override
   { wrapperHelpers::populateMCArray( reference(), node, componentNames ); }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  std::unique_ptr< WrapperBase > averageOverSecondDim( std::string const & name, Group & group ) const override
+  std::unique_ptr< WrapperBase > averageOverSecondDim( string const & name, Group & group ) const override
   {
     auto ptr = wrapperHelpers::averageOverSecondDim( reference() );
     using U = typename decltype( ptr )::element_type;

--- a/src/coreComponents/dataRepository/WrapperBase.cpp
+++ b/src/coreComponents/dataRepository/WrapperBase.cpp
@@ -26,7 +26,7 @@ namespace dataRepository
 {
 
 
-WrapperBase::WrapperBase( std::string const & name,
+WrapperBase::WrapperBase( string const & name,
                           Group * const parent ):
   m_name( name ),
   m_parent( parent ),

--- a/src/coreComponents/dataRepository/WrapperBase.hpp
+++ b/src/coreComponents/dataRepository/WrapperBase.hpp
@@ -163,7 +163,7 @@ public:
    * @brief Return a string representing the default value.
    * @return A string representing the default value.
    */
-  virtual std::string getDefaultValueString() const = 0;
+  virtual string getDefaultValueString() const = 0;
 
   /**
    * @brief Initialize the wrapper from the input xml node.
@@ -181,9 +181,9 @@ public:
    * @note This wrapper must hold an LvArray::Array.
    */
   virtual void addBlueprintField( conduit::Node & fields,
-                                  std::string const & name,
-                                  std::string const & topology,
-                                  std::vector< std::string > const & componentNames = {} ) const = 0;
+                                  string const & name,
+                                  string const & topology,
+                                  std::vector< string > const & componentNames = {} ) const = 0;
 
   /**
    * @brief Push the data in the wrapper into a Conduit Blueprint mcarray.
@@ -191,7 +191,7 @@ public:
    * @param componentNames The names of the components, if not specified they are auto generated.
    * @note This wrapper must hold an LvArray::Array.
    */
-  virtual void populateMCArray( conduit::Node & node, std::vector< std::string > const & componentNames = {} ) const = 0;
+  virtual void populateMCArray( conduit::Node & node, std::vector< string > const & componentNames = {} ) const = 0;
 
   /**
    * @brief Create a new Wrapper with values averaged over the second dimension.
@@ -201,7 +201,7 @@ public:
    * @note This Wrapper must hold an LvArray::Array of dimension 2 or greater.
    * @note The new Wrapper is not registered with @p group.
    */
-  virtual std::unique_ptr< WrapperBase > averageOverSecondDim( std::string const & name, Group & group ) const = 0;
+  virtual std::unique_ptr< WrapperBase > averageOverSecondDim( string const & name, Group & group ) const = 0;
 
   /**
    * @name Restart output methods

--- a/src/coreComponents/dataRepository/unitTests/testObjectCatalog.cpp
+++ b/src/coreComponents/dataRepository/unitTests/testObjectCatalog.cpp
@@ -46,7 +46,7 @@ public:
     return catalog;
   }
 
-  virtual std::string getCatalogName() = 0;
+  virtual string getCatalogName() = 0;
 };
 //STOP_SPHINX
 
@@ -64,8 +64,8 @@ public:
   {
     GEOSX_LOG( "calling Derived1 destructor" );
   }
-  static std::string catalogName() { return "derived1"; }
-  std::string getCatalogName() { return catalogName(); }
+  static string catalogName() { return "derived1"; }
+  string getCatalogName() { return catalogName(); }
 
 };
 REGISTER_CATALOG_ENTRY( Base, Derived1, int &, double const & )
@@ -85,8 +85,8 @@ public:
   {
     GEOSX_LOG( "calling Derived2 destructor" );
   }
-  static std::string catalogName() { return "derived2"; }
-  std::string getCatalogName() { return catalogName(); }
+  static string catalogName() { return "derived2"; }
+  string getCatalogName() { return catalogName(); }
 
 };
 REGISTER_CATALOG_ENTRY( Base, Derived2, int &, double const & )

--- a/src/coreComponents/dataRepository/unitTests/testReferenceWrapper.cpp
+++ b/src/coreComponents/dataRepository/unitTests/testReferenceWrapper.cpp
@@ -19,7 +19,7 @@
 #include "Array.hpp"
 
 #include <functional>
-#include <string>
+
 #include <typeindex>
 #include <vector>
 

--- a/src/coreComponents/dataRepository/unitTests/testRestartBasic.cpp
+++ b/src/coreComponents/dataRepository/unitTests/testRestartBasic.cpp
@@ -87,9 +87,9 @@ public:
   }
 
 private:
-  std::string const m_groupName = "root";
-  std::string const m_wrapperName = "wrapper";
-  std::string const m_fileName = "testRestartBasic_SingleWrapperTest";
+  string const m_groupName = "root";
+  string const m_wrapperName = "wrapper";
+  string const m_fileName = "testRestartBasic_SingleWrapperTest";
 
   Group * m_group;
   int m_groupSize;
@@ -102,26 +102,26 @@ using TestTypes = ::testing::Types< int,
                                     R1Tensor,
                                     std::pair< int, R1Tensor >, // This should be passed to conduit via an external
                                                                 // pointer but currently we're packing it.
-                                    std::pair< std::string, double >,
-                                    std::string,
+                                    std::pair< string, double >,
+                                    string,
                                     std::vector< int >,
-                                    // std::vector< std::string > bufferOps currently can't pack this
+                                    // std::vector< string > bufferOps currently can't pack this
                                     array1d< double >,
-                                    array1d< std::string >,
+                                    array1d< string >,
                                     array1d< array1d< double > >,
-                                    array1d< array1d< std::string > >,
+                                    array1d< array1d< string > >,
                                     array2d< double >,
-                                    array2d< std::string >,
+                                    array2d< string >,
                                     array2d< double, RAJA::PERM_JI >,
-                                    array2d< std::string, RAJA::PERM_JI >,
+                                    array2d< string, RAJA::PERM_JI >,
                                     array3d< double >,
-                                    array3d< std::string >,
+                                    array3d< string >,
                                     array3d< double, RAJA::PERM_KJI >,
-                                    array3d< std::string, RAJA::PERM_IKJ >,
+                                    array3d< string, RAJA::PERM_IKJ >,
                                     SortedArray< int >,
-                                    SortedArray< std::string >,
-                                    map< std::string, int >,
-                                    unordered_map< std::string, int >,
+                                    SortedArray< string >,
+                                    map< string, int >,
+                                    unordered_map< string, int >,
                                     map< long, int >,
                                     unordered_map< long, int >
                                     >;

--- a/src/coreComponents/dataRepository/unitTests/testRestartExtended.cpp
+++ b/src/coreComponents/dataRepository/unitTests/testRestartExtended.cpp
@@ -229,7 +229,7 @@ TEST( testRestartExtended, testRestartExtended )
   int sfp = 55;
 
   /* Create a new Group directly below the conduit root. */
-  Group * root = new Group( std::string( "data" ), nullptr );
+  Group * root = new Group( string( "data" ), nullptr );
   root->resize( group_size );
 
   /* Create a new globalIndex_array Wrapper. */
@@ -418,7 +418,7 @@ TEST( testRestartExtended, testRestartExtended )
 
   /* Restore the conduit tree */
   loadTree( path );
-  root = new Group( std::string( "data" ), nullptr );
+  root = new Group( string( "data" ), nullptr );
 
   /* Create dual GEOS tree. Groups automatically register with the associated conduit::Node. */
   Wrapper< globalIndex_array > * view_globalIndex_new = root->registerWrapper< globalIndex_array >( view_globalIndex_name );

--- a/src/coreComponents/dataRepository/unitTests/testWrapper.cpp
+++ b/src/coreComponents/dataRepository/unitTests/testWrapper.cpp
@@ -89,7 +89,7 @@ public:
     }
   }
 
-  void testDescription( std::string const & value )
+  void testDescription( string const & value )
   {
     {
       Wrapper< T > * rval = m_wrapper.setDescription( value );

--- a/src/coreComponents/dataRepository/unitTests/testWrapperHelpers.cpp
+++ b/src/coreComponents/dataRepository/unitTests/testWrapperHelpers.cpp
@@ -108,7 +108,7 @@ TEST( wrapperHelpers, size )
   checkNoSizeMethod( double() );
   checkNoSizeMethod( R1Tensor() );
 
-  checkSizeMethod( std::string( "hello" ) );
+  checkSizeMethod( string( "hello" ) );
   checkSizeMethod( std::set< int > { 1, 2, 3 } );
   checkSizeMethod( std::vector< int > { 1, 2, 3 } );
   checkSizeMethod( std::array< int, 5 > {} );

--- a/src/coreComponents/dataRepository/unitTests/utils.hpp
+++ b/src/coreComponents/dataRepository/unitTests/utils.hpp
@@ -34,11 +34,11 @@ void fill( R1Tensor & val, localIndex )
   }
 }
 
-void fill( std::string & val, localIndex )
+void fill( string & val, localIndex )
 {
   int const num = rand( -100, 100 );
   val = std::to_string( num ) +
-        std::string( " The rest of this is to avoid any small string optimizations. " ) +
+        string( " The rest of this is to avoid any small string optimizations. " ) +
         std::to_string( 2 * num );
 }
 

--- a/src/coreComponents/dataRepository/wrapperHelpers.hpp
+++ b/src/coreComponents/dataRepository/wrapperHelpers.hpp
@@ -51,10 +51,10 @@ namespace wrapperHelpers
 namespace internal
 {
 
-inline void logOutputType( std::string const & typeString, std::string const & msg )
+inline void logOutputType( string const & typeString, string const & msg )
 {
 #if RESTART_TYPE_LOGGING
-  static std::unordered_set< std::string > m_types;
+  static std::unordered_set< string > m_types;
 
   if( !m_types.count( typeString ) )
   {
@@ -68,14 +68,14 @@ inline void logOutputType( std::string const & typeString, std::string const & m
 }
 
 template< typename T, typename ... INDICES >
-std::string getIndicesToComponent( T const &, int const component, INDICES const ... existingIndices )
+string getIndicesToComponent( T const &, int const component, INDICES const ... existingIndices )
 {
   GEOSX_ERROR_IF_NE( component, 0 );
   return LvArray::indexing::getIndexString( existingIndices ... );
 }
 
 template< typename ... INDICES >
-std::string getIndicesToComponent( R1Tensor const &, int const component, INDICES const ... existingIndices )
+string getIndicesToComponent( R1Tensor const &, int const component, INDICES const ... existingIndices )
 { return LvArray::indexing::getIndexString( existingIndices ..., component ); }
 
 template< typename T >
@@ -108,7 +108,7 @@ size( T const & GEOSX_UNUSED_PARAM( value ) )
 
 
 inline char *
-dataPtr( std::string & var )
+dataPtr( string & var )
 { return const_cast< char * >( var.data() ); }
 
 inline char *
@@ -220,12 +220,12 @@ capacity( T const & value )
 
 template< typename T >
 std::enable_if_t< traits::HasMemberFunction_setName< T > >
-setName( T & value, std::string const & name )
+setName( T & value, string const & name )
 { value.setName( name ); }
 
 template< typename T >
 std::enable_if_t< !traits::HasMemberFunction_setName< T > >
-setName( T & GEOSX_UNUSED_PARAM( value ), std::string const & GEOSX_UNUSED_PARAM( name ) )
+setName( T & GEOSX_UNUSED_PARAM( value ), string const & GEOSX_UNUSED_PARAM( name ) )
 {}
 
 template< typename T >
@@ -278,10 +278,10 @@ pullDataFromConduitNode( T & var, conduit::Node const & node )
   GEOSX_ERROR_IF_NE( bytesRead, byteSize );
 }
 
-// This is for an std::string since the type of char is different on different platforms :(.
+// This is for an string since the type of char is different on different platforms :(.
 inline
 void
-pushDataToConduitNode( std::string const & var, conduit::Node & node )
+pushDataToConduitNode( string const & var, conduit::Node & node )
 {
   internal::logOutputType( LvArray::system::demangleType( var ), "Output via external pointer: " );
 
@@ -292,12 +292,12 @@ pushDataToConduitNode( std::string const & var, conduit::Node & node )
   node[ "__values__" ].set_external( dtype, ptr );
 }
 
-// This is for Path since it derives from std::string. See overload for std::string.
+// This is for Path since it derives from string. See overload for string.
 inline
 void
 pushDataToConduitNode( Path const & var, conduit::Node & node )
 {
-  pushDataToConduitNode( static_cast< std::string const & >(var), node );
+  pushDataToConduitNode( static_cast< string const & >(var), node );
 }
 
 // This is for an object that doesn't need to be packed but isn't an LvArray.
@@ -460,9 +460,9 @@ template< typename T, int NDIM, int USD >
 std::enable_if_t< std::is_arithmetic< T >::value || traits::is_tensorT< T > >
 addBlueprintField( ArrayView< T const, NDIM, USD > const & var,
                    conduit::Node & fields,
-                   std::string const & fieldName,
-                   std::string const & topology,
-                   std::vector< std::string > const & componentNames )
+                   string const & fieldName,
+                   string const & topology,
+                   std::vector< string > const & componentNames )
 {
   GEOSX_ERROR_IF_LE( var.size(), 0 );
 
@@ -487,14 +487,14 @@ addBlueprintField( ArrayView< T const, NDIM, USD > const & var,
   {
     for( int i = 0; i < numComponentsPerValue; ++i )
     {
-      std::string name;
+      string name;
       if( totalNumberOfComponents == 1 )
       {
         name = fieldName;
       }
       else if( componentNames.empty() )
       {
-        std::string indexString = internal::getIndicesToComponent( val, i, indices ... );
+        string indexString = internal::getIndicesToComponent( val, i, indices ... );
         indexString.erase( indexString.begin() );
         indexString.pop_back();
         indexString.pop_back();
@@ -519,9 +519,9 @@ addBlueprintField( ArrayView< T const, NDIM, USD > const & var,
 template< typename T >
 void addBlueprintField( T const &,
                         conduit::Node & fields,
-                        std::string const &,
-                        std::string const &,
-                        std::vector< std::string > const & )
+                        string const &,
+                        string const &,
+                        std::vector< string > const & )
 {
   GEOSX_ERROR( "Cannot create a mcarray out of " << LvArray::system::demangleType< T >() <<
                "\nWas trying to write it to " << fields.path() );
@@ -531,7 +531,7 @@ template< typename T, int NDIM, int USD >
 std::enable_if_t< std::is_arithmetic< T >::value || traits::is_tensorT< T > >
 populateMCArray( ArrayView< T const, NDIM, USD > const & var,
                  conduit::Node & node,
-                 std::vector< std::string > const & componentNames )
+                 std::vector< string > const & componentNames )
 {
   GEOSX_ERROR_IF_LE( var.size(), 0 );
 
@@ -555,7 +555,7 @@ populateMCArray( ArrayView< T const, NDIM, USD > const & var,
   {
     for( int i = 0; i < numComponentsPerValue; ++i )
     {
-      std::string const name = componentNames.empty() ? internal::getIndicesToComponent( val, i, indices ... ) :
+      string const name = componentNames.empty() ? internal::getIndicesToComponent( val, i, indices ... ) :
                                componentNames[ curComponent++ ];
 
       void const * pointer = internal::getPointerToComponent( val, i );
@@ -567,7 +567,7 @@ populateMCArray( ArrayView< T const, NDIM, USD > const & var,
 template< typename T >
 void populateMCArray( T const &,
                       conduit::Node & node,
-                      std::vector< std::string > const & )
+                      std::vector< string > const & )
 {
   GEOSX_ERROR( "Cannot create a mcarray out of " << LvArray::system::demangleType< T >() <<
                "\nWas trying to write it to " << node.path() );

--- a/src/coreComponents/dataRepository/wrapperHelpers.hpp
+++ b/src/coreComponents/dataRepository/wrapperHelpers.hpp
@@ -556,7 +556,7 @@ populateMCArray( ArrayView< T const, NDIM, USD > const & var,
     for( int i = 0; i < numComponentsPerValue; ++i )
     {
       string const name = componentNames.empty() ? internal::getIndicesToComponent( val, i, indices ... ) :
-                               componentNames[ curComponent++ ];
+                          componentNames[ curComponent++ ];
 
       void const * pointer = internal::getPointerToComponent( val, i );
       node[ name ].set_external( dtype, const_cast< void * >( pointer ) );

--- a/src/coreComponents/dataRepository/xmlWrapper.hpp
+++ b/src/coreComponents/dataRepository/xmlWrapper.hpp
@@ -150,7 +150,7 @@ public:
 
   /// Defines a static constexpr bool canParseVariable that is true iff the template parameter T
   /// is a valid argument to StringToInputVariable.
-  IS_VALID_EXPRESSION( canParseVariable, T, stringToInputVariable( std::declval< T & >(), std::string() ) );
+  IS_VALID_EXPRESSION( canParseVariable, T, stringToInputVariable( std::declval< T & >(), string() ) );
 
   /**
    * @name Attribute extraction from XML nodes.

--- a/src/coreComponents/fileIO/coupling/ChomboCoupler.hpp
+++ b/src/coreComponents/fileIO/coupling/ChomboCoupler.hpp
@@ -18,7 +18,7 @@
 #include "common/DataTypes.hpp"
 #include "mesh/MeshLevel.hpp"
 
-#include <string>
+
 
 namespace geosx
 {

--- a/src/coreComponents/fileIO/schema/schemaUtilities.cpp
+++ b/src/coreComponents/fileIO/schema/schemaUtilities.cpp
@@ -37,13 +37,13 @@ namespace schemaUtilities
 {
 
 
-void ConvertDocumentationToSchema( std::string const & fname,
+void ConvertDocumentationToSchema( string const & fname,
                                    Group * const group,
                                    integer documentationType )
 {
   GEOSX_LOG_RANK_0( "Generating XML Schema..." );
 
-  std::string schemaBase=
+  string schemaBase=
     "<?xml version=\"1.1\" encoding=\"ISO-8859-1\" ?>\
   <xsd:schema xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\
   <xsd:annotation>\
@@ -74,7 +74,7 @@ void AppendSimpleType( xmlWrapper::xmlNode & schemaRoot,
                        string const & name,
                        string const & regex )
 {
-  std::string const advanced_match_string = ".*[\\[\\]`$].*|";
+  string const advanced_match_string = ".*[\\[\\]`$].*|";
 
   xmlWrapper::xmlNode newNode = schemaRoot.append_child( "xsd:simpleType" );
   newNode.append_attribute( "name" ) = name.c_str();
@@ -90,7 +90,7 @@ void AppendSimpleType( xmlWrapper::xmlNode & schemaRoot,
   }
   else
   {
-    std::string const patternString = advanced_match_string + regex;
+    string const patternString = advanced_match_string + regex;
     patternNode.append_attribute( "value" ) = patternString.c_str();
   }
 }
@@ -226,8 +226,8 @@ void SchemaConstruction( Group * const group,
             xmlWrapper::xmlNode attributeNode = targetTypeDefNode.append_child( "xsd:attribute" );
             attributeNode.append_attribute( "name" ) = attributeName.c_str();
 
-            std::string const wrappedTypeName = rtTypes::typeNames( wrapper->getTypeId() );
-            std::string const xmlSafeName = std::regex_replace( wrappedTypeName, std::regex( "::" ), "_" );
+            string const wrappedTypeName = rtTypes::typeNames( wrapper->getTypeId() );
+            string const xmlSafeName = std::regex_replace( wrappedTypeName, std::regex( "::" ), "_" );
             GEOSX_LOG_VAR( wrappedTypeName );
             GEOSX_LOG_VAR( xmlSafeName );
             attributeNode.append_attribute( "type" ) = xmlSafeName.c_str();

--- a/src/coreComponents/fileIO/schema/schemaUtilities.hpp
+++ b/src/coreComponents/fileIO/schema/schemaUtilities.hpp
@@ -45,7 +45,7 @@ namespace schemaUtilities
  * @param group group passed in from which the schema information is extracted
  * @param documentationType type of XML schema generated
  */
-void ConvertDocumentationToSchema( std::string const & fname, dataRepository::Group * const group, integer documentationType );
+void ConvertDocumentationToSchema( string const & fname, dataRepository::Group * const group, integer documentationType );
 
 /**
  * @brief Generates the simple schema types.

--- a/src/coreComponents/fileIO/schema/schemaUtilities.hpp
+++ b/src/coreComponents/fileIO/schema/schemaUtilities.hpp
@@ -24,7 +24,7 @@
 #include "dataRepository/DefaultValue.hpp"
 #include <iostream>
 #include <sstream>
-#include <string>
+
 
 namespace geosx
 {

--- a/src/coreComponents/fileIO/silo/SiloFile.cpp
+++ b/src/coreComponents/fileIO/silo/SiloFile.cpp
@@ -34,7 +34,7 @@
 #include "mpiCommunications/MpiWrapper.hpp"
 
 #include <iostream>
-#include <string>
+
 #include <sstream>
 #include <algorithm>
 #include <iterator>

--- a/src/coreComponents/fileIO/silo/SiloFile.cpp
+++ b/src/coreComponents/fileIO/silo/SiloFile.cpp
@@ -1031,12 +1031,12 @@ void SiloFile::clearEmptiesFromMultiObjects( int const cycleNum )
 
   if( rank != 0 )
   {
-    for( std::string const & emptyObject : m_emptyVariables )
+    for( string const & emptyObject : m_emptyVariables )
     {
       sendbufferVars += emptyObject + ' ';
     }
 
-    for( std::string const & emptyObject : m_emptyMeshes )
+    for( string const & emptyObject : m_emptyMeshes )
     {
       sendbufferMesh += emptyObject + ' ';
     }
@@ -1114,7 +1114,7 @@ void SiloFile::clearEmptiesFromMultiObjects( int const cycleNum )
     DBfile *siloFile = DBOpen( baseFilePathAndName.c_str(), DB_UNKNOWN, DB_APPEND );
     string empty( "EMPTY" );
 
-    for( std::string const & emptyObject : m_emptyVariables )
+    for( string const & emptyObject : m_emptyVariables )
     {
       size_t pathBegin = emptyObject.find_first_of( '/', 1 );
       size_t pathEnd = emptyObject.find_last_of( '/' );
@@ -1160,7 +1160,7 @@ void SiloFile::clearEmptiesFromMultiObjects( int const cycleNum )
     }
 
 
-    for( std::string const & emptyObject : m_emptyMeshes )
+    for( string const & emptyObject : m_emptyMeshes )
     {
       size_t pathBegin = emptyObject.find_first_of( '/', 1 );
       size_t pathEnd = emptyObject.find_last_of( '/' );
@@ -1694,7 +1694,7 @@ void SiloFile::writeMeshLevel( MeshLevel const * const meshLevel,
     ArrayOfArraysView< localIndex const > const & faceToNodeMap = faceManager->nodeList().toViewConst();
 
     // face mesh
-    const std::string facemeshName( "face_mesh" );
+    const string facemeshName( "face_mesh" );
 
     if( writeArbitraryPolygon )
     {
@@ -1821,7 +1821,7 @@ void SiloFile::writeMeshLevel( MeshLevel const * const meshLevel,
     localIndex const numEdges = edgeManager->size();
 
 
-    const std::string edgeMeshName( "edge_mesh" );
+    const string edgeMeshName( "edge_mesh" );
 
     const int numEdgeTypes = 1;
     const int numNodesPerEdge = 2;
@@ -1891,7 +1891,7 @@ void SiloFile::writeMeshLevel( MeshLevel const * const meshLevel,
 }
 
 // Arbitrary polygon. Have to deal with this separately
-void SiloFile::writePolygonMeshObject( const std::string & meshName,
+void SiloFile::writePolygonMeshObject( const string & meshName,
                                        const localIndex nnodes,
                                        real64 * coords[3],
                                        const globalIndex *,
@@ -1911,7 +1911,7 @@ void SiloFile::writePolygonMeshObject( const std::string & meshName,
 
 
 //  DBfacelist* facelist;
-//  std::string facelistName;
+//  string facelistName;
 //  facelistName = meshName + "_facelist";
 
   DBoptlist * optlist = DBMakeOptlist( 4 );
@@ -1924,13 +1924,13 @@ void SiloFile::writePolygonMeshObject( const std::string & meshName,
   {
     char pwd[256];
     DBGetDir( m_dbFilePtr, pwd );
-    std::string emptyObject = pwd;
+    string emptyObject = pwd;
     emptyObject += "/" + meshName;
     m_emptyMeshes.emplace_back( emptyObject );
   }
   else
   {
-    std::string zonelistName;
+    string zonelistName;
     zonelistName = meshName + "_zonelist";
 
 

--- a/src/coreComponents/fileIO/silo/SiloFile.hpp
+++ b/src/coreComponents/fileIO/silo/SiloFile.hpp
@@ -189,7 +189,7 @@ public:
    * @param problemTime the current problem time
    * @param lnodelist
    */
-  void writePolygonMeshObject( const std::string & meshName,
+  void writePolygonMeshObject( const string & meshName,
                                const localIndex nnodes,
                                real64 * coords[3],
                                const globalIndex * dummy1,
@@ -683,9 +683,9 @@ private:
 
   string m_baseFileName;
 
-  std::vector< std::string > m_emptyMeshes;
+  std::vector< string > m_emptyMeshes;
 //  string_array m_emptyMaterials;
-  std::vector< std::string > m_emptyVariables;
+  std::vector< string > m_emptyVariables;
 
   integer m_writeEdgeMesh;
   integer m_writeFaceMesh;

--- a/src/coreComponents/fileIO/timeHistory/TimeHistHDF.hpp
+++ b/src/coreComponents/fileIO/timeHistory/TimeHistHDF.hpp
@@ -28,7 +28,7 @@
 #include "managers/TimeHistory/HistoryIO.hpp"
 #include <hdf5.h>
 
-#include <string>
+
 
 namespace geosx
 {

--- a/src/coreComponents/finiteElement/FiniteElementDiscretization.cpp
+++ b/src/coreComponents/finiteElement/FiniteElementDiscretization.cpp
@@ -34,7 +34,7 @@ using namespace dataRepository;
 using namespace finiteElement;
 
 
-FiniteElementDiscretization::FiniteElementDiscretization( std::string const & name, Group * const parent ):
+FiniteElementDiscretization::FiniteElementDiscretization( string const & name, Group * const parent ):
   Group( name, parent )
 {
   setInputFlags( InputFlags::OPTIONAL_NONUNIQUE );
@@ -104,6 +104,6 @@ FiniteElementDiscretization::factory( string const & parentElementShape ) const
   return rval;
 }
 
-REGISTER_CATALOG_ENTRY( Group, FiniteElementDiscretization, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( Group, FiniteElementDiscretization, string const &, Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/finiteElement/FiniteElementDiscretization.hpp
+++ b/src/coreComponents/finiteElement/FiniteElementDiscretization.hpp
@@ -54,7 +54,7 @@ public:
 
   FiniteElementDiscretization() = delete;
 
-  explicit FiniteElementDiscretization( std::string const & name, Group * const parent );
+  explicit FiniteElementDiscretization( string const & name, Group * const parent );
 
   ~FiniteElementDiscretization() override;
 

--- a/src/coreComponents/finiteVolume/FiniteVolumeManager.cpp
+++ b/src/coreComponents/finiteVolume/FiniteVolumeManager.cpp
@@ -71,22 +71,22 @@ void FiniteVolumeManager::expandObjectCatalogs()
 }
 
 
-FluxApproximationBase const & FiniteVolumeManager::getFluxApproximation( std::string const & name ) const
+FluxApproximationBase const & FiniteVolumeManager::getFluxApproximation( string const & name ) const
 {
   return getGroupReference< FluxApproximationBase >( name );
 }
 
-FluxApproximationBase & FiniteVolumeManager::getFluxApproximation( std::string const & name )
+FluxApproximationBase & FiniteVolumeManager::getFluxApproximation( string const & name )
 {
   return getGroupReference< FluxApproximationBase >( name );
 }
 
-HybridMimeticDiscretization const & FiniteVolumeManager::getHybridMimeticDiscretization( std::string const & name ) const
+HybridMimeticDiscretization const & FiniteVolumeManager::getHybridMimeticDiscretization( string const & name ) const
 {
   return getGroupReference< HybridMimeticDiscretization >( name );
 }
 
-HybridMimeticDiscretization & FiniteVolumeManager::getHybridMimeticDiscretization( std::string const & name )
+HybridMimeticDiscretization & FiniteVolumeManager::getHybridMimeticDiscretization( string const & name )
 {
   return getGroupReference< HybridMimeticDiscretization >( name );
 }

--- a/src/coreComponents/finiteVolume/HybridMimeticDiscretization.cpp
+++ b/src/coreComponents/finiteVolume/HybridMimeticDiscretization.cpp
@@ -33,7 +33,7 @@ namespace geosx
 using namespace dataRepository;
 using namespace mimeticInnerProduct;
 
-HybridMimeticDiscretization::HybridMimeticDiscretization( std::string const & name,
+HybridMimeticDiscretization::HybridMimeticDiscretization( string const & name,
                                                           Group * const parent )
   : Group( name, parent )
 {
@@ -116,6 +116,6 @@ HybridMimeticDiscretization::factory( string const & mimeticInnerProductType ) c
   return rval;
 }
 
-REGISTER_CATALOG_ENTRY( HybridMimeticDiscretization, HybridMimeticDiscretization, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( HybridMimeticDiscretization, HybridMimeticDiscretization, string const &, Group * const )
 
 }

--- a/src/coreComponents/finiteVolume/HybridMimeticDiscretization.hpp
+++ b/src/coreComponents/finiteVolume/HybridMimeticDiscretization.hpp
@@ -47,7 +47,7 @@ public:
    * @brief Static Factory Catalog Functions.
    * @return the catalog name
    */
-  static std::string catalogName() { return "HybridMimeticDiscretization"; }
+  static string catalogName() { return "HybridMimeticDiscretization"; }
 
   HybridMimeticDiscretization() = delete;
 
@@ -56,7 +56,7 @@ public:
    * @param name the name of the HybridMimeticDiscretization in the data repository
    * @param parent the parent group of this group.
    */
-  HybridMimeticDiscretization( std::string const & name, dataRepository::Group * const parent );
+  HybridMimeticDiscretization( string const & name, dataRepository::Group * const parent );
 
   /**
    * @brief View keys.

--- a/src/coreComponents/finiteVolume/TwoPointFluxApproximation.cpp
+++ b/src/coreComponents/finiteVolume/TwoPointFluxApproximation.cpp
@@ -35,7 +35,7 @@ namespace geosx
 
 using namespace dataRepository;
 
-TwoPointFluxApproximation::TwoPointFluxApproximation( std::string const & name,
+TwoPointFluxApproximation::TwoPointFluxApproximation( string const & name,
                                                       Group * const parent )
   : FluxApproximationBase( name, parent )
 {
@@ -903,6 +903,6 @@ void TwoPointFluxApproximation::computeBoundaryStencil( MeshLevel & mesh,
 }
 
 
-REGISTER_CATALOG_ENTRY( FluxApproximationBase, TwoPointFluxApproximation, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( FluxApproximationBase, TwoPointFluxApproximation, string const &, Group * const )
 
 }

--- a/src/coreComponents/finiteVolume/TwoPointFluxApproximation.hpp
+++ b/src/coreComponents/finiteVolume/TwoPointFluxApproximation.hpp
@@ -37,7 +37,7 @@ public:
    * @brief Static Factory Catalog Functions.
    * @return the catalog name
    */
-  static std::string catalogName() { return "TwoPointFluxApproximation"; }
+  static string catalogName() { return "TwoPointFluxApproximation"; }
 
   TwoPointFluxApproximation() = delete;
 
@@ -46,7 +46,7 @@ public:
    * @param name the name of the TwoPointFluxApproximation in the data repository
    * @param parent the parent group of this group.
    */
-  TwoPointFluxApproximation( std::string const & name, dataRepository::Group * const parent );
+  TwoPointFluxApproximation( string const & name, dataRepository::Group * const parent );
 
 protected:
 

--- a/src/coreComponents/linearAlgebra/DofManager.cpp
+++ b/src/coreComponents/linearAlgebra/DofManager.cpp
@@ -414,7 +414,7 @@ struct ConnLocPatternBuilder
 {
   static void build( MeshLevel * const mesh,
                      DofManager::FieldDescription const & field,
-                     std::vector< std::string > const & regions,
+                     std::vector< string > const & regions,
                      localIndex const rowOffset,
                      SparsityPattern< globalIndex > & connLocPattern )
   {
@@ -461,7 +461,7 @@ struct ConnLocPatternBuilder< DofManager::Location::Elem, DofManager::Location::
 {
   static void build( MeshLevel * const mesh,
                      DofManager::FieldDescription const & field,
-                     std::vector< std::string > const & regions,
+                     std::vector< string > const & regions,
                      localIndex const rowOffset,
                      SparsityPattern< globalIndex > & connLocPattern )
   {
@@ -503,7 +503,7 @@ struct ConnLocPatternBuilder< DofManager::Location::Elem, DofManager::Location::
 template< DofManager::Location LOC, DofManager::Location CONN >
 void makeConnLocPattern( MeshLevel * const mesh,
                          DofManager::FieldDescription const & field,
-                         std::vector< std::string > const & regions,
+                         std::vector< string > const & regions,
                          SparsityPattern< globalIndex > & connLocPattern )
 {
   using Loc = DofManager::Location;
@@ -1648,9 +1648,9 @@ void DofManager::addCoupling( string const & rowFieldName,
   }
 
   // get row/col field regions
-  std::vector< std::string > const & rowRegions = m_fields[rowFieldIndex].regions;
-  std::vector< std::string > const & colRegions = m_fields[colFieldIndex].regions;
-  std::vector< std::string > & regionList = m_coupling[rowFieldIndex][colFieldIndex].regions;
+  std::vector< string > const & rowRegions = m_fields[rowFieldIndex].regions;
+  std::vector< string > const & colRegions = m_fields[colFieldIndex].regions;
+  std::vector< string > & regionList = m_coupling[rowFieldIndex][colFieldIndex].regions;
 
   if( regions.empty() )
   {

--- a/src/coreComponents/linearAlgebra/DofManager.hpp
+++ b/src/coreComponents/linearAlgebra/DofManager.hpp
@@ -100,7 +100,7 @@ public:
   struct CouplingDescription
   {
     Connector connector = Connector::None;  //!< geometric object defining dof connections
-    std::vector< std::string > regions; //!< list of region names
+    std::vector< string > regions; //!< list of region names
     FluxApproximationBase const * stencils = nullptr; //!< pointer to flux stencils for stencil based connections
   };
 

--- a/src/coreComponents/linearAlgebra/DofManagerHelpers.hpp
+++ b/src/coreComponents/linearAlgebra/DofManagerHelpers.hpp
@@ -452,7 +452,7 @@ struct MeshLoopHelper< LOC, LOC, VISIT_GHOSTS >
 {
   template< typename ... SUBREGIONTYPES, typename LAMBDA >
   static void visit( MeshLevel * const meshLevel,
-                     std::vector< std::string > const & regions,
+                     std::vector< string > const & regions,
                      LAMBDA lambda )
   {
     // derive some useful type aliases
@@ -529,7 +529,7 @@ struct MeshLoopHelper
 {
   template< typename ... SUBREGIONTYPES, typename LAMBDA >
   static void visit( MeshLevel * const meshLevel,
-                     std::vector< std::string > const & regions,
+                     std::vector< string > const & regions,
                      LAMBDA lambda )
   {
     // derive some useful type aliases
@@ -571,7 +571,7 @@ struct MeshLoopHelper< LOC, DofManager::Location::Elem, VISIT_GHOSTS >
 {
   template< typename ... SUBREGIONTYPES, typename LAMBDA >
   static void visit( MeshLevel * const meshLevel,
-                     std::vector< std::string > const & regions,
+                     std::vector< string > const & regions,
                      LAMBDA lambda )
   {
     // derive some useful type aliases
@@ -624,7 +624,7 @@ struct MeshLoopHelper< DofManager::Location::Elem, CONN_LOC, VISIT_GHOSTS >
 {
   template< typename ... SUBREGIONTYPES, typename LAMBDA >
   static void visit( MeshLevel * const meshLevel,
-                     std::vector< std::string > const & regions,
+                     std::vector< string > const & regions,
                      LAMBDA lambda )
   {
     meshLevel->getElemManager()->
@@ -669,7 +669,7 @@ struct MeshLoopHelper< DofManager::Location::Elem, DofManager::Location::Elem, V
 {
   template< typename ... SUBREGIONTYPES, typename LAMBDA >
   static void visit( MeshLevel * const meshLevel,
-                     std::vector< std::string > const & regions,
+                     std::vector< string > const & regions,
                      LAMBDA && lambda )
   {
     meshLevel->getElemManager()->
@@ -719,7 +719,7 @@ struct MeshLoopHelper< DofManager::Location::Elem, DofManager::Location::Elem, V
 template< DofManager::Location LOC, DofManager::Location CONN_LOC, bool VISIT_GHOSTS,
           typename ... SUBREGIONTYPES, typename LAMBDA >
 void forMeshLocation( MeshLevel * const mesh,
-                      std::vector< std::string > const & regions,
+                      std::vector< string > const & regions,
                       LAMBDA && lambda )
 {
   MeshLoopHelper< LOC, CONN_LOC, VISIT_GHOSTS >::template visit< SUBREGIONTYPES... >( mesh,
@@ -733,7 +733,7 @@ void forMeshLocation( MeshLevel * const mesh,
 template< DofManager::Location LOC, bool VISIT_GHOSTS,
           typename ... SUBREGIONTYPES, typename LAMBDA >
 void forMeshLocation( MeshLevel * const mesh,
-                      std::vector< std::string > const & regions,
+                      std::vector< string > const & regions,
                       LAMBDA && lambda )
 {
   forMeshLocation< LOC, LOC, VISIT_GHOSTS, SUBREGIONTYPES... >( mesh,
@@ -757,7 +757,7 @@ void forMeshLocation( MeshLevel * const mesh,
  */
 template< DofManager::Location LOC, bool VISIT_GHOSTS, typename ... SUBREGIONTYPES >
 localIndex countMeshObjects( MeshLevel * const mesh,
-                             std::vector< std::string > const & regions )
+                             std::vector< string > const & regions )
 {
   localIndex count = 0;
   forMeshLocation< LOC, VISIT_GHOSTS, SUBREGIONTYPES... >( mesh, regions,
@@ -787,7 +787,7 @@ struct IndexArrayHelper
   create( Mesh * const mesh,
           string const & key,
           string const & description,
-          std::vector< std::string > const & GEOSX_UNUSED_PARAM( regions ) )
+          std::vector< string > const & GEOSX_UNUSED_PARAM( regions ) )
   {
     ObjectManagerBase & baseManager = getObjectManager< LOC >( mesh );
     baseManager.registerWrapper< ArrayType >( key )->
@@ -816,7 +816,7 @@ struct IndexArrayHelper
   static void
   remove( Mesh * const mesh,
           string const & key,
-          std::vector< std::string > const & GEOSX_UNUSED_PARAM( regions ) )
+          std::vector< string > const & GEOSX_UNUSED_PARAM( regions ) )
   {
     getObjectManager< LOC >( mesh ).deregisterWrapper( key );
   }
@@ -839,7 +839,7 @@ struct IndexArrayHelper< INDEX, DofManager::Location::Elem >
   create( Mesh * const mesh,
           string const & key,
           string const & description,
-          std::vector< std::string > const & regions )
+          std::vector< string > const & regions )
   {
     mesh->getElemManager()->template forElementSubRegions< SUBREGIONTYPES... >( regions,
                                                                                 [&]( localIndex const,
@@ -878,7 +878,7 @@ struct IndexArrayHelper< INDEX, DofManager::Location::Elem >
   static void
   remove( Mesh * const mesh,
           string const & key,
-          std::vector< std::string > const & regions )
+          std::vector< string > const & regions )
   {
     mesh->getElemManager()->template forElementSubRegions< SUBREGIONTYPES... >( regions,
                                                                                 [&]( localIndex const,

--- a/src/coreComponents/linearAlgebra/utilities/LAIHelperFunctions.hpp
+++ b/src/coreComponents/linearAlgebra/utilities/LAIHelperFunctions.hpp
@@ -162,7 +162,7 @@ void SeparateComponentFilter( MATRIX const & src,
 template< typename VECTOR >
 void ComputeRigidBodyModes( MeshLevel const & mesh,
                             DofManager const & dofManager,
-                            std::vector< std::string > const & selection,
+                            std::vector< string > const & selection,
                             array1d< VECTOR > & rigidBodyModes )
 {
   NodeManager const & nodeManager = *mesh.getNodeManager();

--- a/src/coreComponents/managers/DomainPartition.cpp
+++ b/src/coreComponents/managers/DomainPartition.cpp
@@ -32,7 +32,7 @@ namespace geosx
 {
 using namespace dataRepository;
 
-DomainPartition::DomainPartition( std::string const & name,
+DomainPartition::DomainPartition( string const & name,
                                   Group * const parent ):
   Group( name, parent )
 {
@@ -122,7 +122,7 @@ void DomainPartition::generateSets()
 
     auto const & elemToNodeMap = subRegion.nodeList();
 
-    for( std::string const & setName : setNames )
+    for( string const & setName : setNames )
     {
       arrayView1d< bool const > const nodeInCurSet = nodeInSet[setName];
 

--- a/src/coreComponents/managers/DomainPartition.hpp
+++ b/src/coreComponents/managers/DomainPartition.hpp
@@ -56,7 +56,7 @@ public:
    * @param[in] name Name of this object manager
    * @param[in] parent Parent Group
    */
-  DomainPartition( std::string const & name,
+  DomainPartition( string const & name,
                    Group * const parent );
 
   /**

--- a/src/coreComponents/managers/EventManager.cpp
+++ b/src/coreComponents/managers/EventManager.cpp
@@ -28,7 +28,7 @@ namespace geosx
 using namespace dataRepository;
 
 
-EventManager::EventManager( std::string const & name,
+EventManager::EventManager( string const & name,
                             Group * const parent ):
   Group( name, parent ),
   m_maxTime(),

--- a/src/coreComponents/managers/EventManager.hpp
+++ b/src/coreComponents/managers/EventManager.hpp
@@ -43,7 +43,7 @@ public:
    * @param[in] name the name of the EventManager
    * @param[in] parent group this EventManager
    */
-  EventManager( std::string const & name,
+  EventManager( string const & name,
                 Group * const parent );
 
   /**
@@ -102,7 +102,7 @@ public:
   ///@}
 
   /// Alias to access the object catalog for EventBase derived types.
-  using CatalogInterface = dataRepository::CatalogInterface< EventBase, std::string const &, Group * const >;
+  using CatalogInterface = dataRepository::CatalogInterface< EventBase, string const &, Group * const >;
 
   /// @copydoc dataRepository::Group::getCatalog()
   static CatalogInterface::CatalogType & getCatalog();

--- a/src/coreComponents/managers/Events/EventBase.cpp
+++ b/src/coreComponents/managers/Events/EventBase.cpp
@@ -28,7 +28,7 @@ namespace geosx
 using namespace dataRepository;
 
 
-EventBase::EventBase( const std::string & name,
+EventBase::EventBase( const string & name,
                       Group * const parent ):
   ExecutableGroup( name, parent ),
   m_lastTime( -1.0e100 ),

--- a/src/coreComponents/managers/Events/EventBase.hpp
+++ b/src/coreComponents/managers/Events/EventBase.hpp
@@ -39,7 +39,7 @@ public:
    * @param name The name of the object in the data repository.
    * @param parent The parent of this object in the data repository.
    **/
-  explicit EventBase( std::string const & name,
+  explicit EventBase( string const & name,
                       Group * const parent );
 
   /// Destructor
@@ -209,7 +209,7 @@ public:
   /// @endcond
 
   /// Catalog interface
-  using CatalogInterface = dataRepository::CatalogInterface< EventBase, std::string const &, Group * const >;
+  using CatalogInterface = dataRepository::CatalogInterface< EventBase, string const &, Group * const >;
   /// @copydoc dataRepository::Group::getCatalog()
   static CatalogInterface::CatalogType & getCatalog();
 

--- a/src/coreComponents/managers/Events/HaltEvent.cpp
+++ b/src/coreComponents/managers/Events/HaltEvent.cpp
@@ -25,7 +25,7 @@ namespace geosx
 using namespace dataRepository;
 
 
-HaltEvent::HaltEvent( const std::string & name,
+HaltEvent::HaltEvent( const string & name,
                       Group * const parent ):
   EventBase( name, parent ),
   m_externalStartTime( 0.0 ),
@@ -80,5 +80,5 @@ void HaltEvent::estimateEventTiming( real64 const GEOSX_UNUSED_PARAM( time ),
 }
 
 
-REGISTER_CATALOG_ENTRY( EventBase, HaltEvent, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( EventBase, HaltEvent, string const &, Group * const )
 } /* namespace geosx */

--- a/src/coreComponents/managers/Events/HaltEvent.hpp
+++ b/src/coreComponents/managers/Events/HaltEvent.hpp
@@ -38,7 +38,7 @@ public:
    * @param name The name of the object in the data repository.
    * @param parent The parent of this object in the data repository.
    **/
-  HaltEvent( const std::string & name,
+  HaltEvent( const string & name,
              Group * const parent );
 
   /// Destructor

--- a/src/coreComponents/managers/Events/PeriodicEvent.cpp
+++ b/src/coreComponents/managers/Events/PeriodicEvent.cpp
@@ -24,7 +24,7 @@ namespace geosx
 
 using namespace dataRepository;
 
-PeriodicEvent::PeriodicEvent( const std::string & name,
+PeriodicEvent::PeriodicEvent( const string & name,
                               Group * const parent ):
   EventBase( name, parent ),
   m_functionTarget( nullptr ),
@@ -233,6 +233,6 @@ void PeriodicEvent::cleanup( real64 const time_n,
   }
 }
 
-REGISTER_CATALOG_ENTRY( EventBase, PeriodicEvent, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( EventBase, PeriodicEvent, string const &, Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/managers/Events/PeriodicEvent.hpp
+++ b/src/coreComponents/managers/Events/PeriodicEvent.hpp
@@ -33,8 +33,8 @@ class PeriodicEvent : public EventBase
 {
 public:
 
-  /// @copydoc geosx::dataRepository::Group::Group( std::string const & name, Group * const parent )
-  PeriodicEvent( const std::string & name,
+  /// @copydoc geosx::dataRepository::Group::Group( string const & name, Group * const parent )
+  PeriodicEvent( const string & name,
                  Group * const parent );
 
   /// Destructor

--- a/src/coreComponents/managers/Events/SoloEvent.cpp
+++ b/src/coreComponents/managers/Events/SoloEvent.cpp
@@ -24,7 +24,7 @@ namespace geosx
 using namespace dataRepository;
 
 
-SoloEvent::SoloEvent( const std::string & name,
+SoloEvent::SoloEvent( const string & name,
                       Group * const parent ):
   EventBase( name, parent ),
   m_targetTime( -1.0 ),
@@ -107,5 +107,5 @@ real64 SoloEvent::getEventTypeDtRequest( real64 const time )
 
 
 
-REGISTER_CATALOG_ENTRY( EventBase, SoloEvent, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( EventBase, SoloEvent, string const &, Group * const )
 } /* namespace geosx */

--- a/src/coreComponents/managers/Events/SoloEvent.hpp
+++ b/src/coreComponents/managers/Events/SoloEvent.hpp
@@ -33,8 +33,8 @@ class SoloEvent : public EventBase
 {
 public:
 
-  /// @copydoc geosx::dataRepository::Group::Group( std::string const & name, Group * const parent )
-  SoloEvent( const std::string & name,
+  /// @copydoc geosx::dataRepository::Group::Group( string const & name, Group * const parent )
+  SoloEvent( const string & name,
              Group * const parent );
 
   /// Destructor

--- a/src/coreComponents/managers/FieldSpecification/DirichletBoundaryCondition.hpp
+++ b/src/coreComponents/managers/FieldSpecification/DirichletBoundaryCondition.hpp
@@ -31,7 +31,7 @@ namespace geosx
 class DirichletBoundaryCondition : public FieldSpecificationBase
 {
 public:
-  /// @copydoc geosx::dataRepository::Group::Group( std::string const & name, Group * const parent )
+  /// @copydoc geosx::dataRepository::Group::Group( string const & name, Group * const parent )
   DirichletBoundaryCondition( string const & name, dataRepository::Group * const parent );
 
   /**

--- a/src/coreComponents/managers/Functions/CompositeFunction.cpp
+++ b/src/coreComponents/managers/Functions/CompositeFunction.cpp
@@ -23,16 +23,16 @@ namespace dataRepository
 {
 namespace keys
 {
-std::string const functionNames = "functionNames";
-std::string const variableNames = "variableNames";
-std::string const expression = "expression";
+string const functionNames = "functionNames";
+string const variableNames = "variableNames";
+string const expression = "expression";
 }
 }
 
 using namespace dataRepository;
 
 
-CompositeFunction::CompositeFunction( const std::string & name,
+CompositeFunction::CompositeFunction( const string & name,
                                       Group * const parent ):
   FunctionBase( name, parent ),
   parserContext(),
@@ -119,6 +119,6 @@ real64 CompositeFunction::evaluate( real64 const * const input ) const
   return parserExpression.evaluate( reinterpret_cast< void * >( functionResults ));
 }
 
-REGISTER_CATALOG_ENTRY( FunctionBase, CompositeFunction, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( FunctionBase, CompositeFunction, string const &, Group * const )
 
 } // namespace geosx

--- a/src/coreComponents/managers/Functions/CompositeFunction.hpp
+++ b/src/coreComponents/managers/Functions/CompositeFunction.hpp
@@ -34,8 +34,8 @@ namespace geosx
 class CompositeFunction : public FunctionBase
 {
 public:
-  /// @copydoc geosx::dataRepository::Group::Group( std::string const & name, Group * const parent )
-  CompositeFunction( const std::string & name,
+  /// @copydoc geosx::dataRepository::Group::Group( string const & name, Group * const parent )
+  CompositeFunction( const string & name,
                      dataRepository::Group * const parent );
 
   /**

--- a/src/coreComponents/managers/Functions/FunctionBase.cpp
+++ b/src/coreComponents/managers/Functions/FunctionBase.cpp
@@ -26,7 +26,7 @@ using namespace dataRepository;
 
 
 
-FunctionBase::FunctionBase( const std::string & name,
+FunctionBase::FunctionBase( const string & name,
                             Group * const parent ):
   Group( name, parent ),
   m_inputVarNames()

--- a/src/coreComponents/managers/Functions/FunctionBase.hpp
+++ b/src/coreComponents/managers/Functions/FunctionBase.hpp
@@ -45,8 +45,8 @@ string const inputVarNames( "inputVarNames" );
 class FunctionBase : public dataRepository::Group
 {
 public:
-  /// @copydoc geosx::dataRepository::Group::Group( std::string const & name, Group * const parent )
-  FunctionBase( const std::string & name,
+  /// @copydoc geosx::dataRepository::Group::Group( string const & name, Group * const parent )
+  FunctionBase( const string & name,
                 dataRepository::Group * const parent );
 
   /**
@@ -94,7 +94,7 @@ public:
   virtual real64 evaluate( real64 const * const input ) const = 0;
 
   /// Alias for the catalog interface
-  using CatalogInterface = dataRepository::CatalogInterface< FunctionBase, std::string const &, Group * const >;
+  using CatalogInterface = dataRepository::CatalogInterface< FunctionBase, string const &, Group * const >;
 
   /**
    * @brief return the catalog entry for the function

--- a/src/coreComponents/managers/Functions/FunctionManager.cpp
+++ b/src/coreComponents/managers/Functions/FunctionManager.cpp
@@ -28,7 +28,7 @@ namespace geosx
 using namespace dataRepository;
 
 
-FunctionManager::FunctionManager( const std::string & name,
+FunctionManager::FunctionManager( const string & name,
                                   Group * const parent ):
   Group( name, parent )
 {

--- a/src/coreComponents/managers/Functions/FunctionManager.hpp
+++ b/src/coreComponents/managers/Functions/FunctionManager.hpp
@@ -33,8 +33,8 @@ namespace geosx
 class FunctionManager : public dataRepository::Group
 {
 public:
-  /// @copydoc geosx::dataRepository::Group::Group( std::string const & name, Group * const parent )
-  FunctionManager( const std::string & name,
+  /// @copydoc geosx::dataRepository::Group::Group( string const & name, Group * const parent )
+  FunctionManager( const string & name,
                    dataRepository::Group * const parent );
 
   /**

--- a/src/coreComponents/managers/Functions/SymbolicFunction.cpp
+++ b/src/coreComponents/managers/Functions/SymbolicFunction.cpp
@@ -26,14 +26,14 @@ namespace dataRepository
 {
 namespace keys
 {
-std::string const variableNames = "variableNames";
-std::string const expression = "expression";
+string const variableNames = "variableNames";
+string const expression = "expression";
 }
 }
 
 using namespace dataRepository;
 
-SymbolicFunction::SymbolicFunction( const std::string & name,
+SymbolicFunction::SymbolicFunction( const string & name,
                                     Group * const parent ):
   FunctionBase( name, parent ),
   parserContext(),
@@ -69,6 +69,6 @@ void SymbolicFunction::initializeFunction()
   GEOSX_ERROR_IF( err != mathpresso::kErrorOk, "JIT Compiler Error" );
 }
 
-REGISTER_CATALOG_ENTRY( FunctionBase, SymbolicFunction, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( FunctionBase, SymbolicFunction, string const &, Group * const )
 
 } /* namespace ANST */

--- a/src/coreComponents/managers/Functions/SymbolicFunction.hpp
+++ b/src/coreComponents/managers/Functions/SymbolicFunction.hpp
@@ -29,8 +29,8 @@ namespace geosx
 class SymbolicFunction : public FunctionBase
 {
 public:
-  /// @copydoc geosx::dataRepository::Group::Group( std::string const & name, Group * const parent )
-  SymbolicFunction( const std::string & name,
+  /// @copydoc geosx::dataRepository::Group::Group( string const & name, Group * const parent )
+  SymbolicFunction( const string & name,
                     dataRepository::Group * const parent );
 
   /**

--- a/src/coreComponents/managers/Functions/TableFunction.cpp
+++ b/src/coreComponents/managers/Functions/TableFunction.cpp
@@ -27,12 +27,12 @@ namespace dataRepository
 {
 namespace keys
 {
-std::string const tableCoordinates = "coordinates";
-std::string const tableValues = "values";
-std::string const tableInterpolation = "interpolation";
-std::string const coordinateFiles = "coordinateFiles";
-std::string const voxelFile = "voxelFile";
-std::string const valueType = "valueType";
+string const tableCoordinates = "coordinates";
+string const tableValues = "values";
+string const tableInterpolation = "interpolation";
+string const coordinateFiles = "coordinateFiles";
+string const voxelFile = "voxelFile";
+string const valueType = "valueType";
 }
 }
 
@@ -40,7 +40,7 @@ using namespace dataRepository;
 
 
 
-TableFunction::TableFunction( const std::string & name,
+TableFunction::TableFunction( const string & name,
                               Group * const parent ):
   FunctionBase( name, parent ),
   m_tableCoordinates1D(),
@@ -85,7 +85,7 @@ template< typename T >
 void TableFunction::parseFile( array1d< T > & target, string const & filename, char delimiter )
 {
   std::ifstream inputStream( filename.c_str());
-  std::string lineString;
+  string lineString;
   T value;
 
   GEOSX_ERROR_IF( !inputStream, "Could not read input file: " << filename );
@@ -302,6 +302,6 @@ real64 TableFunction::evaluate( real64 const * const input ) const
   return result;
 }
 
-REGISTER_CATALOG_ENTRY( FunctionBase, TableFunction, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( FunctionBase, TableFunction, string const &, Group * const )
 
 } /* namespace ANST */

--- a/src/coreComponents/managers/Functions/TableFunction.hpp
+++ b/src/coreComponents/managers/Functions/TableFunction.hpp
@@ -38,7 +38,7 @@ public:
    * @param[in] name the name of this object manager
    * @param[in] parent the parent Group
    */
-  TableFunction( const std::string & name,
+  TableFunction( const string & name,
                  dataRepository::Group * const parent );
 
   /**

--- a/src/coreComponents/managers/ObjectManagerBase.cpp
+++ b/src/coreComponents/managers/ObjectManagerBase.cpp
@@ -26,7 +26,7 @@ namespace geosx
 {
 using namespace dataRepository;
 
-ObjectManagerBase::ObjectManagerBase( std::string const & name,
+ObjectManagerBase::ObjectManagerBase( string const & name,
                                       Group * const parent ):
   Group( name, parent ),
   m_sets( groupKeyStruct::setsString, this ),
@@ -69,14 +69,14 @@ ObjectManagerBase::CatalogInterface::CatalogType & ObjectManagerBase::getCatalog
   return catalog;
 }
 
-void ObjectManagerBase::createSet( const std::string & newSetName )
+void ObjectManagerBase::createSet( const string & newSetName )
 {
   m_sets.registerWrapper< SortedArray< localIndex > >( newSetName );
 }
 
 void ObjectManagerBase::constructSetFromSetAndMap( SortedArrayView< localIndex const > const & inputSet,
                                                    const array2d< localIndex > & map,
-                                                   const std::string & setName )
+                                                   const string & setName )
 {
   SortedArray< localIndex > & newset = m_sets.getReference< SortedArray< localIndex > >( setName );
   newset.clear();
@@ -108,7 +108,7 @@ void ObjectManagerBase::constructSetFromSetAndMap( SortedArrayView< localIndex c
 
 void ObjectManagerBase::constructSetFromSetAndMap( SortedArrayView< localIndex const > const & inputSet,
                                                    const array1d< localIndex_array > & map,
-                                                   const std::string & setName )
+                                                   const string & setName )
 {
   SortedArray< localIndex > & newset = m_sets.getReference< SortedArray< localIndex > >( setName );
   newset.clear();
@@ -139,7 +139,7 @@ void ObjectManagerBase::constructSetFromSetAndMap( SortedArrayView< localIndex c
 
 void ObjectManagerBase::constructSetFromSetAndMap( SortedArrayView< localIndex const > const & inputSet,
                                                    ArrayOfArraysView< localIndex const > const & map,
-                                                   const std::string & setName )
+                                                   const string & setName )
 {
   SortedArray< localIndex > & newset = m_sets.getReference< SortedArray< localIndex > >( setName );
   newset.clear();

--- a/src/coreComponents/managers/ObjectManagerBase.hpp
+++ b/src/coreComponents/managers/ObjectManagerBase.hpp
@@ -40,7 +40,7 @@ public:
    * @param[in] name Name of this object manager
    * @param[in] parent Parent Group
    */
-  explicit ObjectManagerBase( std::string const & name,
+  explicit ObjectManagerBase( string const & name,
                               dataRepository::Group * const parent );
 
   /**
@@ -54,9 +54,9 @@ public:
   ///@{
   /**
    * @brief Nested type for the `factory` pattern, defining the base class (ObjectManagerBase)
-   *        and the builder arguments (std::string const &, dataRepository::Group * const) of the derived products.
+   *        and the builder arguments (string const &, dataRepository::Group * const) of the derived products.
    */
-  using CatalogInterface = dataRepository::CatalogInterface< ObjectManagerBase, std::string const &, dataRepository::Group * const >;
+  using CatalogInterface = dataRepository::CatalogInterface< ObjectManagerBase, string const &, dataRepository::Group * const >;
 
   /**
    * @brief Acessing the unique instance of this catalog.
@@ -304,7 +304,7 @@ public:
    * @brief Creates a new set.
    * @param newSetName The set name.
    */
-  void createSet( const std::string & newSetName );
+  void createSet( const string & newSetName );
 
   /**
    * @brief Builds a new set on this instance given another objects set and the map between them.
@@ -314,7 +314,7 @@ public:
    */
   void constructSetFromSetAndMap( SortedArrayView< localIndex const > const & inputSet,
                                   const array2d< localIndex > & map,
-                                  const std::string & setName );
+                                  const string & setName );
   /**
    * @brief Builds a new set on this instance given another objects set and the map between them.
    * @param inputSet The input set.
@@ -323,7 +323,7 @@ public:
    */
   void constructSetFromSetAndMap( SortedArrayView< localIndex const > const & inputSet,
                                   const array1d< localIndex_array > & map,
-                                  const std::string & setName );
+                                  const string & setName );
   /**
    * @brief Builds a new set on this instance given another objects set and the map between them.
    * @param inputSet The input set.
@@ -332,7 +332,7 @@ public:
    */
   void constructSetFromSetAndMap( SortedArrayView< localIndex const > const & inputSet,
                                   ArrayOfArraysView< localIndex const > const & map,
-                                  const std::string & setName );
+                                  const string & setName );
 
   /**
    * @brief Constructs the global to local map.
@@ -885,7 +885,7 @@ public:
    */
   void addNeighbor( int const rank )
   {
-    std::string const & rankString = std::to_string( rank );
+    string const & rankString = std::to_string( rank );
     m_neighborData.emplace( std::piecewise_construct, std::make_tuple( rank ), std::make_tuple( rankString, &m_neighborGroup ) );
     m_neighborGroup.registerGroup( rankString, &getNeighborData( rank ) );
   }

--- a/src/coreComponents/managers/Outputs/BlueprintOutput.cpp
+++ b/src/coreComponents/managers/Outputs/BlueprintOutput.cpp
@@ -38,9 +38,9 @@ namespace internal
  * @brief @return The Blueprint shape from the GEOSX element type string.
  * @param elementType the elementType to look up.
  */
-std::string toBlueprintShape( std::string const & elementType )
+string toBlueprintShape( string const & elementType )
 {
-  static std::unordered_map< std::string, std::string > const map =
+  static std::unordered_map< string, string > const map =
   {
     { "C3D8", "hex" },
     { "C3D4", "tet" }
@@ -84,7 +84,7 @@ void reorderElementToNodeMap( CellElementSubRegion const & subRegion, conduit::N
 } /// namespace internal;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-BlueprintOutput::BlueprintOutput( std::string const & name,
+BlueprintOutput::BlueprintOutput( string const & name,
                                   dataRepository::Group * const parent ):
   OutputBase( name, parent )
 {
@@ -147,7 +147,7 @@ void BlueprintOutput::execute( real64 const time,
   /// Write out the root index file, then write out the mesh.
   char buffer[ 128 ];
   GEOSX_ERROR_IF_GE( snprintf( buffer, 128, "blueprintFiles/cycle_%07d", cycle ), 128 );
-  std::string const filePathForRank = dataRepository::writeRootFile( fileRoot, buffer );
+  string const filePathForRank = dataRepository::writeRootFile( fileRoot, buffer );
   conduit::relay::io::save( meshRoot, filePathForRank, "hdf5" );
 }
 
@@ -166,7 +166,7 @@ void BlueprintOutput::addNodalData( NodeManager const & nodeManager,
                                                    { "x", "y", "z" } );
 
   /// Create the points topology
-  std::string const coordsetName = coordset.name();
+  string const coordsetName = coordset.name();
   conduit::Node & nodeTopology = topologies[ coordsetName ];
   nodeTopology[ "coordset" ] = coordsetName;
 
@@ -205,7 +205,7 @@ void BlueprintOutput::addElementData( ElementRegionManager const & elemRegionMan
   elemRegionManager.forElementSubRegionsComplete< CellElementSubRegion >(
     [&] ( localIndex, localIndex, ElementRegionBase const & region, CellElementSubRegion const & subRegion )
   {
-    std::string const topologyName = region.getName() + "-" + subRegion.getName();
+    string const topologyName = region.getName() + "-" + subRegion.getName();
 
     /// Create the topology representing the sub-region.
     conduit::Node & topology = topologies[ topologyName ];
@@ -234,8 +234,8 @@ void BlueprintOutput::addElementData( ElementRegionManager const & elemRegionMan
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 void BlueprintOutput::writeOutWrappersAsFields( Group const & group,
                                                 conduit::Node & fields,
-                                                std::string const & topology,
-                                                std::string const & prefix )
+                                                string const & topology,
+                                                string const & prefix )
 {
   GEOSX_MARK_FUNCTION;
 
@@ -243,7 +243,7 @@ void BlueprintOutput::writeOutWrappersAsFields( Group const & group,
   {
     if( wrapper.getPlotLevel() <= m_plotLevel && wrapper.sizedFromParent() )
     {
-      std::string const name = prefix.empty() ? wrapper.getName() : prefix + "-" + wrapper.getName();
+      string const name = prefix.empty() ? wrapper.getName() : prefix + "-" + wrapper.getName();
 
       // conduit::Node & field = fields[ name ];
       // field[ "association" ] = "element";
@@ -260,7 +260,7 @@ void BlueprintOutput::writeOutWrappersAsFields( Group const & group,
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 void BlueprintOutput::writeOutConstitutiveData( dataRepository::Group const & constitutiveModel,
                                                 conduit::Node & fields,
-                                                std::string const & topology,
+                                                string const & topology,
                                                 dataRepository::Group & averagedSubRegionData )
 {
   GEOSX_MARK_FUNCTION;
@@ -271,7 +271,7 @@ void BlueprintOutput::writeOutConstitutiveData( dataRepository::Group const & co
   {
     if( wrapper.getPlotLevel() <= m_plotLevel && wrapper.sizedFromParent() )
     {
-      std::string const fieldName = constitutiveModel.getName() + "-quadrature-averaged-" + wrapper.getName();
+      string const fieldName = constitutiveModel.getName() + "-quadrature-averaged-" + wrapper.getName();
       averagedConstitutiveData.registerWrapper( fieldName, wrapper.averageOverSecondDim( fieldName, averagedConstitutiveData ) )
         ->addBlueprintField( fields, fieldName, topology );
     }
@@ -280,6 +280,6 @@ void BlueprintOutput::writeOutConstitutiveData( dataRepository::Group const & co
 
 
 
-REGISTER_CATALOG_ENTRY( OutputBase, BlueprintOutput, std::string const &, dataRepository::Group * const )
+REGISTER_CATALOG_ENTRY( OutputBase, BlueprintOutput, string const &, dataRepository::Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/managers/Outputs/BlueprintOutput.hpp
+++ b/src/coreComponents/managers/Outputs/BlueprintOutput.hpp
@@ -42,7 +42,7 @@ public:
    * @param name The name of the BlueprintObject in the data repository.
    * @param parent The parent Group.
    */
-  BlueprintOutput( std::string const & name,
+  BlueprintOutput( string const & name,
                    Group * const parent );
 
   /**
@@ -115,12 +115,12 @@ private:
    */
   void writeOutWrappersAsFields( Group const & group,
                                  conduit::Node & fields,
-                                 std::string const & topology,
-                                 std::string const & prefix="" );
+                                 string const & topology,
+                                 string const & prefix="" );
 
   void writeOutConstitutiveData( dataRepository::Group const & constitutiveModel,
                                  conduit::Node & fields,
-                                 std::string const & topology,
+                                 string const & topology,
                                  dataRepository::Group & averagedElementData );
 
   /// Used to determine which fields to write out.

--- a/src/coreComponents/managers/Outputs/ChomboIO.cpp
+++ b/src/coreComponents/managers/Outputs/ChomboIO.cpp
@@ -29,7 +29,7 @@ namespace geosx
 
 using namespace dataRepository;
 
-ChomboIO::ChomboIO( std::string const & name, Group * const parent ):
+ChomboIO::ChomboIO( string const & name, Group * const parent ):
   OutputBase( name, parent ),
   m_coupler( nullptr ),
   m_outputPath(),
@@ -97,5 +97,5 @@ void ChomboIO::execute( real64 const GEOSX_UNUSED_PARAM( time_n ),
   }
 }
 
-REGISTER_CATALOG_ENTRY( OutputBase, ChomboIO, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( OutputBase, ChomboIO, string const &, Group * const )
 } /* namespace geosx */

--- a/src/coreComponents/managers/Outputs/ChomboIO.cpp
+++ b/src/coreComponents/managers/Outputs/ChomboIO.cpp
@@ -20,7 +20,7 @@
 #include "mesh/MeshLevel.hpp"
 #include "managers/DomainPartition.hpp"
 #include "fileIO/coupling/ChomboCoupler.hpp"
-#include <string>
+
 #include <fstream>
 #include <chrono>
 

--- a/src/coreComponents/managers/Outputs/ChomboIO.hpp
+++ b/src/coreComponents/managers/Outputs/ChomboIO.hpp
@@ -33,8 +33,8 @@ namespace geosx
 class ChomboIO final : public OutputBase
 {
 public:
-  /// @copydoc geosx::dataRepository::Group::Group( std::string const & name, Group * const parent )
-  ChomboIO( std::string const & name, Group * const parent );
+  /// @copydoc geosx::dataRepository::Group::Group( string const & name, Group * const parent )
+  ChomboIO( string const & name, Group * const parent );
 
   /// Destructor
   virtual ~ChomboIO() override;
@@ -90,9 +90,9 @@ public:
 
 private:
   ChomboCoupler * m_coupler;
-  std::string m_outputPath;
+  string m_outputPath;
   double m_beginCycle;
-  std::string m_inputPath;
+  string m_inputPath;
   integer m_waitForInput;
   integer m_useChomboPressures;
 };

--- a/src/coreComponents/managers/Outputs/OutputBase.cpp
+++ b/src/coreComponents/managers/Outputs/OutputBase.cpp
@@ -25,7 +25,7 @@ namespace geosx
 
 using namespace dataRepository;
 
-OutputBase::OutputBase( std::string const & name,
+OutputBase::OutputBase( string const & name,
                         Group * const parent ):
   ExecutableGroup( name, parent ),
   m_childDirectory(),

--- a/src/coreComponents/managers/Outputs/OutputBase.hpp
+++ b/src/coreComponents/managers/Outputs/OutputBase.hpp
@@ -33,8 +33,8 @@ namespace geosx
 class OutputBase : public ExecutableGroup
 {
 public:
-  /// @copydoc geosx::dataRepository::Group::Group( std::string const & name, Group * const parent )
-  explicit OutputBase( std::string const & name, Group * const parent );
+  /// @copydoc geosx::dataRepository::Group::Group( string const & name, Group * const parent )
+  explicit OutputBase( string const & name, Group * const parent );
 
   /// Destructor
   virtual ~OutputBase() override;
@@ -50,7 +50,7 @@ public:
 
   // Catalog interface
   /// @cond DO_NOT_DOCUMENT
-  using CatalogInterface = dataRepository::CatalogInterface< OutputBase, std::string const &, Group * const >;
+  using CatalogInterface = dataRepository::CatalogInterface< OutputBase, string const &, Group * const >;
   static CatalogInterface::CatalogType & getCatalog();
 
   // Catalog view keys

--- a/src/coreComponents/managers/Outputs/OutputManager.cpp
+++ b/src/coreComponents/managers/Outputs/OutputManager.cpp
@@ -24,7 +24,7 @@ namespace geosx
 
 using namespace dataRepository;
 
-OutputManager::OutputManager( std::string const & name,
+OutputManager::OutputManager( string const & name,
                               Group * const parent ):
   Group( name, parent )
 {

--- a/src/coreComponents/managers/Outputs/OutputManager.hpp
+++ b/src/coreComponents/managers/Outputs/OutputManager.hpp
@@ -38,8 +38,8 @@ namespace keys
 class OutputManager : public dataRepository::Group
 {
 public:
-  /// @copydoc geosx::dataRepository::Group::Group( std::string const & name, Group * const parent )
-  OutputManager( std::string const & name,
+  /// @copydoc geosx::dataRepository::Group::Group( string const & name, Group * const parent )
+  OutputManager( string const & name,
                  Group * const parent );
 
   /// Destructor

--- a/src/coreComponents/managers/Outputs/RestartOutput.cpp
+++ b/src/coreComponents/managers/Outputs/RestartOutput.cpp
@@ -29,7 +29,7 @@ namespace geosx
 
 using namespace dataRepository;
 
-RestartOutput::RestartOutput( std::string const & name,
+RestartOutput::RestartOutput( string const & name,
                               Group * const parent ):
   OutputBase( name, parent )
 {}
@@ -64,5 +64,5 @@ void RestartOutput::execute( real64 const GEOSX_UNUSED_PARAM( time_n ),
 }
 
 
-REGISTER_CATALOG_ENTRY( OutputBase, RestartOutput, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( OutputBase, RestartOutput, string const &, Group * const )
 } /* namespace geosx */

--- a/src/coreComponents/managers/Outputs/RestartOutput.hpp
+++ b/src/coreComponents/managers/Outputs/RestartOutput.hpp
@@ -34,8 +34,8 @@ namespace geosx
 class RestartOutput : public OutputBase
 {
 public:
-  /// @copydoc geosx::dataRepository::Group::Group(std::string const & name, Group * const parent)
-  RestartOutput( std::string const & name,
+  /// @copydoc geosx::dataRepository::Group::Group(string const & name, Group * const parent)
+  RestartOutput( string const & name,
                  Group * const parent );
 
   /// Destructor

--- a/src/coreComponents/managers/Outputs/SiloOutput.cpp
+++ b/src/coreComponents/managers/Outputs/SiloOutput.cpp
@@ -28,7 +28,7 @@ namespace geosx
 
 using namespace dataRepository;
 
-SiloOutput::SiloOutput( std::string const & name,
+SiloOutput::SiloOutput( string const & name,
                         Group * const parent ):
   OutputBase( name, parent ),
   m_plotFileRoot( "plot" ),
@@ -109,5 +109,5 @@ void SiloOutput::execute( real64 const time_n,
 }
 
 
-REGISTER_CATALOG_ENTRY( OutputBase, SiloOutput, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( OutputBase, SiloOutput, string const &, Group * const )
 } /* namespace geosx */

--- a/src/coreComponents/managers/Outputs/SiloOutput.hpp
+++ b/src/coreComponents/managers/Outputs/SiloOutput.hpp
@@ -33,8 +33,8 @@ namespace geosx
 class SiloOutput : public OutputBase
 {
 public:
-  /// @copydoc geosx::dataRepository::Group::Group(std::string const & name, Group * const parent)
-  SiloOutput( std::string const & name,
+  /// @copydoc geosx::dataRepository::Group::Group(string const & name, Group * const parent)
+  SiloOutput( string const & name,
               Group * const parent );
 
   /// Destructor

--- a/src/coreComponents/managers/Outputs/TimeHistoryOutput.cpp
+++ b/src/coreComponents/managers/Outputs/TimeHistoryOutput.cpp
@@ -126,5 +126,5 @@ void TimeHistoryOutput::cleanup( real64 const time_n,
   }
 }
 
-REGISTER_CATALOG_ENTRY( OutputBase, TimeHistoryOutput, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( OutputBase, TimeHistoryOutput, string const &, Group * const )
 }

--- a/src/coreComponents/managers/Outputs/TimeHistoryOutput.hpp
+++ b/src/coreComponents/managers/Outputs/TimeHistoryOutput.hpp
@@ -37,7 +37,7 @@ namespace geosx
 class TimeHistoryOutput : public OutputBase
 {
 public:
-  /// @copydoc geosx::dataRepository::Group::Group(std::string const & name, Group * const parent)
+  /// @copydoc geosx::dataRepository::Group::Group(string const & name, Group * const parent)
   TimeHistoryOutput( string const & name,
                      Group * const parent );
 

--- a/src/coreComponents/managers/Outputs/VTKOutput.cpp
+++ b/src/coreComponents/managers/Outputs/VTKOutput.cpp
@@ -24,7 +24,7 @@ namespace geosx
 
 using namespace dataRepository;
 
-VTKOutput::VTKOutput( std::string const & name,
+VTKOutput::VTKOutput( string const & name,
                       Group * const parent ):
   OutputBase( name, parent ),
   m_plotFileRoot(),
@@ -78,5 +78,5 @@ void VTKOutput::execute( real64 const time_n,
 }
 
 
-REGISTER_CATALOG_ENTRY( OutputBase, VTKOutput, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( OutputBase, VTKOutput, string const &, Group * const )
 } /* namespace geosx */

--- a/src/coreComponents/managers/Outputs/VTKOutput.hpp
+++ b/src/coreComponents/managers/Outputs/VTKOutput.hpp
@@ -34,9 +34,9 @@ namespace geosx
 class VTKOutput : public OutputBase
 {
 public:
-  /// @copydoc geosx::dataRepository::Group::Group(std::string const & name, Group * const parent)
+  /// @copydoc geosx::dataRepository::Group::Group(string const & name, Group * const parent)
 
-  VTKOutput( std::string const & name, Group * const parent );
+  VTKOutput( string const & name, Group * const parent );
 
   /// Destructor
   virtual ~VTKOutput() override;

--- a/src/coreComponents/managers/ProblemManager.cpp
+++ b/src/coreComponents/managers/ProblemManager.cpp
@@ -56,7 +56,7 @@ class CellElementSubRegion;
 class FaceElementSubRegion;
 
 
-ProblemManager::ProblemManager( const std::string & name,
+ProblemManager::ProblemManager( const string & name,
                                 Group * const parent ):
   dataRepository::Group( name, parent ),
   m_physicsSolverManager( nullptr ),
@@ -181,7 +181,7 @@ void ProblemManager::parseCommandLineInput()
 
   CommandLineOptions const & opts = getCommandLineOptions();
 
-  commandLine->getReference< std::string >( viewKeys.restartFileName ) = opts.restartFileName;
+  commandLine->getReference< string >( viewKeys.restartFileName ) = opts.restartFileName;
   commandLine->getReference< integer >( viewKeys.beginFromRestart ) = opts.beginFromRestart;
   commandLine->getReference< integer >( viewKeys.xPartitionsOverride ) = opts.xPartitionsOverride;
   commandLine->getReference< integer >( viewKeys.yPartitionsOverride ) = opts.yPartitionsOverride;
@@ -190,16 +190,16 @@ void ProblemManager::parseCommandLineInput()
   commandLine->getReference< integer >( viewKeys.useNonblockingMPI ) = opts.useNonblockingMPI;
   commandLine->getReference< integer >( viewKeys.suppressPinned ) = opts.suppressPinned;
 
-  std::string & inputFileName = commandLine->getReference< std::string >( viewKeys.inputFileName );
+  string & inputFileName = commandLine->getReference< string >( viewKeys.inputFileName );
   inputFileName = opts.inputFileName;
 
-  std::string & schemaName = commandLine->getReference< std::string >( viewKeys.schemaFileName );
+  string & schemaName = commandLine->getReference< string >( viewKeys.schemaFileName );
   schemaName = opts.schemaName;
 
-  std::string & problemName = commandLine->getReference< std::string >( viewKeys.problemName );
+  string & problemName = commandLine->getReference< string >( viewKeys.problemName );
   problemName = opts.problemName;
 
-  std::string & outputDirectory = commandLine->getReference< std::string >( viewKeys.outputDirectory );
+  string & outputDirectory = commandLine->getReference< string >( viewKeys.outputDirectory );
   outputDirectory = opts.outputDirectory;
 
   if( schemaName.empty())
@@ -227,7 +227,7 @@ void ProblemManager::parseCommandLineInput()
 }
 
 
-bool ProblemManager::parseRestart( std::string & restartFileName )
+bool ProblemManager::parseRestart( string & restartFileName )
 {
   CommandLineOptions const & opts = getCommandLineOptions();
   bool const beginFromRestart = opts.beginFromRestart;
@@ -235,21 +235,21 @@ bool ProblemManager::parseRestart( std::string & restartFileName )
 
   if( beginFromRestart == 1 )
   {
-    std::string dirname;
-    std::string basename;
+    string dirname;
+    string basename;
     splitPath( restartFileName, dirname, basename );
 
-    std::vector< std::string > dir_contents;
+    std::vector< string > dir_contents;
     readDirectory( dirname, dir_contents );
 
     GEOSX_ERROR_IF( dir_contents.size() == 0, "Directory gotten from " << restartFileName << " " << dirname << " is empty." );
 
     std::regex basename_regex( basename );
 
-    std::string min_str( "" );
-    std::string & max_match = min_str;
+    string min_str( "" );
+    string & max_match = min_str;
     bool match_found = false;
-    for( std::string & s : dir_contents )
+    for( string & s : dir_contents )
     {
       if( std::regex_match( s, basename_regex ))
       {
@@ -311,7 +311,7 @@ void ProblemManager::generateDocumentation()
   // Documentation output
   std::cout << "Trying to generate schema..." << std::endl;
   Group * commandLine = getGroup< Group >( groupKeys.commandLine );
-  std::string const & schemaName = commandLine->getReference< std::string >( viewKeys.schemaFileName );
+  string const & schemaName = commandLine->getReference< string >( viewKeys.schemaFileName );
 
   if( !schemaName.empty() )
   {
@@ -389,7 +389,7 @@ void ProblemManager::setSchemaDeviations( xmlWrapper::xmlNode schemaRoot,
   Group * benchmarks = this->registerGroup< Group >( "Benchmarks" );
   benchmarks->setInputFlags( InputFlags::OPTIONAL );
 
-  for( std::string const & machineName : {"quartz", "lassen"} )
+  for( string const & machineName : {"quartz", "lassen"} )
   {
     Group * machine = benchmarks->registerGroup< Group >( machineName );
     machine->setInputFlags( InputFlags::OPTIONAL );
@@ -397,7 +397,7 @@ void ProblemManager::setSchemaDeviations( xmlWrapper::xmlNode schemaRoot,
     Group * run = machine->registerGroup< Group >( "Run" );
     run->setInputFlags( InputFlags::OPTIONAL );
 
-    run->registerWrapper< std::string >( "name" )->setInputFlag( InputFlags::REQUIRED )->
+    run->registerWrapper< string >( "name" )->setInputFlag( InputFlags::REQUIRED )->
       setDescription( "The name of this benchmark." );
 
     run->registerWrapper< int >( "nodes" )->setInputFlag( InputFlags::REQUIRED )->
@@ -412,10 +412,10 @@ void ProblemManager::setSchemaDeviations( xmlWrapper::xmlNode schemaRoot,
     run->registerWrapper< int >( "timeLimit" )->setInputFlag( InputFlags::OPTIONAL )->
       setDescription( "The time limit of the benchmark." );
 
-    run->registerWrapper< std::string >( "args" )->setInputFlag( InputFlags::OPTIONAL )->
+    run->registerWrapper< string >( "args" )->setInputFlag( InputFlags::OPTIONAL )->
       setDescription( "Any extra command line arguments to pass to GEOSX." );
 
-    run->registerWrapper< std::string >( "autoPartition" )->setInputFlag( InputFlags::OPTIONAL )->
+    run->registerWrapper< string >( "autoPartition" )->setInputFlag( InputFlags::OPTIONAL )->
       setDescription( "May be 'Off' or 'On', if 'On' partitioning arguments are created automatically. Default is Off." );
 
     run->registerWrapper< array1d< int > >( "strongScaling" )->setInputFlag( InputFlags::OPTIONAL )->
@@ -431,7 +431,7 @@ void ProblemManager::parseInputFile()
   DomainPartition * domain  = getDomainPartition();
 
   Group * commandLine = getGroup< Group >( groupKeys.commandLine );
-  std::string const & inputFileName = commandLine->getReference< std::string >( viewKeys.inputFileName );
+  string const & inputFileName = commandLine->getReference< string >( viewKeys.inputFileName );
 
 
 #ifdef GEOSX_USE_PYTHON

--- a/src/coreComponents/managers/ProblemManager.hpp
+++ b/src/coreComponents/managers/ProblemManager.hpp
@@ -53,7 +53,7 @@ public:
    * @param name the name of this object manager
    * @param parent the parent Group
    */
-  explicit ProblemManager( const std::string & name,
+  explicit ProblemManager( const string & name,
                            Group * const parent );
 
   /**
@@ -95,7 +95,7 @@ public:
    * @param restartFileName the name of the restart file
    * @return flag indicating beginFromRestart status
    */
-  static bool parseRestart( std::string & restartFileName );
+  static bool parseRestart( string & restartFileName );
 
   /**
    * @brief Initializes a python interpreter within GEOSX

--- a/src/coreComponents/managers/Tasks/TaskBase.cpp
+++ b/src/coreComponents/managers/Tasks/TaskBase.cpp
@@ -23,7 +23,7 @@ namespace geosx
 
 using namespace dataRepository;
 
-TaskBase::TaskBase( std::string const & name,
+TaskBase::TaskBase( string const & name,
                     Group * const parent ):
   ExecutableGroup( name, parent )
 {

--- a/src/coreComponents/managers/Tasks/TaskBase.hpp
+++ b/src/coreComponents/managers/Tasks/TaskBase.hpp
@@ -19,7 +19,7 @@
 #ifndef TASKBASE_HPP_
 #define TASKBASE_HPP_
 
-#include <string>
+
 #include <limits>
 
 #include "dataRepository/ExecutableGroup.hpp"

--- a/src/coreComponents/managers/Tasks/TaskBase.hpp
+++ b/src/coreComponents/managers/Tasks/TaskBase.hpp
@@ -34,8 +34,8 @@ namespace geosx
 class TaskBase : public ExecutableGroup
 {
 public:
-  /// @copydoc geosx::dataRepository::Group::Group(std::string const & name, Group * const parent)
-  explicit TaskBase( std::string const & name,
+  /// @copydoc geosx::dataRepository::Group::Group(string const & name, Group * const parent)
+  explicit TaskBase( string const & name,
                      Group * const parent );
   virtual ~TaskBase( ) override;
 
@@ -46,7 +46,7 @@ public:
   static string catalogName() { return "TaskBase"; }
 
   /// The catalog interface type for TaskBase
-  using CatalogInterface = dataRepository::CatalogInterface< TaskBase, std::string const &, Group * const >;
+  using CatalogInterface = dataRepository::CatalogInterface< TaskBase, string const &, Group * const >;
   /**
    * @brief Get the catalog interface for the TaskBase
    * @return the Catalog for TaskBase.

--- a/src/coreComponents/managers/Tasks/TasksManager.cpp
+++ b/src/coreComponents/managers/Tasks/TasksManager.cpp
@@ -25,7 +25,7 @@ namespace geosx
 using namespace dataRepository;
 using namespace LvArray;
 
-TasksManager::TasksManager( std::string const & name,
+TasksManager::TasksManager( string const & name,
                             Group * const parent ):
   Group( name, parent )
 {

--- a/src/coreComponents/managers/Tasks/TasksManager.hpp
+++ b/src/coreComponents/managers/Tasks/TasksManager.hpp
@@ -33,7 +33,7 @@ class TasksManager : public dataRepository::Group
 {
 public:
   /// @copydoc geosx::dataRepository::Group::Group
-  TasksManager( std::string const & name, Group * const parent );
+  TasksManager( string const & name, Group * const parent );
   /// Destructor
   virtual ~TasksManager() override;
 

--- a/src/coreComponents/managers/TimeHistory/HistoryDataSpec.hpp
+++ b/src/coreComponents/managers/TimeHistory/HistoryDataSpec.hpp
@@ -150,7 +150,7 @@ public:
     return m_dims[dim];
   }
 private:
-  std::string m_name;
+  string m_name;
   localIndex m_rank;
   std::vector< localIndex > m_dims;
   std::type_index m_type;

--- a/src/coreComponents/managers/TimeHistory/PackCollection.cpp
+++ b/src/coreComponents/managers/TimeHistory/PackCollection.cpp
@@ -185,5 +185,5 @@ void PackCollection::collect( DomainPartition & domain,
 
 }
 
-REGISTER_CATALOG_ENTRY( TaskBase, PackCollection, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( TaskBase, PackCollection, string const &, Group * const )
 }

--- a/src/coreComponents/managers/TimeHistory/TimeHistoryCollection.hpp
+++ b/src/coreComponents/managers/TimeHistory/TimeHistoryCollection.hpp
@@ -39,7 +39,7 @@ using namespace dataRepository;
 class HistoryCollection : public TaskBase
 {
 public:
-  /// @copydoc geosx::dataRepository::Group::Group(std::string const & name, Group * const parent)
+  /// @copydoc geosx::dataRepository::Group::Group(string const & name, Group * const parent)
   HistoryCollection( string const & name, Group * parent ):
     TaskBase( name, parent ),
     m_collectionCount( 1 ),

--- a/src/coreComponents/managers/initialization.cpp
+++ b/src/coreComponents/managers/initialization.cpp
@@ -68,7 +68,7 @@ void addUmpireHighWaterMarks()
   umpire::ResourceManager & rm = umpire::ResourceManager::getInstance();
 
   // Get a list of all the allocators and sort it so that it's in the same order on each rank.
-  std::vector< std::string > allocatorNames = rm.getAllocatorNames();
+  std::vector< string > allocatorNames = rm.getAllocatorNames();
   std::sort( allocatorNames.begin(), allocatorNames.end() );
 
   // If each rank doesn't have the same number of allocators you can't aggregate them.
@@ -141,7 +141,7 @@ void setupCaliper()
   GEOSX_WARNING_IF( !adiak::systime(), "Error getting the systime." );
   GEOSX_WARNING_IF( !adiak::cputime(), "Error getting the cputime." );
 
-  std::string xmlDir, xmlName;
+  string xmlDir, xmlName;
   splitPath( s_commandLineOptions.inputFileName, xmlDir, xmlName );
   adiak::value( "XML File", xmlName );
   adiak::value( "Problem name", s_commandLineOptions.problemName );
@@ -416,7 +416,7 @@ void parseCommandLineOptions( int argc, char * * argv )
 
   if( s_commandLineOptions.problemName == "" )
   {
-    std::string & inputFileName = s_commandLineOptions.inputFileName;
+    string & inputFileName = s_commandLineOptions.inputFileName;
     if( inputFileName.length() > 4 && inputFileName.substr( inputFileName.length() - 4, 4 ) == ".xml" )
     {
       string::size_type start = inputFileName.find_last_of( '/' ) + 1;
@@ -458,7 +458,7 @@ CommandLineOptions const & getCommandLineOptions()
 { return internal::s_commandLineOptions; }
 
 ///////////////////////////////////////////////////////////////////////////////
-void overrideInputFileName( std::string const & inputFileName )
+void overrideInputFileName( string const & inputFileName )
 { internal::s_commandLineOptions.inputFileName = inputFileName; }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/coreComponents/managers/initialization.hpp
+++ b/src/coreComponents/managers/initialization.hpp
@@ -33,13 +33,13 @@ namespace geosx
 struct CommandLineOptions
 {
   /// The path to the input xml.
-  std::string inputFileName;
+  string inputFileName;
 
   /// True iff restarting from the middle of an existing run.
   bool beginFromRestart = false;
 
   /// The path to the restart file, if specified.
-  std::string restartFileName;
+  string restartFileName;
 
   /// The number of partitions in the x direction.
   integer xPartitionsOverride;
@@ -63,16 +63,16 @@ struct CommandLineOptions
   integer suppressPinned = false;
 
   /// The name of the schema.
-  std::string schemaName;
+  string schemaName;
 
   /// The name of the problem being run.
-  std::string problemName;
+  string problemName;
 
   /// The directory to put all output.
-  std::string outputDirectory = ".";
+  string outputDirectory = ".";
 
   /// The string used to initialize caliper.
-  std::string timerOutput = "";
+  string timerOutput = "";
 
   /// Suppress logging of host-device data migration.
   integer suppressMoveLogging = false;
@@ -95,7 +95,7 @@ CommandLineOptions const & getCommandLineOptions();
  * @brief Override the input file name, useful only for tests.
  * @param inputFileName new input file name
  */
-void overrideInputFileName( std::string const & inputFileName );
+void overrideInputFileName( string const & inputFileName );
 
 /**
  * @brief Perform the basic GEOSX cleanup.
@@ -148,7 +148,7 @@ void finalizeMPI();
  * @param value The value to compute the statistics of.
  */
 template< typename T >
-void pushStatsIntoAdiak( std::string const & name, T const value )
+void pushStatsIntoAdiak( string const & name, T const value )
 {
 #if defined( GEOSX_USE_CALIPER )
   T const total = MpiWrapper::sum( value );

--- a/src/coreComponents/managers/unitTests/testRecursiveFieldApplication.cpp
+++ b/src/coreComponents/managers/unitTests/testRecursiveFieldApplication.cpp
@@ -64,7 +64,7 @@ TEST( FieldSpecification, Recursive )
   auto domain = std::unique_ptr< DomainPartition >( new DomainPartition( "domain", nullptr ) );
   auto meshBodies = domain->getMeshBodies();
   MeshBody * const meshBody = meshBodies->registerGroup< MeshBody >( "body" );
-  MeshLevel * const meshLevel0 = meshBody->registerGroup< MeshLevel >( std::string( "Level0" ));
+  MeshLevel * const meshLevel0 = meshBody->registerGroup< MeshLevel >( string( "Level0" ));
 
   CellBlockManager * cellBlockManager = domain->getGroup< CellBlockManager >( keys::cellManager );
 
@@ -118,7 +118,7 @@ TEST( FieldSpecification, Recursive )
 
   SortedArray< localIndex > & set0hex = reg0->getSubRegion( "reg0hex" )
                                           ->getGroup( "sets" )
-                                          ->registerWrapper< SortedArray< localIndex > >( std::string( "all" ) )
+                                          ->registerWrapper< SortedArray< localIndex > >( string( "all" ) )
                                           ->reference();
   for( localIndex i = 0; i < nbHexReg0; i++ )
   {
@@ -127,7 +127,7 @@ TEST( FieldSpecification, Recursive )
 
   SortedArray< localIndex > & set0tet = reg0->getSubRegion( "reg0tet" )
                                           ->getGroup( "sets" )
-                                          ->registerWrapper< SortedArray< localIndex > >( std::string( "all" ) )
+                                          ->registerWrapper< SortedArray< localIndex > >( string( "all" ) )
                                           ->reference();
   for( localIndex i = 0; i < nbTetReg0; i++ )
   {
@@ -136,7 +136,7 @@ TEST( FieldSpecification, Recursive )
 
   SortedArray< localIndex > & set1hex = reg1->getSubRegion( "reg1hex" )
                                           ->getGroup( "sets" )
-                                          ->registerWrapper< SortedArray< localIndex > >( std::string( "all" ) )
+                                          ->registerWrapper< SortedArray< localIndex > >( string( "all" ) )
                                           ->reference();
   for( localIndex i = 0; i < nbHexReg1; i++ )
   {
@@ -145,7 +145,7 @@ TEST( FieldSpecification, Recursive )
 
   SortedArray< localIndex > & set1tet = reg1->getSubRegion( "reg1tet" )
                                           ->getGroup( "sets" )
-                                          ->registerWrapper< SortedArray< localIndex > >( std::string( "all" ) )
+                                          ->registerWrapper< SortedArray< localIndex > >( string( "all" ) )
                                           ->reference();
   for( localIndex i = 0; i < nbTetReg1; i++ )
   {

--- a/src/coreComponents/mesh/CellBlock.cpp
+++ b/src/coreComponents/mesh/CellBlock.cpp
@@ -320,6 +320,6 @@ void CellBlock::calculateElementGeometricQuantities( NodeManager const & nodeMan
 }
 
 
-REGISTER_CATALOG_ENTRY( ObjectManagerBase, CellBlock, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ObjectManagerBase, CellBlock, string const &, Group * const )
 
 }

--- a/src/coreComponents/mesh/CellElementRegion.cpp
+++ b/src/coreComponents/mesh/CellElementRegion.cpp
@@ -182,6 +182,6 @@ void CellElementRegion::generateAggregates( FaceManager const * const faceManage
   aggregateSubRegion->createFromFineToCoarseMap( nbAggregates, partsGEOS, aggregateBarycenters );
 }
 
-REGISTER_CATALOG_ENTRY( ObjectManagerBase, CellElementRegion, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ObjectManagerBase, CellElementRegion, string const &, Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/mesh/EdgeManager.cpp
+++ b/src/coreComponents/mesh/EdgeManager.cpp
@@ -29,7 +29,7 @@ namespace geosx
 {
 using namespace dataRepository;
 
-EdgeManager::EdgeManager( std::string const & name,
+EdgeManager::EdgeManager( string const & name,
                           Group * const parent ):
   ObjectManagerBase( name, parent ),
   m_edgesToFractureConnectorsEdges(),
@@ -435,7 +435,7 @@ void EdgeManager::buildEdges( FaceManager * const faceManager, NodeManager * con
   for( int i = 0; i < nodeSets.size(); ++i )
   {
     auto const & setWrapper = nodeSets[i];
-    std::string const & setName = setWrapper->getName();
+    string const & setName = setWrapper->getName();
     createSet( setName );
   }
 
@@ -443,7 +443,7 @@ void EdgeManager::buildEdges( FaceManager * const faceManager, NodeManager * con
   forAll< parallelHostPolicy >( nodeSets.size(), [&]( localIndex const i ) -> void
   {
     auto const & setWrapper = nodeSets[i];
-    std::string const & setName = setWrapper->getName();
+    string const & setName = setWrapper->getName();
     SortedArrayView< localIndex const > const targetSet = nodeManager->sets().getReference< SortedArray< localIndex > >( setName ).toViewConst();
     constructSetFromSetAndMap( targetSet, m_toNodesRelation, setName );
   } );

--- a/src/coreComponents/mesh/EdgeManager.hpp
+++ b/src/coreComponents/mesh/EdgeManager.hpp
@@ -87,7 +87,7 @@ public:
    * @param[in] name the name of the EdgeManager object in the repository
    * @param[in] parent the parent group of the EdgeManager object being constructed
    */
-  EdgeManager( std::string const & name,
+  EdgeManager( string const & name,
                Group * const parent );
 
   /**

--- a/src/coreComponents/mesh/ElementRegionManager.cpp
+++ b/src/coreComponents/mesh/ElementRegionManager.cpp
@@ -98,7 +98,7 @@ void ElementRegionManager::expandObjectCatalogs()
        ++iter )
   {
     string const key = iter->first;
-    if( key.find( "ElementRegion" ) != std::string::npos )
+    if( key.find( "ElementRegion" ) != string::npos )
     {
       this->createChild( key, key );
     }

--- a/src/coreComponents/mesh/FaceManager.cpp
+++ b/src/coreComponents/mesh/FaceManager.cpp
@@ -572,7 +572,7 @@ void FaceManager::buildFaces( NodeManager * const nodeManager, ElementRegionMana
   for( localIndex i = 0; i < nodeSets.size(); ++i )
   {
     auto const & setWrapper = nodeSets[i];
-    std::string const & setName = setWrapper->getName();
+    string const & setName = setWrapper->getName();
     createSet( setName );
   }
 
@@ -580,7 +580,7 @@ void FaceManager::buildFaces( NodeManager * const nodeManager, ElementRegionMana
   forAll< parallelHostPolicy >( nodeSets.size(), [&]( localIndex const i ) -> void
   {
     auto const & setWrapper = nodeSets[i];
-    std::string const & setName = setWrapper->getName();
+    string const & setName = setWrapper->getName();
     SortedArrayView< localIndex const > const & targetSet = nodeManager->sets().getReference< SortedArray< localIndex > >( setName ).toViewConst();
     constructSetFromSetAndMap( targetSet, m_nodeList.toViewConst(), setName );
   } );
@@ -1010,6 +1010,6 @@ void FaceManager::depopulateUpMaps( std::set< localIndex > const & receivedFaces
   }
 }
 
-REGISTER_CATALOG_ENTRY( ObjectManagerBase, FaceManager, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ObjectManagerBase, FaceManager, string const &, Group * const )
 
 }

--- a/src/coreComponents/mesh/NodeManager.cpp
+++ b/src/coreComponents/mesh/NodeManager.cpp
@@ -34,7 +34,7 @@ using namespace dataRepository;
  * @return
  */
 //START_SPHINX_REFPOS_REG
-NodeManager::NodeManager( std::string const & name,
+NodeManager::NodeManager( string const & name,
                           Group * const parent ):
   ObjectManagerBase( name, parent ),
   m_referencePosition( 0, 3 ),
@@ -422,6 +422,6 @@ void NodeManager::depopulateUpMaps( std::set< localIndex > const & receivedNodes
   }
 }
 
-REGISTER_CATALOG_ENTRY( ObjectManagerBase, NodeManager, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ObjectManagerBase, NodeManager, string const &, Group * const )
 
 }

--- a/src/coreComponents/mesh/NodeManager.hpp
+++ b/src/coreComponents/mesh/NodeManager.hpp
@@ -91,7 +91,7 @@ public:
    * @param [in] name the name of this instantiation of NodeManager
    * @param [in] parent the parent group of this instantiation of NodeManager
    */
-  NodeManager( std::string const & name,
+  NodeManager( string const & name,
                dataRepository::Group * const parent );
 
   /**

--- a/src/coreComponents/mesh/SurfaceElementRegion.cpp
+++ b/src/coreComponents/mesh/SurfaceElementRegion.cpp
@@ -212,6 +212,6 @@ localIndex SurfaceElementRegion::addToFractureMesh( real64 const time_np1,
 
 
 
-REGISTER_CATALOG_ENTRY( ObjectManagerBase, SurfaceElementRegion, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ObjectManagerBase, SurfaceElementRegion, string const &, Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/mesh/WellElementRegion.cpp
+++ b/src/coreComponents/mesh/WellElementRegion.cpp
@@ -128,6 +128,6 @@ void WellElementRegion::generateWell( MeshLevel & mesh,
 
 }
 
-REGISTER_CATALOG_ENTRY( ObjectManagerBase, WellElementRegion, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ObjectManagerBase, WellElementRegion, string const &, Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/mesh/deprecated/EmbeddedSurfaceRegion.cpp
+++ b/src/coreComponents/mesh/deprecated/EmbeddedSurfaceRegion.cpp
@@ -49,6 +49,6 @@ void EmbeddedSurfaceRegion::initializePreSubGroups( Group * const )
 
 
 
-REGISTER_CATALOG_ENTRY( ObjectManagerBase, EmbeddedSurfaceRegion, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ObjectManagerBase, EmbeddedSurfaceRegion, string const &, Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/mesh/deprecated/FaceElementRegion.cpp
+++ b/src/coreComponents/mesh/deprecated/FaceElementRegion.cpp
@@ -196,6 +196,6 @@ localIndex FaceElementRegion::AddToFractureMesh( real64 const time_np1,
 
 
 
-REGISTER_CATALOG_ENTRY( ObjectManagerBase, FaceElementRegion, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( ObjectManagerBase, FaceElementRegion, string const &, Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/meshUtilities/InternalMeshGenerator.cpp
+++ b/src/coreComponents/meshUtilities/InternalMeshGenerator.cpp
@@ -325,9 +325,9 @@ void InternalMeshGenerator::generateMesh( DomainPartition * const domain )
 
   // This cannot find groupkeys:
   // Group * const meshBodies = domain->GetGroup(domain->groupKeys.meshBodies);
-  Group * const meshBodies = domain->getGroup( std::string( "MeshBodies" ));
+  Group * const meshBodies = domain->getGroup( string( "MeshBodies" ));
   MeshBody * const meshBody = meshBodies->registerGroup< MeshBody >( this->getName() );
-  MeshLevel * const meshLevel0 = meshBody->registerGroup< MeshLevel >( std::string( "Level0" ));
+  MeshLevel * const meshLevel0 = meshBody->registerGroup< MeshLevel >( string( "Level0" ));
 
   // special case
   //  bool isRadialWithOneThetaPartition = (m_mapToRadial > 0) &&
@@ -355,13 +355,13 @@ void InternalMeshGenerator::generateMesh( DomainPartition * const domain )
   }
 
 
-  SortedArray< localIndex > & xnegNodes = nodeSets.registerWrapper< SortedArray< localIndex > >( std::string( "xneg" ) )->reference();
-  SortedArray< localIndex > & xposNodes = nodeSets.registerWrapper< SortedArray< localIndex > >( std::string( "xpos" ) )->reference();
-  SortedArray< localIndex > & ynegNodes = nodeSets.registerWrapper< SortedArray< localIndex > >( std::string( "yneg" ) )->reference();
-  SortedArray< localIndex > & yposNodes = nodeSets.registerWrapper< SortedArray< localIndex > >( std::string( "ypos" ) )->reference();
-  SortedArray< localIndex > & znegNodes = nodeSets.registerWrapper< SortedArray< localIndex > >( std::string( "zneg" ) )->reference();
-  SortedArray< localIndex > & zposNodes = nodeSets.registerWrapper< SortedArray< localIndex > >( std::string( "zpos" ) )->reference();
-  SortedArray< localIndex > & allNodes  = nodeSets.registerWrapper< SortedArray< localIndex > >( std::string( "all" ) )->reference();
+  SortedArray< localIndex > & xnegNodes = nodeSets.registerWrapper< SortedArray< localIndex > >( string( "xneg" ) )->reference();
+  SortedArray< localIndex > & xposNodes = nodeSets.registerWrapper< SortedArray< localIndex > >( string( "xpos" ) )->reference();
+  SortedArray< localIndex > & ynegNodes = nodeSets.registerWrapper< SortedArray< localIndex > >( string( "yneg" ) )->reference();
+  SortedArray< localIndex > & yposNodes = nodeSets.registerWrapper< SortedArray< localIndex > >( string( "ypos" ) )->reference();
+  SortedArray< localIndex > & znegNodes = nodeSets.registerWrapper< SortedArray< localIndex > >( string( "zneg" ) )->reference();
+  SortedArray< localIndex > & zposNodes = nodeSets.registerWrapper< SortedArray< localIndex > >( string( "zpos" ) )->reference();
+  SortedArray< localIndex > & allNodes  = nodeSets.registerWrapper< SortedArray< localIndex > >( string( "all" ) )->reference();
 
 
   // partition based on even spacing to get load balance
@@ -441,8 +441,8 @@ void InternalMeshGenerator::generateMesh( DomainPartition * const domain )
   // calculate number of elements in this partition from each region, and the
   // total number of nodes
 
-  std::map< std::string, int > numElemsInRegions;
-  std::map< std::string, std::string > elemTypeInRegions;
+  std::map< string, int > numElemsInRegions;
+  std::map< string, string > elemTypeInRegions;
 
   integer_array firstElemIndexForBlockInPartition[3];
   integer_array lastElemIndexForBlockInPartition[3];
@@ -624,9 +624,9 @@ void InternalMeshGenerator::generateMesh( DomainPartition * const domain )
     integer_array numElements;
     string_array elementRegionNames;
     string_array elementTypes;
-    std::map< std::string, localIndex > localElemIndexInRegion;
+    std::map< string, localIndex > localElemIndexInRegion;
 
-    for( std::map< std::string, int >::iterator iterNumElemsInRegion = numElemsInRegions.begin();
+    for( std::map< string, int >::iterator iterNumElemsInRegion = numElemsInRegions.begin();
          iterNumElemsInRegion != numElemsInRegions.end(); ++iterNumElemsInRegion )
     {
 
@@ -641,7 +641,7 @@ void InternalMeshGenerator::generateMesh( DomainPartition * const domain )
 
     // assign global numbers to elements
     regionOffset = 0;
-    SortedArray< std::string > processedRegionNames;
+    SortedArray< string > processedRegionNames;
     localIndex iR = 0;
 
     for( int iblock = 0; iblock < m_nElems[0].size(); ++iblock )
@@ -931,7 +931,7 @@ void InternalMeshGenerator::generateMesh( DomainPartition * const domain )
  * @param nodeIDInBox
  * @param node_size
  */
-void InternalMeshGenerator::getElemToNodesRelationInBox( const std::string & elementType,
+void InternalMeshGenerator::getElemToNodesRelationInBox( const string & elementType,
                                                          const int index[],
                                                          const int & iEle,
                                                          int nodeIDInBox[],
@@ -1261,5 +1261,5 @@ void InternalMeshGenerator::remapMesh( dataRepository::Group * const GEOSX_UNUSE
 
 }
 
-REGISTER_CATALOG_ENTRY( MeshGeneratorBase, InternalMeshGenerator, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( MeshGeneratorBase, InternalMeshGenerator, string const &, Group * const )
 }

--- a/src/coreComponents/meshUtilities/InternalMeshGenerator.hpp
+++ b/src/coreComponents/meshUtilities/InternalMeshGenerator.hpp
@@ -82,7 +82,7 @@ public:
    * @param[in] name of the InternalMeshGenerator
    * @param[in] parent point to the parent Group of the InternalMeshGenerator
    */
-  InternalMeshGenerator( const std::string & name,
+  InternalMeshGenerator( const string & name,
                          Group * const parent );
 
   virtual ~InternalMeshGenerator() override;
@@ -112,7 +112,7 @@ public:
   // virtual void GenerateNodesets( xmlWrapper::xmlNode const & targetNode,
   //                                NodeManager * nodeManager ) override;
 
-  virtual void getElemToNodesRelationInBox ( const std::string & elementType,
+  virtual void getElemToNodesRelationInBox ( const string & elementType,
                                              const int index[],
                                              const int & iEle,
                                              int nodeIDInBox[],
@@ -212,7 +212,7 @@ private:
 
   ///@cond DO_NOT_DOCUMENT
   //unused
-  std::string m_meshDx, m_meshDy, m_meshDz;
+  string m_meshDx, m_meshDy, m_meshDz;
   ///@endcond
 
 /**

--- a/src/coreComponents/meshUtilities/InternalWellGenerator.cpp
+++ b/src/coreComponents/meshUtilities/InternalWellGenerator.cpp
@@ -89,7 +89,7 @@ InternalWellGenerator::~InternalWellGenerator()
 
 void InternalWellGenerator::postProcessInput()
 {
-  GEOSX_ERROR_IF( getName().find( "well" ) == std::string::npos,
+  GEOSX_ERROR_IF( getName().find( "well" ) == string::npos,
                   "Currently, the well generator must contain the word well in its name " );
 
   GEOSX_ERROR_IF( m_polyNodeCoords.size( 1 ) != m_nDims,
@@ -563,5 +563,5 @@ void InternalWellGenerator::debugWellGeometry() const
 
 }
 
-REGISTER_CATALOG_ENTRY( MeshGeneratorBase, InternalWellGenerator, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( MeshGeneratorBase, InternalWellGenerator, string const &, Group * const )
 }

--- a/src/coreComponents/meshUtilities/InternalWellGenerator.hpp
+++ b/src/coreComponents/meshUtilities/InternalWellGenerator.hpp
@@ -68,7 +68,7 @@ public:
    * @param name name of the object in the data hierarchy.
    * @param parent pointer to the parent group in the data hierarchy.
    */
-  InternalWellGenerator( const std::string & name,
+  InternalWellGenerator( const string & name,
                          Group * const parent );
 
   /**
@@ -122,7 +122,7 @@ public:
   virtual void generateMesh( DomainPartition * const domain ) override;
 
   /// not implemented
-  virtual void getElemToNodesRelationInBox ( std::string const &,
+  virtual void getElemToNodesRelationInBox ( string const &,
                                              int const *,
                                              int const &,
                                              int *,

--- a/src/coreComponents/meshUtilities/MeshGeneratorBase.hpp
+++ b/src/coreComponents/meshUtilities/MeshGeneratorBase.hpp
@@ -46,7 +46,7 @@ public:
    * @param[in] name of the MeshGenerator object
    * @param[in] parent the parent Group pointer for the MeshGenerator object
    */
-  explicit MeshGeneratorBase( std::string const & name,
+  explicit MeshGeneratorBase( string const & name,
                               Group * const parent );
 
   /**
@@ -85,7 +85,7 @@ public:
  * @param[in] size the number of node on the element
  *
  */
-  virtual void getElemToNodesRelationInBox ( const std::string & elementType,
+  virtual void getElemToNodesRelationInBox ( const string & elementType,
                                              const int index[],
                                              const int & iEle,
                                              int nodeIDInBox[],
@@ -101,7 +101,7 @@ public:
   int m_delayMeshDeformation = 0;
 
   /// using alias for templated Catalog meshGenerator type
-  using CatalogInterface = dataRepository::CatalogInterface< MeshGeneratorBase, std::string const &, Group * const >;
+  using CatalogInterface = dataRepository::CatalogInterface< MeshGeneratorBase, string const &, Group * const >;
 
 /**
  * @brief Accessor for the singleton Catalog object

--- a/src/coreComponents/meshUtilities/MeshManager.cpp
+++ b/src/coreComponents/meshUtilities/MeshManager.cpp
@@ -24,7 +24,7 @@ namespace geosx
 
 using namespace dataRepository;
 
-MeshManager::MeshManager( std::string const & name,
+MeshManager::MeshManager( string const & name,
                           Group * const parent ):
   Group( name, parent )
 {
@@ -68,7 +68,7 @@ void MeshManager::generateMeshLevels( DomainPartition * const domain )
     string meshName = meshGen.getName();
 
     // THIS IS A HACK
-    if( meshName.find( "well" ) == std::string::npos )
+    if( meshName.find( "well" ) == string::npos )
     {
       domain->getMeshBodies()->registerGroup< MeshBody >( meshName )->createMeshLevel( 0 );
     }

--- a/src/coreComponents/meshUtilities/MeshManager.hpp
+++ b/src/coreComponents/meshUtilities/MeshManager.hpp
@@ -39,7 +39,7 @@ public:
    * @param[in] name the name of the MeshManager object in the repository
    * @param[in] parent the parent group of the MeshManager object being constructed
    */
-  MeshManager( std::string const & name,
+  MeshManager( string const & name,
                Group * const parent );
 
   virtual ~MeshManager() override;

--- a/src/coreComponents/meshUtilities/PAMELAMeshGenerator.cpp
+++ b/src/coreComponents/meshUtilities/PAMELAMeshGenerator.cpp
@@ -95,11 +95,11 @@ void PAMELAMeshGenerator::generateMesh( DomainPartition * const domain )
 {
   GEOSX_LOG_RANK_0( "Writing into the GEOSX mesh data structure" );
   domain->getMetisNeighborList() = m_pamelaMesh->getNeighborList();
-  Group * const meshBodies = domain->getGroup( std::string( "MeshBodies" ));
+  Group * const meshBodies = domain->getGroup( string( "MeshBodies" ));
   MeshBody * const meshBody = meshBodies->registerGroup< MeshBody >( this->getName() );
 
   //TODO for the moment we only consider on mesh level "Level0"
-  MeshLevel * const meshLevel0 = meshBody->registerGroup< MeshLevel >( std::string( "Level0" ));
+  MeshLevel * const meshLevel0 = meshBody->registerGroup< MeshLevel >( string( "Level0" ));
   NodeManager * nodeManager = meshLevel0->getNodeManager();
   CellBlockManager * cellBlockManager = domain->getGroup< CellBlockManager >( keys::cellManager );
 
@@ -114,7 +114,7 @@ void PAMELAMeshGenerator::generateMesh( DomainPartition * const domain )
   arrayView1d< globalIndex > const & nodeLocalToGlobal = nodeManager->localToGlobalMap();
 
   Group & nodeSets = nodeManager->sets();
-  SortedArray< localIndex > & allNodes  = nodeSets.registerWrapper< SortedArray< localIndex > >( std::string( "all" ) )->reference();
+  SortedArray< localIndex > & allNodes  = nodeSets.registerWrapper< SortedArray< localIndex > >( string( "all" ) )->reference();
 
   real64 xMax[3] = { std::numeric_limits< real64 >::min() };
   real64 xMin[3] = { std::numeric_limits< real64 >::max() };
@@ -360,7 +360,7 @@ void PAMELAMeshGenerator::generateMesh( DomainPartition * const domain )
     auto const surfacePtr = polygonPart.second;
 
     string surfaceName = DecodePAMELALabels::retrieveSurfaceOrRegionName( surfacePtr->Label );
-    SortedArray< localIndex > & curNodeSet  = nodeSets.registerWrapper< SortedArray< localIndex > >( std::string( surfaceName ) )->reference();
+    SortedArray< localIndex > & curNodeSet  = nodeSets.registerWrapper< SortedArray< localIndex > >( string( surfaceName ) )->reference();
     for( auto const & subPart : surfacePtr->SubParts )
     {
       auto const cellBlockPAMELA = subPart.second;
@@ -384,12 +384,12 @@ void PAMELAMeshGenerator::generateMesh( DomainPartition * const domain )
 
 }
 
-void PAMELAMeshGenerator::getElemToNodesRelationInBox( const std::string & GEOSX_UNUSED_PARAM( elementType ),
+void PAMELAMeshGenerator::getElemToNodesRelationInBox( const string & GEOSX_UNUSED_PARAM( elementType ),
                                                        const int GEOSX_UNUSED_PARAM( index )[],
                                                        const int & GEOSX_UNUSED_PARAM( iEle ),
                                                        int GEOSX_UNUSED_PARAM( nodeIDInBox )[],
                                                        const int GEOSX_UNUSED_PARAM( node_size ) )
 {}
 
-REGISTER_CATALOG_ENTRY( MeshGeneratorBase, PAMELAMeshGenerator, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( MeshGeneratorBase, PAMELAMeshGenerator, string const &, Group * const )
 }

--- a/src/coreComponents/meshUtilities/PAMELAMeshGenerator.hpp
+++ b/src/coreComponents/meshUtilities/PAMELAMeshGenerator.hpp
@@ -45,7 +45,7 @@ public:
  * @param[in] name of the PAMELAMeshGenerator object
  * @param[in] parent the parent Group pointer for the MeshGenerator object
  */
-  PAMELAMeshGenerator( const std::string & name,
+  PAMELAMeshGenerator( const string & name,
                        Group * const parent );
 
   virtual ~PAMELAMeshGenerator() override;
@@ -79,7 +79,7 @@ public:
 
   virtual void generateMesh( DomainPartition * const domain ) override;
 
-  virtual void getElemToNodesRelationInBox ( const std::string & elementType,
+  virtual void getElemToNodesRelationInBox ( const string & elementType,
                                              const int index[],
                                              const int & iEle,
                                              int nodeIDInBox[],

--- a/src/coreComponents/meshUtilities/SimpleGeometricObjects/BoundedPlane.cpp
+++ b/src/coreComponents/meshUtilities/SimpleGeometricObjects/BoundedPlane.cpp
@@ -23,7 +23,7 @@ namespace geosx
 {
 using namespace dataRepository;
 
-BoundedPlane::BoundedPlane( const std::string & name, Group * const parent ):
+BoundedPlane::BoundedPlane( const string & name, Group * const parent ):
   SimpleGeometricObjectBase( name, parent ),
   m_origin{ 0.0, 0.0, 0.0 },
   m_normal{ 0.0, 0.0, 1.0 },
@@ -150,6 +150,6 @@ bool BoundedPlane::isCoordInObject( real64 const ( &coord ) [3] ) const
   return isInside;
 }
 
-REGISTER_CATALOG_ENTRY( SimpleGeometricObjectBase, BoundedPlane, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( SimpleGeometricObjectBase, BoundedPlane, string const &, Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/meshUtilities/SimpleGeometricObjects/BoundedPlane.hpp
+++ b/src/coreComponents/meshUtilities/SimpleGeometricObjects/BoundedPlane.hpp
@@ -42,7 +42,7 @@ public:
    * @param name name of the object in the data hierarchy.
    * @param parent pointer to the parent group in the data hierarchy.
    */
-  BoundedPlane( const std::string & name,
+  BoundedPlane( const string & name,
                 Group * const parent );
 
   /**

--- a/src/coreComponents/meshUtilities/SimpleGeometricObjects/Box.cpp
+++ b/src/coreComponents/meshUtilities/SimpleGeometricObjects/Box.cpp
@@ -27,7 +27,7 @@ namespace geosx
 {
 using namespace dataRepository;
 
-Box::Box( const std::string & name, Group * const parent ):
+Box::Box( const string & name, Group * const parent ):
   SimpleGeometricObjectBase( name, parent ),
   m_min{ 0.0, 0.0, 0.0 },
   m_max{ 0.0, 0.0, 0.0 },
@@ -100,6 +100,6 @@ bool Box::isCoordInObject( real64 const ( &coord ) [3] ) const
   return true;
 }
 
-REGISTER_CATALOG_ENTRY( SimpleGeometricObjectBase, Box, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( SimpleGeometricObjectBase, Box, string const &, Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/meshUtilities/SimpleGeometricObjects/Box.hpp
+++ b/src/coreComponents/meshUtilities/SimpleGeometricObjects/Box.hpp
@@ -43,7 +43,7 @@ public:
    * @param name name of the object in the data hierarchy.
    * @param parent pointer to the parent group in the data hierarchy.
    */
-  Box( const std::string & name,
+  Box( const string & name,
        Group * const parent );
 
   /**

--- a/src/coreComponents/meshUtilities/SimpleGeometricObjects/Cylinder.cpp
+++ b/src/coreComponents/meshUtilities/SimpleGeometricObjects/Cylinder.cpp
@@ -27,7 +27,7 @@ namespace geosx
 {
 using namespace dataRepository;
 
-Cylinder::Cylinder( const std::string & name, Group * const parent ):
+Cylinder::Cylinder( const string & name, Group * const parent ):
   SimpleGeometricObjectBase( name, parent ),
   m_point1{ 0.0, 0.0, 0.0 },
   m_point2{ 0.0, 0.0, 0.0 },
@@ -76,6 +76,6 @@ bool Cylinder::isCoordInObject( real64 const ( &coord ) [3] ) const
   return rval;
 }
 
-REGISTER_CATALOG_ENTRY( SimpleGeometricObjectBase, Cylinder, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( SimpleGeometricObjectBase, Cylinder, string const &, Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/meshUtilities/SimpleGeometricObjects/Cylinder.hpp
+++ b/src/coreComponents/meshUtilities/SimpleGeometricObjects/Cylinder.hpp
@@ -43,7 +43,7 @@ public:
    * @param name name of the object in the data hierarchy.
    * @param parent pointer to the parent group in the data hierarchy.
    */
-  Cylinder( const std::string & name,
+  Cylinder( const string & name,
             Group * const parent );
 
   /**

--- a/src/coreComponents/meshUtilities/SimpleGeometricObjects/GeometricObjectManager.cpp
+++ b/src/coreComponents/meshUtilities/SimpleGeometricObjects/GeometricObjectManager.cpp
@@ -25,7 +25,7 @@ namespace geosx
 
 using namespace dataRepository;
 
-GeometricObjectManager::GeometricObjectManager( std::string const & name,
+GeometricObjectManager::GeometricObjectManager( string const & name,
                                                 Group * const parent ):
   Group( name, parent )
 {

--- a/src/coreComponents/meshUtilities/SimpleGeometricObjects/GeometricObjectManager.hpp
+++ b/src/coreComponents/meshUtilities/SimpleGeometricObjects/GeometricObjectManager.hpp
@@ -43,7 +43,7 @@ public:
    * @param name name of the object in the data hierarchy.
    * @param parent pointer to the parent group in the data hierarchy.
    */
-  GeometricObjectManager( std::string const & name,
+  GeometricObjectManager( string const & name,
                           Group * const parent );
 
   /**

--- a/src/coreComponents/meshUtilities/SimpleGeometricObjects/SimpleGeometricObjectBase.cpp
+++ b/src/coreComponents/meshUtilities/SimpleGeometricObjects/SimpleGeometricObjectBase.cpp
@@ -21,7 +21,7 @@
 namespace geosx
 {
 
-SimpleGeometricObjectBase::SimpleGeometricObjectBase( std::string const & name,
+SimpleGeometricObjectBase::SimpleGeometricObjectBase( string const & name,
                                                       Group * const parent ):
   Group( name, parent )
 {

--- a/src/coreComponents/meshUtilities/SimpleGeometricObjects/SimpleGeometricObjectBase.hpp
+++ b/src/coreComponents/meshUtilities/SimpleGeometricObjects/SimpleGeometricObjectBase.hpp
@@ -54,7 +54,7 @@ public:
    * @param name name of the object in the data hierarchy.
    * @param parent pointer to the parent group in the data hierarchy.
    */
-  explicit SimpleGeometricObjectBase( std::string const & name,
+  explicit SimpleGeometricObjectBase( string const & name,
                                       Group * const parent );
 
   /**
@@ -78,7 +78,7 @@ public:
   /**
    * @brief Type alias for catalog interface used by this class.
    */
-  using CatalogInterface = dataRepository::CatalogInterface< SimpleGeometricObjectBase, std::string const &, Group * const >;
+  using CatalogInterface = dataRepository::CatalogInterface< SimpleGeometricObjectBase, string const &, Group * const >;
 
   /**
    * @copydoc catalogName()

--- a/src/coreComponents/meshUtilities/SimpleGeometricObjects/ThickPlane.cpp
+++ b/src/coreComponents/meshUtilities/SimpleGeometricObjects/ThickPlane.cpp
@@ -23,7 +23,7 @@ namespace geosx
 {
 using namespace dataRepository;
 
-ThickPlane::ThickPlane( const std::string & name, Group * const parent ):
+ThickPlane::ThickPlane( const string & name, Group * const parent ):
   SimpleGeometricObjectBase( name, parent ),
   m_origin{ 0.0, 0.0, 0.0 },
   m_normal{ 0.0, 0.0, 1.0 },
@@ -68,6 +68,6 @@ bool ThickPlane::isCoordInObject( real64 const ( &coord ) [3] ) const
   return std::fabs( normalDistance ) <= m_thickness;
 }
 
-REGISTER_CATALOG_ENTRY( SimpleGeometricObjectBase, ThickPlane, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( SimpleGeometricObjectBase, ThickPlane, string const &, Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/meshUtilities/SimpleGeometricObjects/ThickPlane.hpp
+++ b/src/coreComponents/meshUtilities/SimpleGeometricObjects/ThickPlane.hpp
@@ -42,7 +42,7 @@ public:
    * @param name name of the object in the data hierarchy.
    * @param parent pointer to the parent group in the data hierarchy.
    */
-  ThickPlane( const std::string & name,
+  ThickPlane( const string & name,
               Group * const parent );
 
   /**

--- a/src/coreComponents/mpiCommunications/MpiWrapper.hpp
+++ b/src/coreComponents/mpiCommunications/MpiWrapper.hpp
@@ -684,8 +684,8 @@ void MpiWrapper::broadcast( T & MPI_PARAM( value ), int MPI_PARAM( srcRank ), MP
 template<>
 inline
 void MpiWrapper::broadcast< string >( string & MPI_PARAM( value ),
-                                           int MPI_PARAM( srcRank ),
-                                           MPI_Comm MPI_PARAM( comm ) )
+                                      int MPI_PARAM( srcRank ),
+                                      MPI_Comm MPI_PARAM( comm ) )
 {
 #ifdef GEOSX_USE_MPI
   int size = value.size();

--- a/src/coreComponents/mpiCommunications/MpiWrapper.hpp
+++ b/src/coreComponents/mpiCommunications/MpiWrapper.hpp
@@ -683,7 +683,7 @@ void MpiWrapper::broadcast( T & MPI_PARAM( value ), int MPI_PARAM( srcRank ), MP
 
 template<>
 inline
-void MpiWrapper::broadcast< std::string >( std::string & MPI_PARAM( value ),
+void MpiWrapper::broadcast< string >( string & MPI_PARAM( value ),
                                            int MPI_PARAM( srcRank ),
                                            MPI_Comm MPI_PARAM( comm ) )
 {

--- a/src/coreComponents/mpiCommunications/NeighborData.hpp
+++ b/src/coreComponents/mpiCommunications/NeighborData.hpp
@@ -36,7 +36,7 @@ public:
   /**
    * @brief Create a NeighborData object with name @p name and parent @p parent.
    */
-  NeighborData( std::string const & name, Group * const parent ):
+  NeighborData( string const & name, Group * const parent ):
     dataRepository::Group( name, parent )
   {
     this->registerWrapper( "matchedPartitionBoundaryObjects", &m_matchedPartitionBoundary )->

--- a/src/coreComponents/mpiCommunications/PartitionBase.hpp
+++ b/src/coreComponents/mpiCommunications/PartitionBase.hpp
@@ -126,11 +126,11 @@ public:
 //  template< typename T >
 //  void SendReceive( const array1d< array1d< T > > & sendArray, array1d< array1d< T > > & recvArray );
 
-//  void SynchronizeFields( const std::map<std::string, string_array >& fieldNames,
+//  void SynchronizeFields( const std::map<string, string_array >& fieldNames,
 //                          const CommRegistry::commID commID = CommRegistry::genericComm01 );
 
-//  void SetOwnedByRank( const std::map< std::string, globalIndex_array > & localBoundaryGlobalIndices,
-//                       std::map< std::string, std::map< globalIndex, int > > & boundaryOwnership );
+//  void SetOwnedByRank( const std::map< string, globalIndex_array > & localBoundaryGlobalIndices,
+//                       std::map< string, std::map< globalIndex, int > > & boundaryOwnership );
 
 //  void SetGhostArrays( DomainPartition * domain );
 
@@ -246,13 +246,13 @@ public:
   /// Unused parameter
   bool m_hasLocalGhosts;
   /// Unused parameter
-  std::map< std::string, localIndex_array > m_localGhosts;
+  std::map< string, localIndex_array > m_localGhosts;
   /// Unused parameter
-  std::map< std::string, localIndex_array > m_elementRegionsLocalGhosts;
+  std::map< string, localIndex_array > m_elementRegionsLocalGhosts;
   /// Unused parameter
-  std::map< std::string, localIndex_array > m_localGhostSources;
+  std::map< string, localIndex_array > m_localGhostSources;
   /// Unused parameter
-  std::map< std::string, localIndex_array > m_elementRegionsLocalGhostSources;
+  std::map< string, localIndex_array > m_elementRegionsLocalGhostSources;
   /// Unused parameter
   int m_ghostDepth;
 

--- a/src/coreComponents/physicsSolvers/LinearSolverParameters.cpp
+++ b/src/coreComponents/physicsSolvers/LinearSolverParameters.cpp
@@ -22,7 +22,7 @@ namespace geosx
 {
 using namespace dataRepository;
 
-LinearSolverParametersInput::LinearSolverParametersInput( std::string const & name,
+LinearSolverParametersInput::LinearSolverParametersInput( string const & name,
                                                           Group * const parent )
   :
   Group( name, parent )
@@ -97,7 +97,7 @@ LinearSolverParametersInput::LinearSolverParametersInput( std::string const & na
                     "If the method converges, the iterative solution :math:`\\mathsf{x}_k` is such that\n"
                     "the relative residual norm satisfies:\n"
                     ":math:`\\left\\lVert \\mathsf{b} - \\mathsf{A} \\mathsf{x}_k \\right\\rVert_2` < ``" +
-                    std::string( viewKeyStruct::krylovTolString ) + "`` * :math:`\\left\\lVert\\mathsf{b}\\right\\rVert_2`" );
+                    string( viewKeyStruct::krylovTolString ) + "`` * :math:`\\left\\lVert\\mathsf{b}\\right\\rVert_2`" );
 
   registerWrapper( viewKeyStruct::krylovAdaptiveTolString, &m_parameters.krylov.useAdaptiveTol )->
     setApplyDefaultValue( m_parameters.krylov.useAdaptiveTol )->
@@ -179,6 +179,6 @@ void LinearSolverParametersInput::postProcessInput()
   // TODO input validation for other AMG parameters ?
 }
 
-REGISTER_CATALOG_ENTRY( Group, LinearSolverParametersInput, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( Group, LinearSolverParametersInput, string const &, Group * const )
 
 } // namespace geosx

--- a/src/coreComponents/physicsSolvers/LinearSolverParameters.hpp
+++ b/src/coreComponents/physicsSolvers/LinearSolverParameters.hpp
@@ -45,7 +45,7 @@ public:
   LinearSolverParametersInput() = delete;
 
   /// Constructor
-  LinearSolverParametersInput( std::string const & name, Group * const parent );
+  LinearSolverParametersInput( string const & name, Group * const parent );
 
   /// Copy constructor
   LinearSolverParametersInput( LinearSolverParametersInput && ) = default;

--- a/src/coreComponents/physicsSolvers/NonlinearSolverParameters.cpp
+++ b/src/coreComponents/physicsSolvers/NonlinearSolverParameters.cpp
@@ -19,7 +19,7 @@ namespace geosx
 
 using namespace dataRepository;
 
-NonlinearSolverParameters::NonlinearSolverParameters( std::string const & name,
+NonlinearSolverParameters::NonlinearSolverParameters( string const & name,
                                                       Group * const parent ):
   Group( name, parent )
 {
@@ -113,6 +113,6 @@ void NonlinearSolverParameters::postProcessInput()
 
 
 
-REGISTER_CATALOG_ENTRY( Group, NonlinearSolverParameters, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( Group, NonlinearSolverParameters, string const &, Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/physicsSolvers/NonlinearSolverParameters.hpp
+++ b/src/coreComponents/physicsSolvers/NonlinearSolverParameters.hpp
@@ -38,7 +38,7 @@ public:
    * @param[in] name The name of the new instantiation of this Group.
    * @param[in] parent A pointer to the parent of this Group.
    */
-  NonlinearSolverParameters( std::string const & name,
+  NonlinearSolverParameters( string const & name,
                              Group * const parent );
 
   /**

--- a/src/coreComponents/physicsSolvers/PhysicsSolverManager.cpp
+++ b/src/coreComponents/physicsSolvers/PhysicsSolverManager.cpp
@@ -25,7 +25,7 @@ namespace geosx
 
 using namespace dataRepository;
 
-PhysicsSolverManager::PhysicsSolverManager( std::string const & name,
+PhysicsSolverManager::PhysicsSolverManager( string const & name,
                                             Group * const parent ):
   Group( name, parent ),
   m_gravityVector( { 0.0, 0.0, -9.81 } )

--- a/src/coreComponents/physicsSolvers/PhysicsSolverManager.hpp
+++ b/src/coreComponents/physicsSolvers/PhysicsSolverManager.hpp
@@ -29,7 +29,7 @@ class SolverBase;
 class PhysicsSolverManager : public dataRepository::Group
 {
 public:
-  PhysicsSolverManager( std::string const & name,
+  PhysicsSolverManager( string const & name,
                         Group * const parent );
 
   virtual ~PhysicsSolverManager() override;

--- a/src/coreComponents/physicsSolvers/SolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/SolverBase.cpp
@@ -25,7 +25,7 @@ namespace geosx
 
 using namespace dataRepository;
 
-SolverBase::SolverBase( std::string const & name,
+SolverBase::SolverBase( string const & name,
                         Group * const parent )
   :
   ExecutableGroup( name, parent ),

--- a/src/coreComponents/physicsSolvers/SolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/SolverBase.hpp
@@ -26,7 +26,7 @@
 #include "physicsSolvers/NonlinearSolverParameters.hpp"
 #include "physicsSolvers/LinearSolverParameters.hpp"
 
-#include <string>
+
 #include <limits>
 
 namespace geosx

--- a/src/coreComponents/physicsSolvers/SolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/SolverBase.hpp
@@ -38,7 +38,7 @@ class SolverBase : public ExecutableGroup
 {
 public:
 
-  explicit SolverBase( std::string const & name,
+  explicit SolverBase( string const & name,
                        Group * const parent );
 
   SolverBase( SolverBase && ) = default;
@@ -515,7 +515,7 @@ public:
 
   virtual Group * createChild( string const & childKey, string const & childName ) override;
 
-  using CatalogInterface = dataRepository::CatalogInterface< SolverBase, std::string const &, Group * const >;
+  using CatalogInterface = dataRepository::CatalogInterface< SolverBase, string const &, Group * const >;
   static CatalogInterface::CatalogType & getCatalog();
 
   struct viewKeyStruct

--- a/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBase.cpp
@@ -29,7 +29,7 @@ namespace geosx
 using namespace dataRepository;
 using namespace constitutive;
 
-FlowSolverBase::FlowSolverBase( std::string const & name,
+FlowSolverBase::FlowSolverBase( string const & name,
                                 Group * const parent ):
   SolverBase( name, parent ),
   m_fluidModelNames(),

--- a/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBase.hpp
@@ -45,7 +45,7 @@ public:
  * @param name the name of this instantiation of Group in the repository
  * @param parent the parent group of this instantiation of Group
  */
-  FlowSolverBase( const std::string & name,
+  FlowSolverBase( const string & name,
                   Group * const parent );
 
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/ProppantTransport.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/ProppantTransport.cpp
@@ -47,7 +47,7 @@ using namespace dataRepository;
 using namespace constitutive;
 using namespace ProppantTransportKernels;
 
-ProppantTransport::ProppantTransport( const std::string & name,
+ProppantTransport::ProppantTransport( const string & name,
                                       Group * const parent ):
   FlowSolverBase( name, parent )
 {
@@ -1407,5 +1407,5 @@ void ProppantTransport::updateProppantPackVolume( real64 const GEOSX_UNUSED_PARA
 }
 
 
-REGISTER_CATALOG_ENTRY( SolverBase, ProppantTransport, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( SolverBase, ProppantTransport, string const &, Group * const )
 } /* namespace geosx */

--- a/src/coreComponents/physicsSolvers/fluidFlow/ProppantTransport.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/ProppantTransport.hpp
@@ -47,7 +47,7 @@ public:
    * @param name the name of this instantiation of Group in the repository
    * @param parent the parent group of this instantiation of Group
    */
-  ProppantTransport( const std::string & name,
+  ProppantTransport( const string & name,
                      Group * const parent );
 
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseBase.cpp
@@ -35,7 +35,7 @@ using namespace dataRepository;
 using namespace constitutive;
 using namespace SinglePhaseBaseKernels;
 
-SinglePhaseBase::SinglePhaseBase( const std::string & name,
+SinglePhaseBase::SinglePhaseBase( const string & name,
                                   Group * const parent ):
   FlowSolverBase( name, parent )
 {

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseBase.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseBase.hpp
@@ -45,7 +45,7 @@ public:
    * @param name the name of this instantiation of Group in the repository
    * @param parent the parent group of this instantiation of Group
    */
-  SinglePhaseBase( const std::string & name,
+  SinglePhaseBase( const string & name,
                    Group * const parent );
 
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseFVM.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseFVM.cpp
@@ -41,7 +41,7 @@ using namespace SinglePhaseBaseKernels;
 using namespace SinglePhaseFVMKernels;
 
 template< typename BASE >
-SinglePhaseFVM< BASE >::SinglePhaseFVM( const std::string & name,
+SinglePhaseFVM< BASE >::SinglePhaseFVM( const string & name,
                                         Group * const parent ):
   BASE( name, parent )
 {
@@ -405,7 +405,7 @@ namespace
 {
 typedef SinglePhaseFVM< SinglePhaseBase > NoProppant;
 typedef SinglePhaseFVM< SinglePhaseProppantBase > Proppant;
-REGISTER_CATALOG_ENTRY( SolverBase, NoProppant, std::string const &, Group * const )
-REGISTER_CATALOG_ENTRY( SolverBase, Proppant, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( SolverBase, NoProppant, string const &, Group * const )
+REGISTER_CATALOG_ENTRY( SolverBase, Proppant, string const &, Group * const )
 }
 } /* namespace geosx */

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseFVM.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseFVM.hpp
@@ -101,7 +101,7 @@ public:
    * @param name the name of this instantiation of Group in the repository
    * @param parent the parent group of this instantiation of Group
    */
-  SinglePhaseFVM( const std::string & name,
+  SinglePhaseFVM( const string & name,
                   dataRepository::Group * const parent );
 
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseHybridFVM.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseHybridFVM.cpp
@@ -35,7 +35,7 @@ using namespace constitutive;
 using namespace SinglePhaseHybridFVMKernels;
 using namespace mimeticInnerProduct;
 
-SinglePhaseHybridFVM::SinglePhaseHybridFVM( const std::string & name,
+SinglePhaseHybridFVM::SinglePhaseHybridFVM( const string & name,
                                             Group * const parent ):
   SinglePhaseBase( name, parent ),
   m_faceDofKey( "" ),
@@ -550,5 +550,5 @@ void SinglePhaseHybridFVM::resetStateToBeginningOfStep( DomainPartition & domain
   dFacePres.setValues< parallelDevicePolicy<> >( 0.0 );
 }
 
-REGISTER_CATALOG_ENTRY( SolverBase, SinglePhaseHybridFVM, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( SolverBase, SinglePhaseHybridFVM, string const &, Group * const )
 } /* namespace geosx */

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseHybridFVM.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseHybridFVM.hpp
@@ -41,7 +41,7 @@ public:
    * @param name the name of this instantiation of Group in the repository
    * @param parent the parent group of this instantiation of Group
    */
-  SinglePhaseHybridFVM( const std::string & name,
+  SinglePhaseHybridFVM( const string & name,
                         Group * const parent );
 
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseProppantBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseProppantBase.cpp
@@ -28,7 +28,7 @@ namespace geosx
 
 using constitutive::SlurryFluidBase;
 
-SinglePhaseProppantBase::SinglePhaseProppantBase( const std::string & name,
+SinglePhaseProppantBase::SinglePhaseProppantBase( const string & name,
                                                   Group * const parent ):
   SinglePhaseBase( name, parent )
 {}

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseProppantBase.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseProppantBase.hpp
@@ -32,7 +32,7 @@ public:
    * @param name the name of this instantiation of Group in the repository
    * @param parent the parent group of this instantiation of Group
    */
-  SinglePhaseProppantBase( const std::string & name,
+  SinglePhaseProppantBase( const string & name,
                            Group * const parent );
 
   SinglePhaseProppantBase() = delete;

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/WellSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/WellSolverBase.cpp
@@ -30,7 +30,7 @@ namespace geosx
 using namespace dataRepository;
 using namespace constitutive;
 
-WellSolverBase::WellSolverBase( std::string const & name,
+WellSolverBase::WellSolverBase( string const & name,
                                 Group * const parent )
   : SolverBase( name, parent ),
   m_numDofPerWellElement( 0 ),

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/WellSolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/WellSolverBase.hpp
@@ -63,7 +63,7 @@ public:
    * @param name the name of this instantiation of Group in the repository
    * @param parent the parent group of this instantiation of Group
    */
-  WellSolverBase( const std::string & name,
+  WellSolverBase( const string & name,
                   Group * const parent );
 
   /// default destructor

--- a/src/coreComponents/physicsSolvers/multiphysics/CompositionalMultiphaseReservoir.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/CompositionalMultiphaseReservoir.cpp
@@ -35,7 +35,7 @@ namespace geosx
 using namespace dataRepository;
 using namespace constitutive;
 
-CompositionalMultiphaseReservoir::CompositionalMultiphaseReservoir( const std::string & name,
+CompositionalMultiphaseReservoir::CompositionalMultiphaseReservoir( const string & name,
                                                                     Group * const parent ):
   ReservoirSolverBase( name, parent )
 {
@@ -271,6 +271,6 @@ void CompositionalMultiphaseReservoir::assembleCouplingTerms( real64 const GEOSX
   } );
 }
 
-REGISTER_CATALOG_ENTRY( SolverBase, CompositionalMultiphaseReservoir, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( SolverBase, CompositionalMultiphaseReservoir, string const &, Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/physicsSolvers/multiphysics/CompositionalMultiphaseReservoir.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/CompositionalMultiphaseReservoir.hpp
@@ -38,7 +38,7 @@ public:
    * @param name the name of this instantiation of ManagedGroup in the repository
    * @param parent the parent group of this instantiation of ManagedGroup
    */
-  CompositionalMultiphaseReservoir( const std::string & name,
+  CompositionalMultiphaseReservoir( const string & name,
                                     Group * const parent );
 
   /**

--- a/src/coreComponents/physicsSolvers/multiphysics/FlowProppantTransportSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/FlowProppantTransportSolver.cpp
@@ -31,7 +31,7 @@ namespace geosx
 using namespace dataRepository;
 using namespace constitutive;
 
-FlowProppantTransportSolver::FlowProppantTransportSolver( const std::string & name, Group * const parent ):
+FlowProppantTransportSolver::FlowProppantTransportSolver( const string & name, Group * const parent ):
   SolverBase( name, parent ),
   m_proppantSolverName(),
   m_flowSolverName(),
@@ -176,6 +176,6 @@ real64 FlowProppantTransportSolver::solverStep( real64 const & time_n,
   return dtReturn;
 }
 
-REGISTER_CATALOG_ENTRY( SolverBase, FlowProppantTransportSolver, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( SolverBase, FlowProppantTransportSolver, string const &, Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/physicsSolvers/multiphysics/FlowProppantTransportSolver.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/FlowProppantTransportSolver.hpp
@@ -31,7 +31,7 @@ class FlowSolverBase;
 class FlowProppantTransportSolver : public SolverBase
 {
 public:
-  FlowProppantTransportSolver( const std::string & name,
+  FlowProppantTransportSolver( const string & name,
                                Group * const parent );
   ~FlowProppantTransportSolver() override;
 

--- a/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.cpp
@@ -45,7 +45,7 @@ namespace geosx
 using namespace dataRepository;
 using namespace constitutive;
 
-HydrofractureSolver::HydrofractureSolver( const std::string & name,
+HydrofractureSolver::HydrofractureSolver( const string & name,
                                           Group * const parent ):
   SolverBase( name, parent ),
   m_solidSolverName(),
@@ -1049,5 +1049,5 @@ void HydrofractureSolver::initializeNewFaceElements( DomainPartition const & )
 //  m_flowSolver->
 }
 
-REGISTER_CATALOG_ENTRY( SolverBase, HydrofractureSolver, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( SolverBase, HydrofractureSolver, string const &, Group * const )
 } /* namespace geosx */

--- a/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.hpp
@@ -32,7 +32,7 @@ class SolidMechanicsLagrangianFEM;
 class HydrofractureSolver : public SolverBase
 {
 public:
-  HydrofractureSolver( const std::string & name,
+  HydrofractureSolver( const string & name,
                        Group * const parent );
 
   ~HydrofractureSolver() override;

--- a/src/coreComponents/physicsSolvers/multiphysics/LagrangianContactSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/LagrangianContactSolver.cpp
@@ -59,7 +59,7 @@ constexpr integer LagrangianContactSolver::FractureState::SLIP;
 constexpr integer LagrangianContactSolver::FractureState::NEW_SLIP;
 constexpr integer LagrangianContactSolver::FractureState::OPEN;
 
-LagrangianContactSolver::LagrangianContactSolver( const std::string & name,
+LagrangianContactSolver::LagrangianContactSolver( const string & name,
                                                   Group * const parent ):
   SolverBase( name, parent ),
   m_solidSolverName(),
@@ -1126,7 +1126,7 @@ void LagrangianContactSolver::createPreconditioner( DomainPartition const & doma
   if( m_linearSolverParameters.get().preconditionerType == LinearSolverParameters::PreconditionerType::block )
   {
     // TODO: move among inputs (xml)
-    std::string const leadingBlockApproximation = "blockJacobi";
+    string const leadingBlockApproximation = "blockJacobi";
 
     LinearSolverParameters mechParams = m_solidSolver->getLinearSolverParameters();
     // Because of boundary conditions
@@ -2422,5 +2422,5 @@ void LagrangianContactSolver::setNextDt( real64 const & currentDt,
   nextDt = currentDt;
 }
 
-REGISTER_CATALOG_ENTRY( SolverBase, LagrangianContactSolver, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( SolverBase, LagrangianContactSolver, string const &, Group * const )
 } /* namespace geosx */

--- a/src/coreComponents/physicsSolvers/multiphysics/LagrangianContactSolver.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/LagrangianContactSolver.hpp
@@ -31,7 +31,7 @@ class LagrangianContactSolver : public SolverBase
 {
 public:
 
-  LagrangianContactSolver( const std::string & name,
+  LagrangianContactSolver( const string & name,
                            Group * const parent );
 
   ~LagrangianContactSolver() override;

--- a/src/coreComponents/physicsSolvers/multiphysics/PhaseFieldFractureSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/PhaseFieldFractureSolver.cpp
@@ -34,7 +34,7 @@ namespace geosx
 using namespace dataRepository;
 using namespace constitutive;
 
-PhaseFieldFractureSolver::PhaseFieldFractureSolver( const std::string & name,
+PhaseFieldFractureSolver::PhaseFieldFractureSolver( const string & name,
                                                     Group * const parent ):
   SolverBase( name, parent ),
   m_solidSolverName(),
@@ -365,6 +365,6 @@ void PhaseFieldFractureSolver::mapDamageToQuadrature( DomainPartition & domain )
 
 }
 
-REGISTER_CATALOG_ENTRY( SolverBase, PhaseFieldFractureSolver, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( SolverBase, PhaseFieldFractureSolver, string const &, Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/physicsSolvers/multiphysics/PhaseFieldFractureSolver.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/PhaseFieldFractureSolver.hpp
@@ -29,7 +29,7 @@ namespace geosx
 class PhaseFieldFractureSolver : public SolverBase
 {
 public:
-  PhaseFieldFractureSolver( const std::string & name,
+  PhaseFieldFractureSolver( const string & name,
                             Group * const parent );
   ~PhaseFieldFractureSolver() override;
 

--- a/src/coreComponents/physicsSolvers/multiphysics/PoroelasticSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/PoroelasticSolver.cpp
@@ -42,7 +42,7 @@ namespace geosx
 using namespace dataRepository;
 using namespace constitutive;
 
-PoroelasticSolver::PoroelasticSolver( const std::string & name,
+PoroelasticSolver::PoroelasticSolver( const string & name,
                                       Group * const parent ):
   SolverBase( name, parent ),
   m_solidSolverName(),
@@ -640,6 +640,6 @@ real64 PoroelasticSolver::splitOperatorStep( real64 const & time_n,
 }
 
 
-REGISTER_CATALOG_ENTRY( SolverBase, PoroelasticSolver, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( SolverBase, PoroelasticSolver, string const &, Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/physicsSolvers/multiphysics/PoroelasticSolver.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/PoroelasticSolver.hpp
@@ -33,7 +33,7 @@ class FlowSolverBase;
 class PoroelasticSolver : public SolverBase
 {
 public:
-  PoroelasticSolver( const std::string & name,
+  PoroelasticSolver( const string & name,
                      Group * const parent );
   ~PoroelasticSolver() override;
 

--- a/src/coreComponents/physicsSolvers/multiphysics/ReservoirSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/ReservoirSolverBase.cpp
@@ -33,7 +33,7 @@ namespace geosx
 using namespace dataRepository;
 using namespace constitutive;
 
-ReservoirSolverBase::ReservoirSolverBase( const std::string & name,
+ReservoirSolverBase::ReservoirSolverBase( const string & name,
                                           Group * const parent ):
   SolverBase( name, parent ),
   m_flowSolverName(),

--- a/src/coreComponents/physicsSolvers/multiphysics/ReservoirSolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/ReservoirSolverBase.hpp
@@ -41,7 +41,7 @@ public:
    * @param name the name of this instantiation of ManagedGroup in the repository
    * @param parent the parent group of this instantiation of ManagedGroup
    */
-  ReservoirSolverBase( const std::string & name,
+  ReservoirSolverBase( const string & name,
                        Group * const parent );
 
   /**

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhaseReservoir.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhaseReservoir.cpp
@@ -34,7 +34,7 @@ namespace geosx
 using namespace dataRepository;
 using namespace constitutive;
 
-SinglePhaseReservoir::SinglePhaseReservoir( const std::string & name,
+SinglePhaseReservoir::SinglePhaseReservoir( const string & name,
                                             Group * const parent ):
   ReservoirSolverBase( name, parent )
 {}
@@ -231,6 +231,6 @@ void SinglePhaseReservoir::assembleCouplingTerms( real64 const GEOSX_UNUSED_PARA
   } );
 }
 
-REGISTER_CATALOG_ENTRY( SolverBase, SinglePhaseReservoir, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( SolverBase, SinglePhaseReservoir, string const &, Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhaseReservoir.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhaseReservoir.hpp
@@ -38,7 +38,7 @@ public:
    * @param name the name of this instantiation of ManagedGroup in the repository
    * @param parent the parent group of this instantiation of ManagedGroup
    */
-  SinglePhaseReservoir( const std::string & name,
+  SinglePhaseReservoir( const string & name,
                         Group * const parent );
 
   /**

--- a/src/coreComponents/physicsSolvers/simplePDE/LaplaceFEM.cpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/LaplaceFEM.cpp
@@ -80,7 +80,7 @@ using namespace dataRepository;
  */
 
 //START_SPHINX_INCLUDE_01
-LaplaceFEM::LaplaceFEM( const std::string & name,
+LaplaceFEM::LaplaceFEM( const string & name,
                         Group * const parent ):
   SolverBase( name, parent ),
   m_fieldName( "primaryField" ),
@@ -368,6 +368,6 @@ void LaplaceFEM::resetStateToBeginningOfStep( DomainPartition & GEOSX_UNUSED_PAR
 {}
 
 //START_SPHINX_INCLUDE_00
-REGISTER_CATALOG_ENTRY( SolverBase, LaplaceFEM, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( SolverBase, LaplaceFEM, string const &, Group * const )
 //END_SPHINX_INCLUDE_00
 } /* namespace ANST */

--- a/src/coreComponents/physicsSolvers/simplePDE/LaplaceFEM.hpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/LaplaceFEM.hpp
@@ -36,7 +36,7 @@ public:
   LaplaceFEM() = delete;
 
   // The constructor needs a user-defined "name" and a parent Group (to place this instance in the tree structure of classes)
-  LaplaceFEM( const std::string & name,
+  LaplaceFEM( const string & name,
               Group * const parent );
 
   // Destructor

--- a/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEM.cpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEM.cpp
@@ -52,7 +52,7 @@ namespace keys
 using namespace dataRepository;
 using namespace constitutive;
 
-PhaseFieldDamageFEM::PhaseFieldDamageFEM( const std::string & name,
+PhaseFieldDamageFEM::PhaseFieldDamageFEM( const string & name,
                                           Group * const parent ):
   SolverBase( name, parent ),
   m_fieldName( "primaryField" ),
@@ -593,6 +593,6 @@ void PhaseFieldDamageFEM::applyDirichletBCImplicit( real64 const time,
   fsManager.applyFieldValue< serialPolicy >( time, &domain, "ElementRegions", viewKeyStruct::coeffName );
 }
 
-REGISTER_CATALOG_ENTRY( SolverBase, PhaseFieldDamageFEM, std::string const &,
+REGISTER_CATALOG_ENTRY( SolverBase, PhaseFieldDamageFEM, string const &,
                         Group * const )
 } // namespace geosx

--- a/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEM.hpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEM.hpp
@@ -42,7 +42,7 @@ class DomainPartition;
 class PhaseFieldDamageFEM : public SolverBase
 {
 public:
-  PhaseFieldDamageFEM( const std::string & name, Group * const parent );
+  PhaseFieldDamageFEM( const string & name, Group * const parent );
 
   virtual ~PhaseFieldDamageFEM() override;
 

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsEmbeddedFractures.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsEmbeddedFractures.cpp
@@ -41,7 +41,7 @@ namespace geosx
 using namespace dataRepository;
 using namespace constitutive;
 
-SolidMechanicsEmbeddedFractures::SolidMechanicsEmbeddedFractures( const std::string & name,
+SolidMechanicsEmbeddedFractures::SolidMechanicsEmbeddedFractures( const string & name,
                                                                   Group * const parent ):
   SolverBase( name, parent ),
   m_solidSolverName(),
@@ -562,5 +562,5 @@ void SolidMechanicsEmbeddedFractures::applySystemSolution( DofManager const & do
 
 }
 
-REGISTER_CATALOG_ENTRY( SolverBase, SolidMechanicsEmbeddedFractures, std::string const &, Group * const )
+REGISTER_CATALOG_ENTRY( SolverBase, SolidMechanicsEmbeddedFractures, string const &, Group * const )
 } /* namespace geosx */

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsEmbeddedFractures.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsEmbeddedFractures.hpp
@@ -31,7 +31,7 @@ class SolidMechanicsLagrangianFEM;
 class SolidMechanicsEmbeddedFractures : public SolverBase
 {
 public:
-  SolidMechanicsEmbeddedFractures( const std::string & name,
+  SolidMechanicsEmbeddedFractures( const string & name,
                                    Group * const parent );
 
   ~SolidMechanicsEmbeddedFractures() override;

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
@@ -45,7 +45,7 @@ namespace geosx
 using namespace dataRepository;
 using namespace constitutive;
 
-SolidMechanicsLagrangianFEM::SolidMechanicsLagrangianFEM( const std::string & name,
+SolidMechanicsLagrangianFEM::SolidMechanicsLagrangianFEM( const string & name,
                                                           Group * const parent ):
   SolverBase( name, parent ),
   m_newmarkGamma( 0.5 ),

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.hpp
@@ -56,7 +56,7 @@ public:
    * @param name The name of the solver instance
    * @param parent the parent group of the solver
    */
-  SolidMechanicsLagrangianFEM( const std::string & name,
+  SolidMechanicsLagrangianFEM( const string & name,
                                Group * const parent );
 
 

--- a/src/coreComponents/physicsSolvers/surfaceGeneration/EmbeddedSurfaceGenerator.cpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/EmbeddedSurfaceGenerator.cpp
@@ -42,7 +42,7 @@ namespace geosx
 using namespace dataRepository;
 using namespace constitutive;
 
-EmbeddedSurfaceGenerator::EmbeddedSurfaceGenerator( const std::string & name,
+EmbeddedSurfaceGenerator::EmbeddedSurfaceGenerator( const string & name,
                                                     Group * const parent ):
   SolverBase( name, parent )
 {
@@ -237,6 +237,6 @@ void EmbeddedSurfaceGenerator::addToFractureStencil( DomainPartition & domain )
 
 REGISTER_CATALOG_ENTRY( SolverBase,
                         EmbeddedSurfaceGenerator,
-                        std::string const &, dataRepository::Group * const )
+                        string const &, dataRepository::Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/physicsSolvers/surfaceGeneration/EmbeddedSurfaceGenerator.hpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/EmbeddedSurfaceGenerator.hpp
@@ -55,7 +55,7 @@ class ElementRegionBase;
 class EmbeddedSurfaceGenerator : public SolverBase
 {
 public:
-  EmbeddedSurfaceGenerator( const std::string & name,
+  EmbeddedSurfaceGenerator( const string & name,
                             Group * const parent );
   ~EmbeddedSurfaceGenerator() override;
 

--- a/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
@@ -170,7 +170,7 @@ static void CheckForAndRemoveDeadEndPath( const localIndex edgeIndex,
 }
 
 
-SurfaceGenerator::SurfaceGenerator( const std::string & name,
+SurfaceGenerator::SurfaceGenerator( const string & name,
                                     Group * const parent ):
   SolverBase( name, parent ),
   m_failCriterion( 1 ),
@@ -4543,6 +4543,6 @@ SurfaceGenerator::calculateRuptureRate( SurfaceElementRegion & faceElementRegion
 
 REGISTER_CATALOG_ENTRY( SolverBase,
                         SurfaceGenerator,
-                        std::string const &, dataRepository::Group * const )
+                        string const &, dataRepository::Group * const )
 
 } /* namespace geosx */

--- a/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.hpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.hpp
@@ -60,7 +60,7 @@ class ElementRegionBase;
 class SurfaceGenerator : public SolverBase
 {
 public:
-  SurfaceGenerator( const std::string & name,
+  SurfaceGenerator( const string & name,
                     Group * const parent );
   ~SurfaceGenerator() override;
 

--- a/src/docs/doxygen/GeosxConfig.hpp
+++ b/src/docs/doxygen/GeosxConfig.hpp
@@ -69,11 +69,11 @@
 #define GEOSX_USE_PETSC
 
 /// Choice of global linear algebra interface (CMake option GEOSX_LA_INTERFACE)
-#define GEOSX_LA_INTERFACE Trilinos
+#define GEOSX_LA_INTERFACE Hypre
 /// Macro defined when Trilinos interface is selected
-#define GEOSX_LA_INTERFACE_TRILINOS
+/* #undef GEOSX_LA_INTERFACE_TRILINOS */
 /// Macro defined when Hypre interface is selected
-/* #undef GEOSX_LA_INTERFACE_HYPRE */
+#define GEOSX_LA_INTERFACE_HYPRE
 /// Macro defined when PETSc interface is selected
 /* #undef GEOSX_LA_INTERFACE_PETSC */
 

--- a/src/externalComponents/newComponentTemplate/src/NewComponent.cpp
+++ b/src/externalComponents/newComponentTemplate/src/NewComponent.cpp
@@ -25,7 +25,7 @@
 namespace geosx
 {
 
-NewComponent::NewComponent( std::string const & name,
+NewComponent::NewComponent( string const & name,
                             Group * const parent ):
     SolverBase(name,parent)
 {
@@ -47,6 +47,6 @@ real64 NewComponent::SolverStep( real64 const & /*time_n*/,
   return 0;
 }
 
-REGISTER_CATALOG_ENTRY( SolverBase, NewComponent, std::string const &, dataRepository::Group * const )
+REGISTER_CATALOG_ENTRY( SolverBase, NewComponent, string const &, dataRepository::Group * const )
 
 } /* namespace geosx */

--- a/src/externalComponents/newComponentTemplate/src/NewComponent.hpp
+++ b/src/externalComponents/newComponentTemplate/src/NewComponent.hpp
@@ -36,11 +36,11 @@ class DomainPartition;
 class NewComponent : public SolverBase
 {
 public:
-  NewComponent( std::string const & name,
+  NewComponent( string const & name,
                 Group * const parent);
   virtual ~NewComponent() override;
 
-  static std::string catalogName() { return "NewComponent"; }
+  static string catalogName() { return "NewComponent"; }
 
 
   virtual real64 SolverStep( real64 const& time_n,

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -48,7 +48,7 @@ int main( int argc, char *argv[] )
   gettimeofday( &tim, nullptr );
   real64 t_start = tim.tv_sec + (tim.tv_usec / 1000000.0);
 
-  std::string restartFileName;
+  string restartFileName;
   bool restart = ProblemManager::parseRestart( restartFileName );
   if( restart )
   {


### PR DESCRIPTION
This PR replaces instances of `std::string` with the `string` alias inside of GEOSX. 