### PR TITLE
Fixed crash in SinglePhaseFVM with wells and fractures

### DIFF
--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhaseReservoir.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhaseReservoir.cpp
@@ -26,7 +26,7 @@
 #include "common/TimingMacros.hpp"
 #include "physicsSolvers/fluidFlow/SinglePhaseBase.hpp"
 #include "physicsSolvers/fluidFlow/wells/SinglePhaseWell.hpp"
-
+#include "physicsSolvers/fluidFlow/SinglePhaseFVM.hpp"
 
 namespace geosx
 {
@@ -41,6 +41,29 @@ SinglePhaseReservoir::SinglePhaseReservoir( const std::string & name,
 
 SinglePhaseReservoir::~SinglePhaseReservoir()
 {}
+
+void SinglePhaseReservoir::setupSystem( DomainPartition & domain,
+                                        DofManager & dofManager,
+                                        CRSMatrix< real64, globalIndex > & localMatrix,
+                                        array1d< real64 > & localRhs,
+                                        array1d< real64 > & localSolution,
+                                        bool const setSparsity )
+{
+  ReservoirSolverBase::setupSystem( domain,
+                                    dofManager,
+                                    localMatrix,
+                                    localRhs,
+                                    localSolution,
+                                    setSparsity );
+
+  // we need to set the dR_dAper CRS matrix in SinglePhaseFVM to handle the presence of fractures
+  if( dynamicCast< SinglePhaseFVM< SinglePhaseBase > * >( m_flowSolver ) )
+  {
+    SinglePhaseFVM< SinglePhaseBase > * fvmSolver = dynamicCast< SinglePhaseFVM< SinglePhaseBase > * >( m_flowSolver );
+    fvmSolver->setUpDflux_dApertureMatrix( domain, dofManager, localMatrix );
+  }
+}
+
 
 void SinglePhaseReservoir::addCouplingSparsityPattern( DomainPartition const & domain,
                                                        DofManager const & dofManager,

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhaseReservoir.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhaseReservoir.hpp
@@ -71,6 +71,14 @@ public:
    */
   /**@{*/
 
+  virtual void
+  setupSystem( DomainPartition & domain,
+               DofManager & dofManager,
+               CRSMatrix< real64, globalIndex > & localMatrix,
+               array1d< real64 > & localRhs,
+               array1d< real64 > & localSolution,
+               bool const setSparsity = true ) override;
+
   /**@}*/
 
   virtual void addCouplingSparsityPattern( DomainPartition const & domain,


### PR DESCRIPTION
The CRS matrix `m_derivativeFluxResidual_dAperture` was not initialized properly when the `SinglePhaseFVM` solver was used with wells, causing a crash. This PR adds an initialization of this matrix in `SinglePhaseReservoir::setupSystem`.

@ishovkun let me know if you have other issues with wells.

Fixes #1302.