### PR TITLE
Apply renaming to update functions in CompositionalMultiphaseFlowKernels

### DIFF
--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFlowKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFlowKernels.hpp
@@ -235,7 +235,7 @@ struct FluidUpdateKernel
       localIndex const k = targetSet[a];
       for( localIndex q = 0; q < fluidWrapper.numGauss(); ++q )
       {
-        fluidWrapper.Update( k, q, pres[k] + dPres[k], temp, compFrac[k] );
+        fluidWrapper.update( k, q, pres[k] + dPres[k], temp, compFrac[k] );
       }
     } );
   }
@@ -289,7 +289,7 @@ struct RelativePermeabilityUpdateKernel
       localIndex const k = targetSet[a];
       for( localIndex q = 0; q < relPermWrapper.numGauss(); ++q )
       {
-        relPermWrapper.Update( k, q, phaseVolFrac[k] );
+        relPermWrapper.update( k, q, phaseVolFrac[k] );
       }
     } );
   }
@@ -325,7 +325,7 @@ struct CapillaryPressureUpdateKernel
       localIndex const k = targetSet[a];
       for( localIndex q = 0; q < capPresWrapper.numGauss(); ++q )
       {
-        capPresWrapper.Update( k, q, phaseVolFrac[k] );
+        capPresWrapper.update( k, q, phaseVolFrac[k] );
       }
     } );
   }


### PR DESCRIPTION
This PR applies the camel back naming conventions to three function calls in `CompositionalMultiphaseFlowKernels.hpp`. The `Update` function currently called in `develop` does not exist anymore after the `clang-tidy` renaming.