### PR TITLE
Fix Debug-build compile fail on Lassen

### DIFF
--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseHybridFVMKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseHybridFVMKernels.hpp
@@ -860,7 +860,7 @@ struct PrecomputeKernel
       }
     } );
 
-    forAll< serialPolicy >( faceManagerSize, [=] GEOSX_HOST_DEVICE ( localIndex const iface )
+    forAll< serialPolicy >( faceManagerSize, [=] GEOSX_HOST ( localIndex const iface )
     {
       if( !isZero( mimFaceGravCoefDenominator[iface].get() ) )
       {

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseHybridFVMKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseHybridFVMKernels.hpp
@@ -860,7 +860,7 @@ struct PrecomputeKernel
       }
     } );
 
-    forAll< serialPolicy >( faceManagerSize, [=] GEOSX_HOST ( localIndex const iface )
+    forAll< serialPolicy >( faceManagerSize, [=] ( localIndex const iface )
     {
       if( !isZero( mimFaceGravCoefDenominator[iface].get() ) )
       {


### PR DESCRIPTION
This only effects the Debug build on Lassen. The Release and RelWithDebInfo builds work fine, which is why the nightlies didn't fail. Only one travis might have caught this: Ubuntu18.04_clang8.0.0_cuda10.1.243_debug, but presumably compiler/other version differences prevented it?

There was a host-only call ( `serialReduce::get()` ) inside a host-device lambda.