### PR TITLE
Changed how the finite element kernel objects are constructed.

### DIFF
--- a/src/coreComponents/finiteElement/kernelInterface/KernelBase.hpp
+++ b/src/coreComponents/finiteElement/kernelInterface/KernelBase.hpp
@@ -27,61 +27,6 @@
 #include "mesh/ElementRegionManager.hpp"
 #include "common/GEOS_RAJA_Interface.hpp"
 
-
-
-#if defined(__APPLE__)
-/// Use camp::tuple to hold constructor params.
-#define CONSTRUCTOR_PARAM_OPTION 2
-#else
-/// Use std::tuple to hold constructor params.
-#define CONSTRUCTOR_PARAM_OPTION 1
-#endif
-
-#if CONSTRUCTOR_PARAM_OPTION==1
-namespace std
-{
-namespace detail
-{
-/**
- * @brief Implementation of std::make_from_tuple()
- * @tparam T
- * @tparam Tuple
- * @tparam I
- * @tparam T
- * @tparam Tuple
- * @tparam I
- * @param t
- * @param
- * @return
- */
-template< class T, class Tuple, std::size_t... I >
-constexpr T make_from_tuple_impl( Tuple && t, std::index_sequence< I... > )
-{
-  return T( std::get< I >( std::forward< Tuple >( t ))... );
-}
-} // namespace detail
-
-/**
- * @brief Implementation of std::make_from_tuple()
- * @tparam T
- * @tparam Tuple
- * @tparam T
- * @tparam Tuple
- * @param t
- * @return
- */
-template< class T, class Tuple >
-constexpr T make_from_tuple( Tuple && t )
-{
-  return detail::make_from_tuple_impl< T >( std::forward< Tuple >( t ),
-                                            std::make_index_sequence< std::tuple_size< std::remove_reference_t< Tuple > >::value >{} );
-}
-
-}
-#elif CONSTRUCTOR_PARAM_OPTION==2
-  #include "camp/camp.hpp"
-#endif
-
 namespace geosx
 {
 
@@ -313,6 +258,75 @@ protected:
   FE_TYPE const & m_finiteElementSpace;
 };
 
+/**
+ * @class KernelFactory
+ * @brief Used to forward arguments to a class that implements the KernelBase interface.
+ * @tparam KERNEL_TYPE The template class to construct, should implement the KernelBase interface.
+ * @tparam ARGS The arguments used to construct a @p KERNEL_TYPE in addition to the standard arguments.
+ */
+template< template< typename SUBREGION_TYPE,
+                    typename CONSTITUTIVE_TYPE,
+                    typename FE_TYPE > class KERNEL_TYPE,
+          typename ... ARGS >
+class KernelFactory
+{
+public:
+
+  /**
+   * @brief Initialize the factory.
+   * @param args The arguments used to construct a @p KERNEL_TYPE in addition to the standard arguments.
+   */
+  KernelFactory( ARGS ... args ):
+    m_args( args ... )
+  {}
+
+  /**
+   * @brief Create a new kernel with the given standard arguments.
+   * @tparam SUBREGION_TYPE The type of @p elementSubRegion.
+   * @tparam CONSTITUTIVE_TYPE The type of @p inputConstitutiveType.
+   * @tparam FE_TYPE The type of @p finiteElementSpace.
+   * @param nodeManager The node manager.
+   * @param edgeManager The edge manager.
+   * @param faceManager The face manager.
+   * @param targetRegionIndex The target region index.
+   * @param elementSubRegion The subregion to execute on.
+   * @param finiteElementSpace The finite element space.
+   * @param inputConstitutiveType The constitutive relation.
+   * @return A new kernel constructed with the given arguments and @c ARGS.
+   */
+  template< typename SUBREGION_TYPE, typename CONSTITUTIVE_TYPE, typename FE_TYPE >
+  KERNEL_TYPE< SUBREGION_TYPE, CONSTITUTIVE_TYPE, FE_TYPE > createKernel(
+    NodeManager & nodeManager,
+    EdgeManager const & edgeManager,
+    FaceManager const & faceManager,
+    localIndex const targetRegionIndex,
+    SUBREGION_TYPE const & elementSubRegion,
+    FE_TYPE const & finiteElementSpace,
+    CONSTITUTIVE_TYPE & inputConstitutiveType )
+  {
+    camp::tuple< NodeManager &,
+                 EdgeManager const &,
+                 FaceManager const &,
+                 localIndex const,
+                 SUBREGION_TYPE const &,
+                 FE_TYPE const &,
+                 CONSTITUTIVE_TYPE & > standardArgs { nodeManager,
+                                                      edgeManager,
+                                                      faceManager,
+                                                      targetRegionIndex,
+                                                      elementSubRegion,
+                                                      finiteElementSpace,
+                                                      inputConstitutiveType };
+
+    auto allArgs = camp::tuple_cat_pair( standardArgs, m_args );
+    return camp::make_from_tuple< KERNEL_TYPE< SUBREGION_TYPE, CONSTITUTIVE_TYPE, FE_TYPE > >( allArgs );
+  }
+
+private:
+  /// The arguments to append to the standard kernel constructor arguments.
+  camp::tuple< ARGS ... > m_args;
+};
+
 
 //*****************************************************************************
 //*****************************************************************************
@@ -320,56 +334,36 @@ protected:
 
 //START_regionBasedKernelApplication
 /**
- * @brief Performs a loop over specific regions (by type and name) and calls
- *        a kernel launch on the subregions with compile time knowledge of
- *        sub-loop bounds such as number of nodes and quadrature points per
- *        element.
+ * @brief Performs a loop over specific regions (by type and name) and calls a kernel launch on the subregions
+ *   with compile time knowledge of sub-loop bounds such as number of nodes and quadrature points per element.
  * @tparam POLICY The RAJA launch policy to pass to the kernel launch.
- * @tparam CONSTITUTIVE_BASE The common base class for constitutive
- *                           pass-thru/dispatch which gives the kernel launch
- *                           compile time knowledge of the constitutive model.
- *                           This is achieved through a call to the
- *                           ConstitutivePassThru function which
- *                           should have a specialization for CONSTITUTIVE_BASE
- *                           implemented in order to perform the compile time
- *                           dispatch.
- * @tparam REGION_TYPE The type of region to loop over. TODO make this a
- *                     parameter pack?
- * @tparam KERNEL_TEMPLATE The type of template for the physics kernel, which
- *                         conforms to the interface specified by KernelBase.
- * @tparam KERNEL_CONSTRUCTOR_PARAMS The template parameter pack to hold the
- *                                   parameter pack (i.e. custom) parameters
- *                                   that are sent to the constructor for the
- *                                   @p KERNEL_TEMPLATE.
+ * @tparam CONSTITUTIVE_BASE The common base class for constitutive pass-thru/dispatch which gives the kernel
+ *   launch compile time knowledge of the constitutive model. This is achieved through a call to the
+ *   ConstitutivePassThru function which should have a specialization for CONSTITUTIVE_BASE implemented in
+ *   order to perform the compile time dispatch.
+ * @tparam SUBREGION_TYPE The type of subregion to loop over. TODO make this a parameter pack?
+ * @tparam KERNEL_FACTORY The type of @p kernelFactory, typically an instantiation of @c KernelFactory, and
+ *   must adhere to that interface.
  * @param mesh The MeshLevel object.
- * @param targetRegions The names of the target regions(of type @p REGION_TYPE)
- *                      to apply the @p KERNEL_TEMPLATE.
+ * @param targetRegions The names of the target regions(of type @p SUBREGION_TYPE) to apply the @p KERNEL_TEMPLATE.
  * @param finiteElementName The name of the finite element.
- * @param constitutiveNames The names of the constitutive models present in the
- *                          Region.
- * @param kernelConstructorParams The parameter list for corresponding to the
- *                                parameter @p KERNEL_CONSTRUCTOR_PARAMS that
- *                                are passed to the @p KERNEL_TEMPLATE
- *                                constructor.
- * @return The maximum contribution to the residual, which may be used to scale
- *         the residual.
+ * @param constitutiveNames The names of the constitutive models present in the region.
+ * @param kernelFactory The object used to construct the kernel.
+ * @return The maximum contribution to the residual, which may be used to scale the residual.
  *
- * Loops over all regions Applies/Launches a kernel specified by the @p KERNEL_TEMPLATE through
+ * @details Loops over all regions Applies/Launches a kernel specified by the @p KERNEL_TEMPLATE through
  * #::geosx::finiteElement::KernelBase::kernelLaunch().
  */
 template< typename POLICY,
           typename CONSTITUTIVE_BASE,
-          typename REGION_TYPE,
-          template< typename SUBREGION_TYPE,
-                    typename CONSTITUTIVE_TYPE,
-                    typename FE_TYPE > class KERNEL_TEMPLATE,
-          typename ... KERNEL_CONSTRUCTOR_PARAMS >
+          typename SUBREGION_TYPE,
+          typename KERNEL_FACTORY >
 static
 real64 regionBasedKernelApplication( MeshLevel & mesh,
                                      arrayView1d< string const > const & targetRegions,
                                      string const & finiteElementName,
                                      arrayView1d< string const > const & constitutiveNames,
-                                     KERNEL_CONSTRUCTOR_PARAMS && ... kernelConstructorParams )
+                                     KERNEL_FACTORY & kernelFactory )
 {
   GEOSX_MARK_FUNCTION;
   // save the maximum residual contribution for scaling residuals for convergence criteria.
@@ -380,31 +374,18 @@ real64 regionBasedKernelApplication( MeshLevel & mesh,
   FaceManager & faceManager = mesh.getFaceManager();
   ElementRegionManager & elementRegionManager = mesh.getElemManager();
 
-
-  // Create a tuple that contains the kernelConstructorParams, as the lambda does not properly catch the parameter pack
-  // until c++20
-#if CONSTRUCTOR_PARAM_OPTION==1
-  std::tuple< KERNEL_CONSTRUCTOR_PARAMS &... > kernelConstructorParamsTuple = std::forward_as_tuple( kernelConstructorParams ... );
-#elif CONSTRUCTOR_PARAM_OPTION==2
-  camp::tuple< KERNEL_CONSTRUCTOR_PARAMS &... > kernelConstructorParamsTuple = camp::forward_as_tuple( kernelConstructorParams ... );
-#endif
-
-
-  // Loop over all sub-regions in regiongs of type REGION_TYPE, that are listed in the targetRegions array.
-  elementRegionManager.forElementSubRegions< REGION_TYPE >( targetRegions,
-                                                            [&constitutiveNames,
-                                                             &maxResidualContribution,
-                                                             &nodeManager,
-                                                             &edgeManager,
-                                                             &faceManager,
-                                                             &kernelConstructorParamsTuple,
-                                                             &finiteElementName]
-                                                              ( localIndex const targetRegionIndex, auto & elementSubRegion )
+  // Loop over all sub-regions in regions of type SUBREGION_TYPE, that are listed in the targetRegions array.
+  elementRegionManager.forElementSubRegions< SUBREGION_TYPE >( targetRegions,
+                                                               [&constitutiveNames,
+                                                                &maxResidualContribution,
+                                                                &nodeManager,
+                                                                &edgeManager,
+                                                                &faceManager,
+                                                                &kernelFactory,
+                                                                &finiteElementName]
+                                                                 ( localIndex const targetRegionIndex, auto & elementSubRegion )
   {
     localIndex const numElems = elementSubRegion.size();
-
-    // Create an alias for the type of subregion we are in, which is now known at compile time.
-    typedef TYPEOFREF( elementSubRegion ) SUBREGIONTYPE;
 
     // Get the constitutive model...and allocate a null constitutive model if required.
     constitutive::ConstitutiveBase * constitutiveRelation = nullptr;
@@ -425,17 +406,13 @@ real64 regionBasedKernelApplication( MeshLevel & mesh,
                                                                        &nodeManager,
                                                                        &edgeManager,
                                                                        &faceManager,
-                                                                       &kernelConstructorParamsTuple,
-                                                                       &targetRegionIndex,
+                                                                       targetRegionIndex,
+                                                                       &kernelFactory,
                                                                        &elementSubRegion,
                                                                        &finiteElementName,
                                                                        numElems]
                                                                         ( auto & castedConstitutiveRelation )
     {
-      // Create an alias for the type of constitutive model.
-      using CONSTITUTIVE_TYPE = TYPEOFREF( castedConstitutiveRelation );
-
-
       string const elementTypeString = elementSubRegion.getElementTypeString();
 
       FiniteElementBase &
@@ -446,59 +423,26 @@ real64 regionBasedKernelApplication( MeshLevel & mesh,
                                   &nodeManager,
                                   &edgeManager,
                                   &faceManager,
-                                  &kernelConstructorParamsTuple,
-                                  &targetRegionIndex,
+                                  targetRegionIndex,
+                                  &kernelFactory,
                                   &elementSubRegion,
-                                  &numElems,
+                                  numElems,
                                   &castedConstitutiveRelation] ( auto const finiteElement )
       {
-        using FE_TYPE = TYPEOFREF( finiteElement );
+        auto kernel = kernelFactory.createKernel( nodeManager,
+                                                  edgeManager,
+                                                  faceManager,
+                                                  targetRegionIndex,
+                                                  elementSubRegion,
+                                                  finiteElement,
+                                                  castedConstitutiveRelation );
 
-        // Define an alias for the kernel type for easy use.
-        using KERNEL_TYPE = KERNEL_TEMPLATE< SUBREGIONTYPE,
-                                             CONSTITUTIVE_TYPE,
-                                             FE_TYPE >;
-
-        // 1) Combine the tuple containing the physics kernel specific constructor parameters with
-        // the parameters common to all phsyics kernels that use this interface,
-        // 2) Instantiate the kernel.
-        // note: have two options, using std::tuple and camp::tuple. Due to a bug in the OSX
-        // implementation of std::tuple_cat, we must use camp on OSX. In the future, we should
-        // only use one option...most likely camp since we can easily fix bugs.
-#if CONSTRUCTOR_PARAM_OPTION==1
-        auto temp = std::forward_as_tuple( nodeManager,
-                                           edgeManager,
-                                           faceManager,
-                                           targetRegionIndex,
-                                           elementSubRegion,
-                                           finiteElement,
-                                           castedConstitutiveRelation );
-
-        auto fullKernelComponentConstructorArgs = std::tuple_cat( temp,
-                                                                  kernelConstructorParamsTuple );
-
-        KERNEL_TYPE kernelComponent = std::make_from_tuple< KERNEL_TYPE >( fullKernelComponentConstructorArgs );
-
-#elif CONSTRUCTOR_PARAM_OPTION==2
-        auto temp = camp::forward_as_tuple( nodeManager,
-                                            edgeManager,
-                                            faceManager,
-                                            targetRegionIndex,
-                                            elementSubRegion,
-                                            finiteElement,
-                                            castedConstitutiveRelation );
-        auto fullKernelComponentConstructorArgs = camp::tuple_cat_pair( temp,
-                                                                        kernelConstructorParamsTuple );
-        KERNEL_TYPE kernelComponent = camp::make_from_tuple< KERNEL_TYPE >( fullKernelComponentConstructorArgs );
-
-#endif
+        using KERNEL_TYPE = decltype( kernel );
 
         // Call the kernelLaunch function, and store the maximum contribution to the residual.
         maxResidualContribution =
           std::max( maxResidualContribution,
-                    KERNEL_TYPE::template kernelLaunch< POLICY,
-                                                        KERNEL_TYPE >( numElems,
-                                                                       kernelComponent ) );
+                    KERNEL_TYPE::template kernelLaunch< POLICY, KERNEL_TYPE >( numElems, kernel ) );
       } );
     } );
 

--- a/src/coreComponents/finiteElement/kernelInterface/SparsityKernelBase.hpp
+++ b/src/coreComponents/finiteElement/kernelInterface/SparsityKernelBase.hpp
@@ -175,36 +175,78 @@ private:
  * @brief Helper struct to define a specialization of
  *   #::geosx::finiteElement::SparsityKernelBase that may be used to generate the sparsity pattern.
  * @tparam KERNEL_TEMPLATE Templated class that defines the physics kernel.
- *                         Most likely derives from SparsityKernelBase.
+ *   Most likely derives from SparsityKernelBase.
  */
 template< template< typename,
                     typename,
                     typename > class KERNEL_TEMPLATE >
-struct SparsityHelper
+class SparsityKernelFactory
 {
+public:
 
   /**
-   * Defines an alias for the specialization of
-   * #geosx::finiteElement::SparsityKernelBase from the compile time constants
-   * defined in @p KERNEL_TEMPLATE. Specifically, the
-   * NUM_TEST_SUPPORT_POINTS_PER_ELEM and NUM_TRIAL_SUPPORT_POINTS_PER_ELEM
-   * parameters are specified by the physics solver.
+   * @brief Constructor.
+   * @param inputDofNumber An array containing the input degree of freedom numbers.
+   * @param rankOffset The global rank offset.
+   * @param inputSparsityPattern The local sparsity pattern.
    */
-  template< typename SUBREGION_TYPE,
-            typename CONSTITUTIVE_TYPE,
-            typename FE_TYPE >
-  using Kernel = SparsityKernelBase< SUBREGION_TYPE,
-                                     CONSTITUTIVE_TYPE,
-                                     FE_TYPE,
-                                     KERNEL_TEMPLATE< SUBREGION_TYPE,
-                                                      CONSTITUTIVE_TYPE,
-                                                      FE_TYPE >::numDofPerTestSupportPoint,
-                                     KERNEL_TEMPLATE< SUBREGION_TYPE,
-                                                      CONSTITUTIVE_TYPE,
-                                                      FE_TYPE >::numDofPerTrialSupportPoint
-                                     >;
-};
+  SparsityKernelFactory( arrayView1d< globalIndex const > const & inputDofNumber,
+                         globalIndex const rankOffset,
+                         SparsityPattern< globalIndex > & inputSparsityPattern ):
+    m_inputDofNumber( inputDofNumber ),
+    m_rankOffset( rankOffset ),
+    m_inputSparsityPattern( inputSparsityPattern )
+  {}
 
+  /**
+   * @brief Return a new instance of @c SparsityKernelBase specialized for @c KERNEL_TEMPLATE.
+   * @tparam SUBREGION_TYPE The type of of @p elementSubRegion.
+   * @tparam CONSTITUTIVE_TYPE The type of @p inputConstitutiveType.
+   * @tparam FE_TYPE The type of @p finiteElementSpace.
+   * @param nodeManager The node manager.
+   * @param edgeManager The edge manager.
+   * @param faceManager The face manager.
+   * @param targetRegionIndex The target region index.
+   * @param elementSubRegion The sub region on which to generate the sparsity.
+   * @param finiteElementSpace The finite element space.
+   * @param inputConstitutiveType The constitutive relation.
+   * @return A new instance of @c SparsityKernelBase specialized for @c KERNEL_TEMPLATE.
+   */
+  template< typename SUBREGION_TYPE, typename CONSTITUTIVE_TYPE, typename FE_TYPE >
+  auto createKernel( NodeManager const & nodeManager,
+                     EdgeManager const & edgeManager,
+                     FaceManager const & faceManager,
+                     localIndex const targetRegionIndex,
+                     SUBREGION_TYPE const & elementSubRegion,
+                     FE_TYPE const & finiteElementSpace,
+                     CONSTITUTIVE_TYPE & inputConstitutiveType )
+  {
+    using Kernel = KERNEL_TEMPLATE< SUBREGION_TYPE, CONSTITUTIVE_TYPE, FE_TYPE >;
+
+    return SparsityKernelBase< SUBREGION_TYPE,
+                               CONSTITUTIVE_TYPE,
+                               FE_TYPE,
+                               Kernel::numDofPerTestSupportPoint,
+                               Kernel::numDofPerTrialSupportPoint >( nodeManager,
+                                                                     edgeManager,
+                                                                     faceManager,
+                                                                     targetRegionIndex,
+                                                                     elementSubRegion,
+                                                                     finiteElementSpace,
+                                                                     inputConstitutiveType,
+                                                                     m_inputDofNumber,
+                                                                     m_rankOffset,
+                                                                     m_inputSparsityPattern );
+  }
+
+private:
+  /// The input degree of freedom numbers.
+  arrayView1d< globalIndex const > const & m_inputDofNumber;
+  /// The global rank offset.
+  globalIndex const m_rankOffset;
+  /// The local sparsity pattern.
+  SparsityPattern< globalIndex > & m_inputSparsityPattern;
+};
 
 //*****************************************************************************
 //*****************************************************************************
@@ -244,17 +286,15 @@ real64 fillSparsity( MeshLevel & mesh,
 {
   GEOSX_MARK_FUNCTION;
 
+  SparsityKernelFactory< KERNEL_TEMPLATE > KernelFactory( inputDofNumber, rankOffset, inputSparsityPattern );
+
   regionBasedKernelApplication< serialPolicy,
                                 constitutive::NullModel,
-                                REGION_TYPE,
-                                SparsityHelper< KERNEL_TEMPLATE >::template Kernel
-                                >( mesh,
-                                   targetRegions,
-                                   discretizationName,
-                                   arrayView1d< string const >(),
-                                   inputDofNumber,
-                                   rankOffset,
-                                   inputSparsityPattern );
+                                REGION_TYPE >( mesh,
+                                               targetRegions,
+                                               discretizationName,
+                                               arrayView1d< string const >(),
+                                               KernelFactory );
 
   return 0;
 }

--- a/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoroelasticKernel.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoroelasticKernel.hpp
@@ -92,7 +92,7 @@ public:
               real64 const (&inputGravityVector)[3],
               localIndex const numComponents,
               localIndex const numPhases,
-              arrayView1d< string const > const & fluidModelNames,
+              arrayView1d< string const > const fluidModelNames,
               CRSMatrixView< real64, globalIndex const > const & inputMatrix,
               arrayView1d< real64 > const & inputRhs ):
     Base( nodeManager,
@@ -526,6 +526,16 @@ protected:
   real64 const m_biotCoefficient;
 };
 
+using MultiphaseKernelFactory = finiteElement::KernelFactory< Multiphase,
+                                                              arrayView1d< globalIndex const > const &,
+                                                              string const &,
+                                                              globalIndex const,
+                                                              real64 const (&)[3],
+                                                              localIndex const,
+                                                              localIndex const,
+                                                              arrayView1d< string const > const,
+                                                              CRSMatrixView< real64, globalIndex const > const &,
+                                                              arrayView1d< real64 > const & >;
 
 } // namespace PoroelasticKernels
 

--- a/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoroelasticSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoroelasticSolver.cpp
@@ -194,28 +194,26 @@ void MultiphasePoroelasticSolver::assembleSystem( real64 const time_n,
 
   real64 const gravityVectorData[3] = LVARRAY_TENSOROPS_INIT_LOCAL_3( gravityVector() );
 
+  PoroelasticKernels::MultiphaseKernelFactory kernelFactory( displacementDofNumber,
+                                                             flowDofKey,
+                                                             dofManager.rankOffset(),
+                                                             gravityVectorData,
+                                                             numComponents,
+                                                             numPhases,
+                                                             m_flowSolver->fluidModelNames(),
+                                                             localMatrix,
+                                                             localRhs );
+
   // Cell-based contributions
   m_solidSolver->getMaxForce() =
     finiteElement::
       regionBasedKernelApplication< parallelDevicePolicy< 32 >,
                                     constitutive::PoroElasticBase,
-                                    CellElementSubRegion,
-                                    PoroelasticKernels::Multiphase >( mesh,
-                                                                      targetRegionNames(),
-                                                                      this->getDiscretizationName(),
-                                                                      m_solidSolver->solidMaterialNames(),
-                                                                      //
-                                                                      displacementDofNumber,
-                                                                      flowDofKey,
-                                                                      dofManager.rankOffset(),
-                                                                      //
-                                                                      gravityVectorData,
-                                                                      numComponents,
-                                                                      numPhases,
-                                                                      m_flowSolver->fluidModelNames(),
-                                                                      //
-                                                                      localMatrix,
-                                                                      localRhs );
+                                    CellElementSubRegion >( mesh,
+                                                            targetRegionNames(),
+                                                            this->getDiscretizationName(),
+                                                            m_solidSolver->solidMaterialNames(),
+                                                            kernelFactory );
 
 
 

--- a/src/coreComponents/physicsSolvers/multiphysics/PoroelasticSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/PoroelasticSolver.cpp
@@ -342,23 +342,24 @@ void PoroelasticSolver::assembleSystem( real64 const time_n,
 
   real64 const gravityVectorData[3] = LVARRAY_TENSOROPS_INIT_LOCAL_3( gravityVector() );
 
+  PoroelasticKernels::SinglePhaseKernelFactory kernelFactory( dispDofNumber,
+                                                              pDofKey,
+                                                              dofManager.rankOffset(),
+                                                              localMatrix,
+                                                              localRhs,
+                                                              gravityVectorData,
+                                                              m_flowSolver->fluidModelNames() );
+
   // Cell-based contributions
   m_solidSolver->getMaxForce() =
     finiteElement::
       regionBasedKernelApplication< parallelDevicePolicy< 32 >,
                                     constitutive::PoroElasticBase,
-                                    CellElementSubRegion,
-                                    PoroelasticKernels::SinglePhase >( mesh,
-                                                                       targetRegionNames(),
-                                                                       this->getDiscretizationName(),
-                                                                       m_solidSolver->solidMaterialNames(),
-                                                                       dispDofNumber,
-                                                                       pDofKey,
-                                                                       dofManager.rankOffset(),
-                                                                       localMatrix,
-                                                                       localRhs,
-                                                                       gravityVectorData,
-                                                                       m_flowSolver->fluidModelNames() );
+                                    CellElementSubRegion >( mesh,
+                                                            targetRegionNames(),
+                                                            this->getDiscretizationName(),
+                                                            m_solidSolver->solidMaterialNames(),
+                                                            kernelFactory );
 
   // Face-based contributions
   m_flowSolver->assembleFluxTerms( time_n, dt,

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoroelasticKernel.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoroelasticKernel.hpp
@@ -93,7 +93,7 @@ public:
                CRSMatrixView< real64, globalIndex const > const & inputMatrix,
                arrayView1d< real64 > const & inputRhs,
                real64 const (&inputGravityVector)[3],
-               arrayView1d< string const > const & fluidModelNames ):
+               arrayView1d< string const > const fluidModelNames ):
     Base( nodeManager,
           edgeManager,
           faceManager,
@@ -421,6 +421,14 @@ protected:
 
 };
 
+using SinglePhaseKernelFactory = finiteElement::KernelFactory< SinglePhase,
+                                                               arrayView1d< globalIndex const > const &,
+                                                               string const &,
+                                                               globalIndex const,
+                                                               CRSMatrixView< real64, globalIndex const > const &,
+                                                               arrayView1d< real64 > const &,
+                                                               real64 const (&)[3],
+                                                               arrayView1d< string const > const >;
 
 } // namespace PoroelasticKernels
 

--- a/src/coreComponents/physicsSolvers/simplePDE/LaplaceFEM.cpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/LaplaceFEM.cpp
@@ -154,19 +154,16 @@ void LaplaceFEM::assembleSystem( real64 const GEOSX_UNUSED_PARAM( time_n ),
   dofIndex =  nodeManager.getReference< array1d< globalIndex > >( dofKey );
 
 
+  LaplaceFEMKernelFactory kernelFactory( dofIndex, dofManager.rankOffset(), localMatrix, localRhs, m_fieldName );
+
   finiteElement::
     regionBasedKernelApplication< parallelDevicePolicy< 32 >,
                                   constitutive::NullModel,
-                                  CellElementSubRegion,
-                                  LaplaceFEMKernel >( mesh,
-                                                      targetRegionNames(),
-                                                      this->getDiscretizationName(),
-                                                      arrayView1d< string const >(),
-                                                      dofIndex,
-                                                      dofManager.rankOffset(),
-                                                      localMatrix,
-                                                      localRhs,
-                                                      m_fieldName );
+                                  CellElementSubRegion >( mesh,
+                                                          targetRegionNames(),
+                                                          this->getDiscretizationName(),
+                                                          arrayView1d< string const >(),
+                                                          kernelFactory );
 
 }
 //END_SPHINX_INCLUDE_ASSEMBLY

--- a/src/coreComponents/physicsSolvers/simplePDE/LaplaceFEMKernels.hpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/LaplaceFEMKernels.hpp
@@ -24,6 +24,7 @@
 
 namespace geosx
 {
+
 //*****************************************************************************
 /**
  * @brief Implements kernels for solving Laplace's equation.
@@ -243,6 +244,12 @@ protected:
   arrayView1d< real64 const > const m_primaryField;
 
 };
+
+/// The factory used to construct a LaplaceFEMKernel.
+using LaplaceFEMKernelFactory = finiteElement::KernelFactory< LaplaceFEMKernel,
+                                                              arrayView1d< globalIndex const > const &,
+                                                              globalIndex, CRSMatrixView< real64, globalIndex const > const &,
+                                                              arrayView1d< real64 > const &, string const & >;
 
 } // namespace geosx
 

--- a/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEM.cpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEM.cpp
@@ -228,20 +228,21 @@ void PhaseFieldDamageFEM::assembleSystem( real64 const GEOSX_UNUSED_PARAM( time_
   localMatrix.zero();
   localRhs.zero();
 
+  PhaseFieldDamageKernelFactory kernelFactory( dofIndex,
+                                               dofManager.rankOffset(),
+                                               localMatrix,
+                                               localRhs,
+                                               m_fieldName,
+                                               m_localDissipationOption=="Linear" ? 1 : 2 );
+
   finiteElement::
     regionBasedKernelApplication< parallelDevicePolicy<>,
                                   constitutive::DamageBase,
-                                  CellElementSubRegion,
-                                  PhaseFieldDamageKernel >( mesh,
-                                                            targetRegionNames(),
-                                                            this->getDiscretizationName(),
-                                                            m_solidModelNames,
-                                                            dofIndex,
-                                                            dofManager.rankOffset(),
-                                                            localMatrix,
-                                                            localRhs,
-                                                            m_fieldName,
-                                                            m_localDissipationOption=="Linear" ? 1 : 2 );
+                                  CellElementSubRegion >( mesh,
+                                                          targetRegionNames(),
+                                                          this->getDiscretizationName(),
+                                                          m_solidModelNames,
+                                                          kernelFactory );
 #else // this has your changes to the old base code
   matrix.zero();
   rhs.zero();

--- a/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEMKernels.hpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEMKernels.hpp
@@ -287,6 +287,13 @@ protected:
 
 };
 
+using PhaseFieldDamageKernelFactory = finiteElement::KernelFactory< PhaseFieldDamageKernel,
+                                                                    arrayView1d< globalIndex const > const &,
+                                                                    globalIndex,
+                                                                    CRSMatrixView< real64, globalIndex const > const &,
+                                                                    arrayView1d< real64 > const &,
+                                                                    string const &,
+                                                                    int >;
 
 } // namespace geosx
 

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsEFEMKernels.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsEFEMKernels.hpp
@@ -474,6 +474,16 @@ protected:
   ArrayOfArraysView< localIndex const > const m_cellsToEmbeddedSurfaces;
 };
 
+/// The factory used to construct a QuasiStatic kernel.
+using QuasiStaticFactory = finiteElement::KernelFactory< QuasiStatic,
+                                                         EmbeddedSurfaceSubRegion const &,
+                                                         arrayView1d< globalIndex const > const &,
+                                                         arrayView1d< globalIndex const > const &,
+                                                         globalIndex const,
+                                                         CRSMatrixView< real64, globalIndex const > const &,
+                                                         arrayView1d< real64 > const &,
+                                                         real64 const (&) [3] >;
+
 } // namespace SolidMechanicsEFEMKernels
 
 } // namespace geosx

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsEmbeddedFractures.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsEmbeddedFractures.cpp
@@ -274,22 +274,23 @@ void SolidMechanicsEmbeddedFractures::assembleSystem( real64 const time,
 
   real64 const gravityVectorData[3] = LVARRAY_TENSOROPS_INIT_LOCAL_3( gravityVector() );
 
+  SolidMechanicsEFEMKernels::QuasiStaticFactory kernelFactory( subRegion,
+                                                               dispDofNumber,
+                                                               jumpDofNumber,
+                                                               dofManager.rankOffset(),
+                                                               localMatrix,
+                                                               localRhs,
+                                                               gravityVectorData );
+
   real64 maxTraction = finiteElement::
                          regionBasedKernelApplication
                        < parallelDevicePolicy< 32 >,
                          constitutive::SolidBase,
-                         CellElementSubRegion,
-                         SolidMechanicsEFEMKernels::QuasiStatic >( mesh,
-                                                                   targetRegionNames(),
-                                                                   m_solidSolver->getDiscretizationName(),
-                                                                   m_solidSolver->solidMaterialNames(),
-                                                                   subRegion,
-                                                                   dispDofNumber,
-                                                                   jumpDofNumber,
-                                                                   dofManager.rankOffset(),
-                                                                   localMatrix,
-                                                                   localRhs,
-                                                                   gravityVectorData );
+                         CellElementSubRegion >( mesh,
+                                                 targetRegionNames(),
+                                                 m_solidSolver->getDiscretizationName(),
+                                                 m_solidSolver->solidMaterialNames(),
+                                                 kernelFactory );
 
   GEOSX_UNUSED_VAR( maxTraction );
 }

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsFiniteStrainExplicitNewmarkKernel.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsFiniteStrainExplicitNewmarkKernel.hpp
@@ -196,12 +196,13 @@ public:
 
     FE_TYPE::plusGradNajAij( dNdX, P, stack.fLocal );
   }
-
-
-
 };
 #undef UPDATE_STRESS
 
+/// The factory used to construct a ExplicitFiniteStrain kernel.
+using ExplicitFiniteStrainFactory = finiteElement::KernelFactory< ExplicitFiniteStrain,
+                                                                  real64,
+                                                                  string const & >;
 
 } // namespace SolidMechanicsLagrangianFEMKernels
 

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsPoroElasticKernel.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsPoroElasticKernel.hpp
@@ -139,6 +139,14 @@ using QuasiStaticPoroElastic = PoroElastic< SUBREGION_TYPE,
                                             FE_TYPE,
                                             QuasiStatic >;
 
+/// The factory used to construct a QuasiStaticPoroElastic kernel.
+using QuasiStaticPoroElasticFactory = finiteElement::KernelFactory< QuasiStaticPoroElastic,
+                                                                    arrayView1d< globalIndex const > const &,
+                                                                    globalIndex,
+                                                                    CRSMatrixView< real64, globalIndex const > const &,
+                                                                    arrayView1d< real64 > const &,
+                                                                    real64 const (&)[3] >;
+
 } // namespace SolidMechanicsLagrangianFEMKernels
 
 } // namespace geosx

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsSmallStrainExplicitNewmarkKernel.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsSmallStrainExplicitNewmarkKernel.hpp
@@ -339,6 +339,11 @@ protected:
 };
 #undef UPDATE_STRESS
 
+/// The factory used to construct a ExplicitSmallStrain kernel.
+using ExplicitSmallStrainFactory = finiteElement::KernelFactory< ExplicitSmallStrain,
+                                                                 real64,
+                                                                 string const & >;
+
 } // namespace SolidMechanicsLagrangianFEMKernels
 
 } // namespace geosx

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsSmallStrainImplicitNewmarkKernel.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsSmallStrainImplicitNewmarkKernel.hpp
@@ -291,6 +291,19 @@ protected:
 
 };
 
+/// The factory used to construct a ImplicitNewmark kernel.
+using ImplicitNewmarkFactory = finiteElement::KernelFactory< ImplicitNewmark,
+                                                             arrayView1d< globalIndex const > const &,
+                                                             globalIndex,
+                                                             CRSMatrixView< real64, globalIndex const > const &,
+                                                             arrayView1d< real64 > const &,
+                                                             real64 const (&)[3],
+                                                             real64,
+                                                             real64,
+                                                             real64,
+                                                             real64,
+                                                             real64 >;
+
 } // namespace SolidMechanicsLagrangianFEMKernels
 
 } // namespace geosx

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsSmallStrainQuasiStaticKernel.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsSmallStrainQuasiStaticKernel.hpp
@@ -328,6 +328,13 @@ protected:
 
 };
 
+/// The factory used to construct a QuasiStatic kernel.
+using QuasiStaticFactory = finiteElement::KernelFactory< QuasiStatic,
+                                                         arrayView1d< globalIndex const > const &,
+                                                         globalIndex,
+                                                         CRSMatrixView< real64, globalIndex const > const &,
+                                                         arrayView1d< real64 > const &,
+                                                         real64 const (&)[3] >;
 
 } // namespace SolidMechanicsLagrangianFEMKernels
 


### PR DESCRIPTION
This removes the need for the template of templates in `regionBasedKernelApplication`, as well as the variadic parameter pack. The benefit is that it simplifies both the use and the implementation of `regionBasedKernelApplication`. The downside is that now there's an extra class that needs to be created for each of the kernel types.