### PR TITLE
Fixed bug in the computation of the Peaceman index

### DIFF
--- a/src/coreComponents/mesh/WellElementSubRegion.cpp
+++ b/src/coreComponents/mesh/WellElementSubRegion.cpp
@@ -20,6 +20,7 @@
 #include "mpiCommunications/MpiWrapper.hpp"
 #include "LvArray/src/output.hpp"
 
+
 namespace geosx
 {
 
@@ -71,7 +72,7 @@ namespace
  * @param[out] boundaryNodes set of local well nodes that are at the boundary between this rank
                and another rank
  */
-void CollectLocalAndBoundaryNodes( InternalWellGenerator const & wellGeometry,
+void collectLocalAndBoundaryNodes( InternalWellGenerator const & wellGeometry,
                                    SortedArray< globalIndex >      const & localElems,
                                    SortedArray< globalIndex > & localNodes,
                                    SortedArray< globalIndex > & boundaryNodes )
@@ -119,7 +120,7 @@ void CollectLocalAndBoundaryNodes( InternalWellGenerator const & wellGeometry,
  * @param[in] ei the index of the reservoir element
  * @return true if "location" is contained in reservoir element ei, false otherwise
  */
-bool IsPointInsideElement( NodeManager const & nodeManager,
+bool isPointInsideElement( NodeManager const & nodeManager,
                            R1Tensor const & location,
                            CellBlock const & subRegion,
                            localIndex ei )
@@ -150,7 +151,7 @@ bool IsPointInsideElement( NodeManager const & nodeManager,
  * @param[in] ei the index of the reservoir element
  * @param[inout] nodes the nodes that have already been visited
  */
-void CollectElementNodes( CellBlock const & subRegion,
+void collectElementNodes( CellBlock const & subRegion,
                           localIndex ei,
                           SortedArray< localIndex > & nodes )
 {
@@ -179,7 +180,7 @@ void CollectElementNodes( CellBlock const & subRegion,
  * @param[inout] esrMatched the subregion index of the reservoir element that contains "location", if any
  * @param[inout] eiMatched the element index of the reservoir element that contains "location", if any
  */
-bool VisitNeighborElements( MeshLevel const & mesh,
+bool visitNeighborElements( MeshLevel const & mesh,
                             R1Tensor const & location,
                             SortedArray< localIndex > & nodes,
                             SortedArray< globalIndex > & elements,
@@ -229,7 +230,7 @@ bool VisitNeighborElements( MeshLevel const & mesh,
 
         // perform the test to see if the point is in this reservoir element
         // if the point is in the resevoir element, save the indices and stop the search
-        if( IsPointInsideElement( nodeManager, location, subRegion, eiLocal ))
+        if( isPointInsideElement( nodeManager, location, subRegion, eiLocal ))
         {
           erMatched  = er;
           esrMatched = esr;
@@ -240,7 +241,7 @@ bool VisitNeighborElements( MeshLevel const & mesh,
         // otherwise add the nodes of this element to the set of new nodes to visit
         else
         {
-          CollectElementNodes( subRegion, eiLocal, nodes );
+          collectElementNodes( subRegion, eiLocal, nodes );
         }
       }
     }
@@ -266,7 +267,7 @@ bool VisitNeighborElements( MeshLevel const & mesh,
  * @param[inout] esrInit the subregion index of the reservoir element from which we start the search
  * @param[inout] eiInit the element index of the reservoir element from which we start the search
  */
-void InitializeLocalSearch( MeshLevel const & mesh,
+void initializeLocalSearch( MeshLevel const & mesh,
                             R1Tensor const & location,
                             localIndex & erInit,
                             localIndex & esrInit,
@@ -305,7 +306,7 @@ void InitializeLocalSearch( MeshLevel const & mesh,
  * @param[inout] esrMatched the subregion index of the reservoir element that contains "location", if any
  * @param[inout] eiMatched the element index of the reservoir element that contains "location", if any
  */
-bool SearchLocalElements( MeshLevel const & mesh,
+bool searchLocalElements( MeshLevel const & mesh,
                           R1Tensor const & location,
                           localIndex const & searchDepth,
                           localIndex const & erInit,
@@ -335,7 +336,7 @@ bool SearchLocalElements( MeshLevel const & mesh,
 
   // collect the nodes of the current element
   // they will be used to access the neighbors and check if they contain the perforation
-  CollectElementNodes( subRegion, eiInit, nodes );
+  collectElementNodes( subRegion, eiInit, nodes );
 
   // if no match is found, enlarge the neighborhood m_searchDepth'th times
   for( localIndex d = 0; d < searchDepth; ++d )
@@ -345,7 +346,7 @@ bool SearchLocalElements( MeshLevel const & mesh,
     // search the reservoir elements that can be accessed from the set "nodes"
     // stop if a reservoir element containing the perforation is found
     // if not, enlarge the set "nodes"
-    resElemFound = VisitNeighborElements( mesh, location, nodes, elements,
+    resElemFound = visitNeighborElements( mesh, location, nodes, elements,
                                           erMatched, esrMatched, eiMatched );
     if( resElemFound || nNodes == nodes.size())
     {
@@ -418,12 +419,10 @@ void WellElementSubRegion::generate( MeshLevel & mesh,
   // 2) collect the local nodes and tag the boundary nodes using element info
   // now that all the elements have been assigned, we collected the local nodes
   // and tag the boundary nodes (i.e., the nodes in contact with both local and remote elems)
-  CollectLocalAndBoundaryNodes( wellGeometry,
+  collectLocalAndBoundaryNodes( wellGeometry,
                                 localElems,
                                 localNodes,
                                 boundaryNodes );
-
-  //DebugNodeManager( mesh );
 
   // 3) size update in the nodeManager
   // this is necessary to later use the node matching procedure
@@ -434,8 +433,6 @@ void WellElementSubRegion::generate( MeshLevel & mesh,
                          boundaryNodes,
                          nodeOffsetGlobal );
 
-  //DebugNodeManager( mesh );
-
   // 4) resize the well element subregion
   // and construct local to global, global to local, maps, etc
   constructSubRegionLocalElementMaps( mesh,
@@ -443,8 +440,6 @@ void WellElementSubRegion::generate( MeshLevel & mesh,
                                       localElems,
                                       nodeOffsetGlobal,
                                       elemOffsetGlobal );
-
-  //DebugWellElementSubRegions( elemStatusGlobal, elemOffsetGlobal );
 
   // 5) node-to-elem map update in the nodeManager
   // This map will be used by MeshLevel::GenerateAdjacencyLists
@@ -486,12 +481,12 @@ void WellElementSubRegion::assignUnownedElementsInReservoir( MeshLevel & mesh,
     //         note that this reservoir element does not necessarily contain the center of the well element
     //         this "init" reservoir element will be used in SearchLocalElements to find the reservoir element that
     //         contains the well element
-    InitializeLocalSearch( mesh, location,
+    initializeLocalSearch( mesh, location,
                            erInit, esrInit, eiInit );
 
     // Step 2: then, search for the reservoir element that contains the well element
     //         to do that, we loop over the reservoir elements that are in the neighborhood of (erInit,esrInit,eiInit)
-    bool resElemFound = SearchLocalElements( mesh, location, m_searchDepth,
+    bool resElemFound = searchLocalElements( mesh, location, m_searchDepth,
                                              erInit, esrInit, eiInit,
                                              erMatched, esrMatched, eiMatched );
 
@@ -798,12 +793,12 @@ void WellElementSubRegion::connectPerforationsToMeshElements( MeshLevel & mesh,
     //         note that this reservoir element does not necessarily contain the center of the well element
     //         this "init" reservoir element will be used in SearchLocalElements to find the reservoir element that
     //         contains the well element
-    InitializeLocalSearch( mesh, location,
+    initializeLocalSearch( mesh, location,
                            erInit, esrInit, eiInit );
 
     // Step 2: then, search for the reservoir element that contains the well element
     //         to do that, we loop over the reservoir elements that are in the neighborhood of (erInit,esrInit,eiInit)
-    bool resElemFound = SearchLocalElements( mesh, location, m_searchDepth,
+    bool resElemFound = searchLocalElements( mesh, location, m_searchDepth,
                                              erInit, esrInit, eiInit,
                                              erMatched, esrMatched, eiMatched );
 
@@ -910,90 +905,6 @@ void WellElementSubRegion::fixUpDownMaps( bool const clearIfUnmapped )
   ObjectManagerBase::fixUpDownMaps( nodeList(),
                                     m_unmappedGlobalIndicesInNodelist,
                                     clearIfUnmapped );
-}
-
-void WellElementSubRegion::debugNodeManager( MeshLevel const & mesh ) const
-{
-  NodeManager const & nodeManager = mesh.getNodeManager();
-  // arrayView2d< real64 const > const & X = nodeManager.referencePosition();
-
-  if( MpiWrapper::commRank( MPI_COMM_GEOSX ) != 1 )
-  {
-    return;
-  }
-
-  GEOSX_LOG_RANK( "++++++++++++++++++++++++++" );
-  GEOSX_LOG_RANK( "WellElementSubRegion = " << getName() );
-  GEOSX_LOG_RANK( "Number of local well elements = " << size() );
-  GEOSX_LOG_RANK( "Number of local node elements = " << nodeManager.size() );
-
-  if( nodeManager.size() > 0 )
-  {
-    return;
-  }
-
-  arrayView1d< globalIndex const > const & nodeLocalToGlobal = nodeManager.localToGlobalMap();
-  for( localIndex inodeLocal = 0; inodeLocal < nodeManager.size(); ++inodeLocal )
-  {
-    std::cout << "nodeManager.localToGlobalMap["    << inodeLocal << "] = " << nodeLocalToGlobal[inodeLocal]  << std::endl;
-  }
-}
-
-void WellElementSubRegion::debugWellElementSubRegions( arrayView1d< integer const > const & elemStatusGlobal, globalIndex elemOffsetGlobal ) const
-{
-  if( size() == 0 )
-  {
-    return;
-  }
-
-  if( MpiWrapper::commRank( MPI_COMM_GEOSX ) < 1 )
-  {
-    return;
-  }
-
-  GEOSX_LOG_RANK( "++++++++++++++++++++++++++" );
-  GEOSX_LOG_RANK( "WellElementSubRegion = " << getName() );
-  GEOSX_LOG_RANK( "Number of local well elements = " << size() );
-
-  for( localIndex iwelem = 0; iwelem < size(); ++iwelem )
-  {
-    GEOSX_LOG_RANK_VAR( iwelem );
-    GEOSX_LOG_RANK_VAR( m_nextWellElementIndex[iwelem] );
-    GEOSX_LOG_RANK_VAR( m_nextWellElementIndexGlobal[iwelem] );
-    GEOSX_LOG_RANK_VAR( m_elementCenter[iwelem] );
-    GEOSX_LOG_RANK_VAR( m_localToGlobalMap[iwelem] );
-    GEOSX_LOG_RANK_VAR( elemStatusGlobal[m_localToGlobalMap[iwelem] - elemOffsetGlobal] );
-    GEOSX_LOG_RANK_VAR( m_topWellElementIndex );
-  }
-}
-
-void WellElementSubRegion::debugWellElementSubRegionsAfterSetupCommunications() const
-{
-  if( size() == 0 )
-  {
-    return;
-  }
-
-  if( MpiWrapper::commRank( MPI_COMM_GEOSX ) != 1 )
-  {
-    return;
-  }
-
-  GEOSX_LOG_RANK( "++++++++++++++++++++++++++" );
-  GEOSX_LOG_RANK( "WellElementSubRegion = " << getName() );
-  GEOSX_LOG_RANK( "Number of local well elements = " << size() );
-  GEOSX_LOG_RANK( "Number of ghost well elements = " << this->getNumberOfGhosts() );
-
-  for( localIndex iwelem = 0; iwelem < size(); ++iwelem )
-  {
-    GEOSX_LOG_RANK_VAR( iwelem );
-    GEOSX_LOG_RANK_VAR( m_nextWellElementIndex[iwelem] );
-    GEOSX_LOG_RANK_VAR( m_nextWellElementIndexGlobal[iwelem] );
-    GEOSX_LOG_RANK_VAR( m_elementCenter[iwelem] );
-    GEOSX_LOG_RANK_VAR( m_localToGlobalMap[iwelem] );
-    GEOSX_LOG_RANK_VAR( m_ghostRank[iwelem] );
-    GEOSX_LOG_RANK_VAR( m_topWellElementIndex );
-  }
 }
 
 }

--- a/src/coreComponents/mesh/WellElementSubRegion.hpp
+++ b/src/coreComponents/mesh/WellElementSubRegion.hpp
@@ -281,10 +281,6 @@ public:
 
   ///@}
 
-  /// @cond DO_NOT_DOCUMENT
-  void debugWellElementSubRegionsAfterSetupCommunications() const;
-  /// @endcond
-
   /**
    * @brief Struct to serve as a container for variable strings and keys.
    * @struct viewKeyStruct
@@ -416,14 +412,6 @@ private:
    * The function WellElementSubRegion::ConstructSubRegionLocalElementMaps must have been called before this function
    */
   void updateNodeManagerNodeToElementMap( MeshLevel & mesh );
-
-  /// @cond DO_NOT_DOCUMENT
-  void debugNodeManager( MeshLevel const & mesh ) const;
-  /// @endcond
-
-  /// @cond DO_NOT_DOCUMENT
-  void debugWellElementSubRegions( arrayView1d< integer const > const & wellElemStatus, globalIndex elemOffsetGlobal ) const;
-  /// @endcond
 
   /**
    * @brief Pack element-to-node and element-to-face maps

--- a/src/coreComponents/meshUtilities/PerforationData.cpp
+++ b/src/coreComponents/meshUtilities/PerforationData.cpp
@@ -50,9 +50,9 @@ namespace
 
 /**
  * @brief Check if the well is along the x-, y-, or z- directions.
- * @tparam VEC_TYPE type of @p vecTopNodeToBottom
+ * @tparam VEC_TYPE type of @p topToBottomVec
  * @tparam PERM_TYPE type of @p perm
- * @param[in] vecTopToBottom vector connecting the well element center to the perforation
+ * @param[in] topToBottomVec vector connecting the well element center to the perforation
  * @param[in] dx dimension of the element in the x-direction
  * @param[in] dy dimension of the element in the y-direction
  * @param[in] dz dimension of the element in the z-direction
@@ -64,7 +64,7 @@ namespace
  * @param[out] k2 absolute permeability in the reservoir element (second direction)
  */
 template< typename VEC_TYPE, typename PERM_TYPE >
-void decideWellDirection( VEC_TYPE const & vecTopToBottom,
+void decideWellDirection( VEC_TYPE const & topToBottomVec,
                           real64 const & dx,
                           real64 const & dy,
                           real64 const & dz,
@@ -76,8 +76,8 @@ void decideWellDirection( VEC_TYPE const & vecTopToBottom,
                           real64 & k2 )
 {
   // vertical well (approximately along the z-direction)
-  if( fabs( vecTopToBottom[2] ) > fabs( vecTopToBottom[0] )
-      && fabs( vecTopToBottom[2] ) > fabs( vecTopToBottom[1] ) )
+  if( fabs( topToBottomVec[2] ) > fabs( topToBottomVec[0] )
+      && fabs( topToBottomVec[2] ) > fabs( topToBottomVec[1] ) )
   {
     d1 = dx;
     d2 = dy;
@@ -86,8 +86,8 @@ void decideWellDirection( VEC_TYPE const & vecTopToBottom,
     k2 = perm[1];
   }
   // well approximately along the y-direction
-  else if( fabs( vecTopToBottom[1] ) > fabs( vecTopToBottom[0] )
-           && fabs( vecTopToBottom[1] ) > fabs( vecTopToBottom[2] ) )
+  else if( fabs( topToBottomVec[1] ) > fabs( topToBottomVec[0] )
+           && fabs( topToBottomVec[1] ) > fabs( topToBottomVec[2] ) )
   {
     d1 = dx;
     d2 = dz;
@@ -156,15 +156,15 @@ void PerforationData::computeWellTransmissibility( MeshLevel const & mesh,
     localIndex const bottomNode = elemToNodeMap[wellElemIndex][InternalWellGenerator::NodeLocation::BOTTOM];
     // using the direction of the segment, compute the perforation "direction"
     // that will be used to construct the Peaceman index
-    real64 vecTopToBottom[3] = { X[bottomNode][0],
+    real64 topToBottomVec[3] = { X[bottomNode][0],
                                  X[bottomNode][1],
                                  X[bottomNode][2] };
-    LvArray::tensorOps::subtract< 3 >( vecTopToBottom, X[topNode] );
-    LvArray::tensorOps::normalize< 3 >( vecTopToBottom );
+    LvArray::tensorOps::subtract< 3 >( topToBottomVec, X[topNode] );
+    LvArray::tensorOps::normalize< 3 >( topToBottomVec );
 
     // check if this is a vertical well or a horizontal well
     // assign d1, d2, h, k1, and k2 accordingly
-    decideWellDirection( vecTopToBottom,
+    decideWellDirection( topToBottomVec,
                          dx, dy, dz, perm[er][esr][ei],
                          d1, d2, h, k1, k2 );
 

--- a/src/coreComponents/meshUtilities/PerforationData.hpp
+++ b/src/coreComponents/meshUtilities/PerforationData.hpp
@@ -234,6 +234,8 @@ public:
     static constexpr char const * locationString() { return "location"; }
     /// String key for the well transmissibility
     static constexpr char const * wellTransmissibilityString() { return "wellTransmissibility"; }
+    /// String key for the perforation direction
+    static constexpr char const * directionString() { return "direction"; }
 
     /// ViewKey for the global number of perforations
     dataRepository::ViewKey numPerforationsGlobal     = { numPerforationsGlobalString() };
@@ -245,10 +247,13 @@ public:
     dataRepository::ViewKey reservoirElementIndex     = { reservoirElementIndexString() };
     /// ViewKey for the well element index
     dataRepository::ViewKey wellElementIndex          = { wellElementIndexString() };
-    /// ViewKey for the well location
+    /// ViewKey for the perf location
     dataRepository::ViewKey location                  = { locationString() };
     /// ViewKey for the well transmissibility
     dataRepository::ViewKey wellTransmissibility      = { wellTransmissibilityString() };
+    /// ViewKey for the perf direction
+    dataRepository::ViewKey direction                 = { directionString() };
+
   }
   /// ViewKey struct for the PerforationData class
   viewKeysPerforationData;

--- a/src/coreComponents/physicsSolvers/multiphysics/CompositionalMultiphaseReservoir.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/CompositionalMultiphaseReservoir.cpp
@@ -1,19 +1,15 @@
 /*
- *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
  *
- * Produced at the Lawrence Livermore National Laboratory
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 Total, S.A
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
  *
- * LLNL-CODE-746361
- *
- * All rights reserved. See COPYRIGHT for details.
- *
- * This file is part of the GEOSX Simulation Framework.
- *
- * GEOSX is a free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License (as published by the
- * Free Software Foundation) version 2.1 dated February 1999.
- *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
  */
 
 /**

--- a/src/coreComponents/physicsSolvers/multiphysics/ReservoirSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/ReservoirSolverBase.cpp
@@ -1,19 +1,15 @@
 /*
- *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
  *
- * Produced at the Lawrence Livermore National Laboratory
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 Total, S.A
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
  *
- * LLNL-CODE-746361
- *
- * All rights reserved. See COPYRIGHT for details.
- *
- * This file is part of the GEOSX Simulation Framework.
- *
- * GEOSX is a free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License (as published by the
- * Free Software Foundation) version 2.1 dated February 1999.
- *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
  */
 
 /**

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhaseReservoir.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhaseReservoir.cpp
@@ -1,19 +1,15 @@
 /*
- *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
  *
- * Produced at the Lawrence Livermore National Laboratory
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 Total, S.A
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
  *
- * LLNL-CODE-746361
- *
- * All rights reserved. See COPYRIGHT for details.
- *
- * This file is part of the GEOSX Simulation Framework.
- *
- * GEOSX is a free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License (as published by the
- * Free Software Foundation) version 2.1 dated February 1999.
- *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
  */
 
 /**


### PR DESCRIPTION
This PR fixes a bug in the computation of the well Peaceman index that occurs when the perforation is placed exactly at the center of the well element (my bad). It also fixes some well function names that were not following the camelCase convention. 

This PR does not require a rebaseline (the bug does not appear in the integrated tests).