### PR TITLE
Eighth-order finite-difference tests with RAJA (for discussion only)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,3 +140,8 @@ install( DIRECTORY ../scripts/
 if( ENABLE_PYGEOSX )
   add_subdirectory( pygeosx )
 endif()
+
+option(ENABLE_FDWAVE  "Build fd wave eqn " On)
+if( ENABLE_FDWAVE)
+   add_subdirectory(fdwave_raja)
+endif()

--- a/src/fdwave_raja/CMakeLists.txt
+++ b/src/fdwave_raja/CMakeLists.txt
@@ -1,0 +1,35 @@
+###############################################################################
+# Copyright (c) 2016-21, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+set (fdwave_sources
+     grid.cpp
+     pml.cpp
+     data_setup.cpp
+     target_3d.cpp)
+
+set( fdwave_headers 
+     memoryManager.hpp
+     constants.hpp
+     grid.hpp
+     pml.hpp
+     data_setup.hpp
+     target_3d.hpp)
+
+set( dependencyList lvarray  RAJA chai common)
+
+blt_add_library( NAME          fdwavelib_raja
+                 SOURCES       ${fdwave_sources}
+                 HEADERS       ${fdwave_headers}
+                 DEPENDS_ON    ${dependencyList}
+                 OBJECT        ${buildAsObj}
+	       )
+
+set( extraComponentsLinkList ${extraComponentsLinkList} fdwavelib_raja)
+blt_add_executable(NAME fdwave-eqn_raja
+                   SOURCES fdwave-eqn.cpp
+                   DEPENDS_ON ${extraComponentsLinkList}
+                              ${externalComponentsLinkList}
+             )

--- a/src/fdwave_raja/constants.cpp
+++ b/src/fdwave_raja/constants.cpp
@@ -1,0 +1,7 @@
+#include "constants.hpp"
+
+// Constants
+const float _fmax = 25.0f;
+const float vmin = 1500.f;
+const float vmax = 4500.f;
+const float cfl = 0.8f;

--- a/src/fdwave_raja/constants.hpp
+++ b/src/fdwave_raja/constants.hpp
@@ -1,0 +1,18 @@
+#ifndef CONSTANTS_HPP
+#define CONSTANTS_HPP
+
+#define POW2(x) ((x)*(x))
+#define IDX3(i,j,k) (nz*ny*(i) + nz*(j) + (k))
+#define IDX3_l(i,j,k) ((nz+2*lz)*(ny+2*ly)*((i)+lx) + (nz+2*lz)*((j)+ly) + ((k)+lz))
+#define IDX3_eta1(i,j,k) ((nz+2)*(ny+2)*((i)+1) + (nz+2)*((j)+1) + ((k)+1))
+#define IDX3_eta0(i,j,k) ((nz+2)*(ny+2)*(i) + (nz+2)*(j) + (k))
+
+extern const float _fmax;
+extern const float vmin;
+extern const float vmax;
+extern const float cfl;
+
+typedef long long int llint;
+typedef unsigned int uint;
+
+#endif

--- a/src/fdwave_raja/data_setup.cpp
+++ b/src/fdwave_raja/data_setup.cpp
@@ -1,0 +1,54 @@
+#include "data_setup.hpp"
+
+#include <float.h>
+#include <math.h>
+
+//void target_init(struct grid_t grid, uint nsteps,
+//                 const float *u, const float *v, const float *phi,
+//                 const float *eta, const float *coefx, const float *coefy,
+//                 const float *coefz, const float *vp, const float *source)
+//{
+//    // Nothing needed
+//}
+
+//void target_finalize(struct grid_t grid, uint nsteps,
+//                     const float *u, const float *v, const float *phi,
+//		     const float *eta, const float *coefx, const float *coefy,
+//                     const float *coefz, const float *vp, const float *source)
+//{
+//    // Nothing needed
+//}
+
+void kernel_add_source(struct grid_t grid,
+                       float *u, const float *source, llint istep,
+                       llint sx, llint sy, llint sz)
+{
+    const llint ny = grid.ny;
+    const llint nz = grid.nz;
+    const llint lx = grid.lx;
+    const llint ly = grid.ly;
+    const llint lz = grid.lz;
+    u[IDX3_l(sx,sy,sz)] += source[istep-1];
+}
+
+void find_min_max_u(struct grid_t grid,
+                    const float *u, float *min_u, float *max_u)
+{
+    const llint nx = grid.nx;
+    const llint ny = grid.ny;
+    const llint nz = grid.nz;
+    const llint lx = grid.lx;
+    const llint ly = grid.ly;
+    const llint lz = grid.lz;
+
+    *min_u = FLT_MAX;
+    *max_u = FLT_MIN;
+    for (llint i = -lx; i < nx+lx; ++i) {
+        for (llint j = -ly; j < ny+ly; ++j) {
+            for (llint k = -lz; k < nz+lz; ++k) {
+                *min_u = fminf(*min_u, u[IDX3_l(i,j,k)]);
+                *max_u = fmaxf(*max_u, u[IDX3_l(i,j,k)]);
+            }
+        }
+    }
+}

--- a/src/fdwave_raja/data_setup.hpp
+++ b/src/fdwave_raja/data_setup.hpp
@@ -1,0 +1,24 @@
+#ifndef DATA_SETUP_HPP
+#define DATA_SETUP_HPP
+
+#include "constants.hpp"
+#include "grid.hpp"
+
+//void target_init(struct grid_t grid, uint nsteps,
+//                 const float *u, const float *v, const float *phi,
+//                 const float *eta, const float *coefx, const float *coefy,
+//                 const float *coefz, const float *vp, const float *source);
+
+//void target_finalize(struct grid_t grid, uint nsteps,
+//                     const float *u, const float *v, const float *phi,
+//                     const float *eta, const float *coefx, const float *coefy,
+//                     const float *coefz, const float *vp, const float *source);
+
+void kernel_add_source(struct grid_t grid,
+                       float *u, const float *source, llint istep,
+                       llint sx, llint sy, llint sz);
+
+void find_min_max_u(struct grid_t grid,
+                    const float *u, float *min_u, float *max_u);
+
+#endif

--- a/src/fdwave_raja/fdwave-eqn.cpp
+++ b/src/fdwave_raja/fdwave-eqn.cpp
@@ -1,0 +1,358 @@
+#include <float.h>
+#include <math.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "constants.hpp"
+#include "grid.hpp"
+#include "pml.hpp"
+#include "data_setup.hpp"
+#include "target_3d.hpp"
+
+#include "memoryManager.hpp"
+#include "RAJA/RAJA.hpp"
+
+const float _fmax = 25.0f;
+const float vmin = 1500.f;
+const float vmax = 4500.f;
+const float cfl = 0.8f;
+
+void init_coef(float dx, float *coefx)
+{
+    float dx2 = dx*dx;
+    coefx[0] = -205.f/72.f/dx2;
+    coefx[1] = 8.f/5.f/dx2;
+    coefx[2] = -1.f/5.f/dx2;
+    coefx[3] = 8.f/315.f/dx2;
+    coefx[4] = -1.f/560.f/dx2;
+}
+
+float compute_dt_sch(const float *coefx, const float *coefy, const float *coefz)
+{
+
+    float ftmp = 0.f;
+    ftmp += fabsf(coefx[0]) + fabsf(coefy[0]) + fabsf(coefz[0]);
+    for (uint i = 1; i < 5; i++) {
+        ftmp += 2.f*fabsf(coefx[i]);
+        ftmp += 2.f*fabsf(coefy[i]);
+        ftmp += 2.f*fabsf(coefz[i]);
+    }
+    return 2.f*cfl/(sqrtf(ftmp)*vmax);
+}
+
+void gaussian_source(uint nt, float dt, float *source)
+{
+    const float sigma = 0.6f*_fmax;
+    const float tau = 1.0f;
+    const float scale = 8.0f;
+
+    for (uint it = 1; it <= nt; ++it) {
+        float t = dt*(it-1);
+        source[it-1] = -2.f*scale*sigma
+                     *(sigma-2.f*sigma*scale*POW2(sigma*t-tau))
+                     *expf(-scale*POW2(sigma*t-tau));
+    }
+}
+
+void write_io(llint nx, llint ny, llint nz,
+              llint lx, llint ly, llint lz,
+              const float *u, uint istep)
+{
+    char filename_buf[32];
+    snprintf(filename_buf, sizeof(filename_buf), "snapshot.it%u.n%llu.raw", istep, nz);
+    FILE *snapshot_file = fopen(filename_buf, "wb");
+    for (llint k = lz; k < nz+lz; ++k) {
+        for (llint j = ly; j < ny+ly; ++j) {
+            for (llint i = lx; i < nx+lx; ++i) {
+                fwrite(&u[IDX3_l(i,j,k)], sizeof(float),1, snapshot_file);
+            }
+        }
+    }
+    /* Clean up */
+    fclose(snapshot_file);
+}
+
+
+int main(int argc, char *argv[])
+{
+    llint nx = 100, ny = 100, nz = 100;
+    /* Task size (supported targets only) */
+    llint tsx = 10, tsy = 10;
+    /* Number of GPUs (supported targets only) */
+    llint ngpus = 1;
+    uint nsteps = 1000;
+    uint niters = 1;
+    bool disable_warm_up_iter = true;
+    bool finalio = false;
+
+    /* Process arguments */
+    if( argc == 1 )
+        printf( "Usage:\n ./main --grid N --nsteps M --finalio\nUsing default values, no IO.\n\n" );
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i],"--grid") == 0) {
+            ++i;
+            nx = strtoll(argv[i],NULL,10);
+            ny = nx;
+            nz = nx;
+        }
+        else if (strcmp(argv[i],"--tsize") == 0) {
+            ++i;
+            tsx = strtoll(argv[i],NULL,10);
+            tsy = tsx;
+            printf("tsx, tsy = %lld, %lld\n", tsx, tsy);
+        }
+        else if (strcmp(argv[i],"--nsteps") == 0) {
+            ++i;
+            nsteps = strtoll(argv[i],NULL,10);
+            printf("nsteps = %d\n", nsteps);
+        }
+        else if (strcmp(argv[i],"--niters") == 0) {
+            ++i;
+            niters = strtoll(argv[i],NULL,10);
+            printf("niters = %d\n", niters);
+        }
+        else if (strcmp(argv[i],"--warm-up") == 0) {
+            disable_warm_up_iter = false;
+            printf("warm up iteration is enabled\n");
+        }
+        else if (strcmp(argv[i],"--finalio") == 0) {
+            finalio = true;
+            printf("writing final wavefile is enabled\n");
+        }
+        else if (strcmp(argv[i],"--ngpus") == 0) {
+            ++i;
+            ngpus = strtoll(argv[i],NULL,10);
+            printf("ngpus = %lld\n", ngpus);
+        }
+    }
+
+    double time_kernel = 0.0;
+    double time_modeling = 0.0;
+    bool warm_up_iter = !disable_warm_up_iter;
+
+
+
+    for (uint iiter = 0; iiter < (disable_warm_up_iter ? niters : niters+1); iiter++) {
+
+        const struct grid_t grid = init_grid(nx,ny,nz,tsx,tsy,ngpus);
+
+        printf("grid = %lld %lld %lld\n", grid.nx, grid.ny, grid.nz);
+
+        const llint lx = grid.lx, ly = grid.ly, lz = grid.lz;
+
+        const llint sx = nx/2, sy = ny/2, sz = nz/2;
+
+        //
+        // Define range indices
+        //
+        RAJA::TypedRangeSegment<llint> KLRange(-lx, nx+lx-1);
+        RAJA::TypedRangeSegment<llint> JLRange(-ly, ny+ly-1);
+        RAJA::TypedRangeSegment<llint> ILRange(-lz, nz+lz-1);
+        //
+        RAJA::TypedRangeSegment<llint> XvpRange(0, nx-1);
+        RAJA::TypedRangeSegment<llint> YvpRange(0, ny-1);
+        RAJA::TypedRangeSegment<llint> ZvpRange(0, nz-1);
+
+        RAJA::TypedRangeSegment<llint> XphiRange(0, nx-1);
+        RAJA::TypedRangeSegment<llint> YphiRange(0, ny-1);
+        RAJA::TypedRangeSegment<llint> ZphiRange(0, nz-1);
+
+        RAJA::TypedRangeSegment<llint> XetaRange(-1, nx);
+        RAJA::TypedRangeSegment<llint> YetaRange(-1, ny);
+        RAJA::TypedRangeSegment<llint> ZetaRange(-1, nz);
+
+        //
+        // Define the nested loop
+        //
+        using KJI_EXECPOL = RAJA::KernelPolicy<
+                            RAJA::statement::For<2, RAJA::loop_exec,    // k
+                            RAJA::statement::For<1, RAJA::loop_exec,  // j
+                            RAJA::statement::For<0, RAJA::loop_exec,// i 
+                            RAJA::statement::Lambda<0>
+                            > 
+                          > 
+                        > 
+                      >;
+
+        //float *u = (float *) malloc(sizeof(float)*(nx+2*lx)*(ny+2*ly)*(nz+2*lz));
+        //float *v = (float *)malloc(sizeof(float)*(nx+2*lx)*(ny+2*ly)*(nz+2*lz));
+        float *u = memoryManager::allocate<float>((nx+2*lx)*(ny+2*ly)*(nz+2*lz));
+        float *v = memoryManager::allocate<float>((nx+2*lx)*(ny+2*ly)*(nz+2*lz));
+        
+
+        // PML arrays
+        //float *phi =(float *) malloc(sizeof(float)*nx*ny*nz);
+        //float *eta =(float *) malloc(sizeof(float)*(nx+2)*(ny+2)*(nz+2));
+        float *phi = memoryManager::allocate<float>(nx*ny*nz);
+        float *eta = memoryManager::allocate<float>((nx+2)*(ny+2)*(nz+2)); 
+
+        // Wave field initialization
+        //for (llint i = -lx; i < nx+lx; ++i) {
+        //    for (llint j = -ly; j < ny+ly; ++j) {
+        //        for (llint k = -lz; k < nz+lz; ++k) {
+        //            u[IDX3_l(i,j,k)] = 0.0f;
+        //            v[IDX3_l(i,j,k)] = 0.0f;
+        //        }
+        //    }
+        //}
+        RAJA::kernel<KJI_EXECPOL>( RAJA::make_tuple(ILRange, JLRange, KLRange),
+                                   [=] (llint i, llint j, llint k) 
+                                   { 
+                                      //printf( " (%d, %d, %d) \n", (int)(i), (int)(j), (int)(k));
+                                      u[IDX3_l(i,j,k)] = 0.0f;
+                                      v[IDX3_l(i,j,k)] = 0.0f;
+                                   }
+                                 );
+
+        //float *source =(float *) malloc(sizeof(float)*nsteps);
+        //float *vp =(float *) malloc(sizeof(float)*nx*ny*nz);
+        float *source = memoryManager::allocate<float>(nsteps);
+        float *vp     = memoryManager::allocate<float>(nx*ny*nz);
+
+        float coefx[5], coefy[5], coefz[5];
+        init_coef(grid.dx, coefx);
+        init_coef(grid.dy, coefy);
+        init_coef(grid.dz, coefz);
+
+        const float dt_sch = compute_dt_sch(coefx, coefy, coefz);
+        // Init vp and phi
+        const float vp_all = POW2(2000.f*dt_sch);
+        //for (llint i = 0; i < nx; ++i) {
+        //    for (llint j = 0; j < ny; ++j) {
+        //        for (llint k = 0; k < nz; ++k) {
+        //            phi[IDX3(i,j,k)] = 0.f;
+        //            vp[IDX3(i,j,k)] = vp_all;
+        //        }
+        //    }
+        //}
+        RAJA::kernel<KJI_EXECPOL>( RAJA::make_tuple(XvpRange, YvpRange, ZvpRange),
+                                   [=] (llint i, llint j, llint k) 
+                                   { 
+                                    //phi[IDX3(i,j,k)] = 0.f;
+                                    vp[IDX3(i,j,k)] = vp_all;
+                                   }
+                                 );
+
+        RAJA::kernel<KJI_EXECPOL>( RAJA::make_tuple(XvpRange, YvpRange, ZvpRange),
+                                   [=] (llint i, llint j, llint k) 
+                                   { 
+                                    //phi[IDX3(i,j,k)] = 0.f;
+                                    phi[IDX3(i,j,k)] = 0;
+                                   }
+                                 );        
+        (void) gaussian_source(nsteps,dt_sch,source);
+        // Init PML
+        init_eta(nx, ny, nz, grid, dt_sch,
+                 eta);
+
+        const float hdx_2 = 1.f / (4.f * POW2(grid.dx));
+        const float hdy_2 = 1.f / (4.f * POW2(grid.dy));
+        const float hdz_2 = 1.f / (4.f * POW2(grid.dz));
+
+        struct timespec start,end,start_m,end_m;
+        const uint npo = 100;
+        const bool l_snapshot = false;
+        const uint nsnapshot_freq = 100;
+
+        //target_init(grid,nsteps,u,v,phi,eta,coefx,coefy,coefz,vp,source);
+
+        // Time loop
+        clock_gettime(CLOCK_REALTIME, &start_m);
+        // #ifdef OMP_PARALLEL_MASTER_IN_MAIN
+        //     #pragma omp parallel default(shared)
+        //     #pragma omp master
+        // #endif
+        #ifdef __NVCC__
+        target(
+            nsteps, &time_kernel,
+            nx, ny, nz,
+            grid.x1, grid.x2, grid.x3, grid.x4, grid.x5, grid.x6,
+            grid.y1, grid.y2, grid.y3, grid.y4, grid.y5, grid.y6,
+            grid.z1, grid.z2, grid.z3, grid.z4, grid.z5, grid.z6,
+            lx, ly, lz,
+            sx, sy, sz,
+            hdx_2, hdy_2, hdz_2,
+            coefx, coefy, coefz,
+            u, v, vp,
+            phi, eta, source
+        );
+        if (warm_up_iter) {
+            time_kernel = 0;
+        }
+        #else
+        for (uint istep = 1; istep <= nsteps; ++istep) {
+
+            /* Write snapshot if requested */
+            if (l_snapshot && istep % nsnapshot_freq == 0) {
+                write_io(nx, ny, nz, lx, ly, lz,
+                         u, istep);
+            }
+
+            /*******************************
+             * Main loop
+             *******************************/
+            clock_gettime(CLOCK_REALTIME, &start);
+            target_3d( nx, ny, nz,
+                       grid.x1, grid.x2, grid.x3, grid.x4, grid.x5, grid.x6,
+                       grid.y1, grid.y2, grid.y3, grid.y4, grid.y5, grid.y6,
+                       grid.z1, grid.z2, grid.z3, grid.z4, grid.z5, grid.z6,
+                       lx, ly, lz,
+                       hdx_2, hdy_2, hdz_2,
+                       coefx, coefy, coefz,
+                       u, v, vp, phi, eta );
+            clock_gettime(CLOCK_REALTIME, &end);
+            if (!warm_up_iter) {
+                time_kernel += (end.tv_sec  - start.tv_sec) +
+                               (double)(end.tv_nsec - start.tv_nsec) / 1.0e9;
+            }
+
+            // Print out
+            if (istep % npo == 0) {
+                printf("time step %u / %u\n", istep, nsteps);
+
+                #ifdef MINMAX_U_IN_TIME_LOOP
+                    float min_v, max_v;
+                    find_min_max_u(grid, v, &min_v, &max_v);
+                    printf("min_v,  max_v = %f, %f\n", min_v, max_v);
+                #endif
+            }
+
+            // Add source
+            kernel_add_source(grid, v, source, istep, sx, sy, sz);
+
+            // Swap u and v
+            float *t = u;
+            u = v;
+            v = t;
+        }
+        #endif
+        clock_gettime(CLOCK_REALTIME, &end_m);
+        if (!warm_up_iter) {
+            time_modeling += (end_m.tv_sec  - start_m.tv_sec) +
+                             (double)(end_m.tv_nsec - start_m.tv_nsec) / 1.0e9;
+        }
+
+        float min_u, max_u;
+        find_min_max_u(grid, u, &min_u, &max_u);
+        printf("FINAL min_u,  max_u = %f, %f\n", min_u, max_u);
+
+        if( finalio )
+            write_io(nx, ny, nz, lx, ly, lz, u, nsteps);
+
+        //target_finalize(grid,nsteps,u,v,phi,eta,coefx,coefy,coefz,vp,source);
+        free(u);
+        free(v);
+        free(phi);
+        free(eta);
+        free(source);
+        free(vp);
+
+        warm_up_iter = false;
+    }
+
+    printf("Time kernel: %g s\n", time_kernel / niters);
+    printf("Time modeling: %g s\n", time_modeling / niters);
+}

--- a/src/fdwave_raja/grid.cpp
+++ b/src/fdwave_raja/grid.cpp
@@ -1,0 +1,51 @@
+#include "grid.hpp"
+
+#include "constants.hpp"
+#include <stdio.h>
+
+struct grid_t init_grid(llint nx, llint ny, llint nz, llint tsx, llint tsy,
+                        llint ngpu)
+{
+    struct grid_t grid;
+    grid.nx = nx; grid.ny = ny; grid.nz = nz;
+    grid.dx = 20;  grid.dy = 20;  grid.dz = 20;
+    grid.lx = 4; grid.ly = 4; grid.lz = 4;
+    grid.ntaperx = 3; grid.ntapery = 3; grid.ntaperz = 3;
+
+    const float lambdamax = vmax/_fmax;
+    grid.ndampx = grid.ntaperx * lambdamax / grid.dx;
+    grid.ndampy = grid.ntapery * lambdamax / grid.dy;
+    grid.ndampz = grid.ntaperz * lambdamax / grid.dz;
+
+    grid.x1 = 0;
+    grid.x2 = grid.ndampx;
+    grid.x3 = grid.ndampx;
+    grid.x4 = grid.nx-grid.ndampx;
+    grid.x5 = grid.nx-grid.ndampx;
+    grid.x6 = grid.nx;
+
+    grid.y1 = 0;
+    grid.y2 = grid.ndampy;
+    grid.y3 = grid.ndampy;
+    grid.y4 = grid.ny-grid.ndampy;
+    grid.y5 = grid.ny-grid.ndampy;
+    grid.y6 = grid.ny;
+
+    grid.z1 = 0;
+    grid.z2 = grid.ndampz;
+    grid.z3 = grid.ndampz;
+    grid.z4 = grid.nz-grid.ndampz;
+    grid.z5 = grid.nz-grid.ndampz;
+    grid.z6 = grid.nz;
+
+    grid.tsx = tsx;
+    grid.tsy = tsy;
+    grid.ntx = nx/tsx;
+    grid.nty = ny/tsy;
+
+    // For multi-gpu targets
+    grid.ngpu = ngpu;
+
+    printf("ndamp = %lld %lld %lld\n", grid.ndampx, grid.ndampy, grid.ndampz);
+    return grid;
+}

--- a/src/fdwave_raja/grid.hpp
+++ b/src/fdwave_raja/grid.hpp
@@ -1,0 +1,25 @@
+#ifndef GRID_H
+#define GRID_H
+
+#include "constants.hpp"
+
+struct grid_t {
+    llint ntaperx, ntapery, ntaperz;
+    llint ndampx, ndampy, ndampz;
+    llint nx, ny, nz;
+    llint dx, dy, dz;
+    llint x1, x2, x3, x4, x5, x6;
+    llint y1, y2, y3, y4, y5, y6;
+    llint z1, z2, z3, z4, z5, z6;
+    llint lx, ly, lz;
+    // These parameters are used only for tasks
+    llint ntx, nty, tsx, tsy;
+
+    // Used for multi-gpu targets
+    llint ngpu;
+};
+
+struct grid_t init_grid(llint nx, llint ny, llint nz, llint tsx, llint tsy,
+                        llint ngpu);
+
+#endif

--- a/src/fdwave_raja/memoryManager.hpp
+++ b/src/fdwave_raja/memoryManager.hpp
@@ -1,0 +1,84 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2016-21, Lawrence Livermore National Security, LLC
+// and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef EXAMPLES_MEMORYMANAGER_HPP
+#define EXAMPLES_MEMORYMANAGER_HPP
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+#include "RAJA/policy/cuda/raja_cudaerrchk.hpp"
+#endif
+
+#if defined(RAJA_ENABLE_HIP)
+#include "RAJA/policy/hip/raja_hiperrchk.hpp"
+#endif
+
+/*
+  As RAJA does not manage memory we include a general purpose memory
+  manager which may be used to perform c++ style allocation/deallocation
+  or allocate/deallocate CUDA unified memory. The type of memory allocated
+  is dependent on how RAJA was configured.
+*/
+namespace memoryManager
+{
+
+template <typename T>
+T *allocate(RAJA::Index_type size)
+{
+  T *ptr;
+#if defined(RAJA_ENABLE_CUDA)
+  cudaErrchk(
+      cudaMallocManaged((void **)&ptr, sizeof(T) * size, cudaMemAttachGlobal));
+#else
+  ptr = new T[size];
+#endif
+  return ptr;
+}
+
+template <typename T>
+void deallocate(T *&ptr)
+{
+  if (ptr) {
+#if defined(RAJA_ENABLE_CUDA)
+    cudaErrchk(cudaFree(ptr));
+#else
+    delete[] ptr;
+#endif
+    ptr = nullptr;
+  }
+}
+
+#if defined(RAJA_ENABLE_CUDA) || defined(RAJA_ENABLE_HIP)
+  template <typename T>
+  T *allocate_gpu(RAJA::Index_type size)
+  {
+    T *ptr;
+#if defined(RAJA_ENABLE_CUDA)
+    cudaErrchk(cudaMalloc((void **)&ptr, sizeof(T) * size));
+#elif defined(RAJA_ENABLE_HIP)
+    hipErrchk(hipMalloc((void **)&ptr, sizeof(T) * size));
+#endif
+    return ptr;
+  }
+
+  template <typename T>
+  void deallocate_gpu(T *&ptr)
+  {
+    if (ptr) {
+#if defined(RAJA_ENABLE_CUDA)
+      cudaErrchk(cudaFree(ptr));
+#elif defined(RAJA_ENABLE_HIP)
+      hipErrchk(hipFree(ptr));
+#endif
+      ptr = nullptr;
+    }
+  }
+#endif
+
+}  // namespace memoryManager
+#endif

--- a/src/fdwave_raja/pml.cpp
+++ b/src/fdwave_raja/pml.cpp
@@ -1,0 +1,117 @@
+#include "pml.hpp"
+
+#include <math.h>
+
+#include "constants.hpp"
+
+// For debug
+#include <stdlib.h>
+#include <stdio.h>
+
+/**
+ * @param profile has dimension [i_min,i_max]
+ */
+void pml_profile_init(float *profile, llint i_min, llint i_max, llint n_first, llint n_last,
+                      float scale)
+{
+    llint n = i_max-i_min+1;
+    llint shift = i_min-1;
+
+    llint first_beg = 1 + shift;
+    llint first_end = n_first + shift;
+    llint last_beg  = n - n_last+1 + shift;
+    llint last_end  = n + shift;
+
+    for (llint i = i_min; i <= i_max; ++i) {
+        profile[i] = 0.f;
+    }
+
+    float tmp = scale / POW2(first_end-first_beg+1);
+    for (llint i = 1; i <= first_end-first_beg+1; ++i) {
+        profile[first_end-i+1] = POW2(i)*tmp;
+    }
+
+    for (llint i = 1; i <= last_end-last_beg+1; ++i) {
+        profile[last_beg+i-1] = POW2(i)*tmp;
+    } 
+}
+
+void pml_profile_extend(llint ny, llint nz,
+                        float *eta, const float *etax, const float *etay, const float *etaz,
+                        llint xbeg, llint xend, llint ybeg, llint yend, llint zbeg, llint zend)
+{
+    const llint n_ghost = 1;
+    for (llint ix = xbeg-n_ghost; ix <= xend+n_ghost; ++ix) {
+        for (llint iy = ybeg-n_ghost; iy <= yend+n_ghost; ++iy) {
+            for (llint iz = zbeg-n_ghost; iz <= zend+n_ghost; ++iz) {
+                eta[IDX3_eta0(ix,iy,iz)] = etax[ix] + etay[iy] + etaz[iz];
+            }
+        }
+    }
+}
+
+void pml_profile_extend_all(llint ny, llint nz,
+                            float *eta, const float *etax, const float *etay, const float *etaz,
+                            llint xmin, llint xmax, llint ymin, llint ymax,
+                            llint x1, llint x2, llint x5, llint x6,
+                            llint y1, llint y2, llint y3, llint y4, llint y5, llint y6,
+                            llint z1, llint z2, llint z3, llint z4, llint z5, llint z6)
+{
+    // Top.
+    if (z1 != -1)
+    pml_profile_extend(ny,nz,eta,etax,etay,etaz,xmin,xmax,ymin,ymax,z1,z2);
+    // Bottom.
+    if (z5 != -5)
+    pml_profile_extend(ny,nz,eta,etax,etay,etaz,xmin,xmax,ymin,ymax,z5,z6);
+    // Front.
+    if ((y1!=-1) && (z3!=-3))
+    pml_profile_extend(ny,nz,eta,etax,etay,etaz,xmin,xmax,y1,y2,z3,z4);
+    // Back.
+    if ((y6!=-6) && (z3!=-3))
+    pml_profile_extend(ny,nz,eta,etax,etay,etaz,xmin,xmax,y5,y6,z3,z4);
+    // Left.
+    if ((x1!=-1) && (y3!=-3) && (z3!=-3))
+    pml_profile_extend(ny,nz,eta,etax,etay,etaz,x1,x2,y3,y4,z3,z4);
+    // Right.
+    if ((x6!=-6) && (y3!=-3) && (z3!=-3))
+    pml_profile_extend(ny,nz,eta,etax,etay,etaz,x5,x6,y3,y4,z3,z4);
+}
+
+void init_eta(llint nx, llint ny, llint nz, struct grid_t grid,
+              float dt_sch,
+              float *eta)
+{
+    for (llint i = -1; i < nx+1; ++i) {
+        for (llint j = -1; j < ny+1; ++j) {
+            for (llint k = -1; k < nz+1; ++k) {
+                eta[IDX3_eta1(i,j,k)] = 0.f;
+            }
+        }
+    }
+
+    /* etax */
+    float param = dt_sch * 3.f * vmax * logf(1000.f)/(2.f*grid.ndampx*grid.dx);
+    float *etax =(float *) malloc(sizeof(float)*(nx+2));
+    pml_profile_init(etax, 0, grid.nx+1, grid.ndampx, grid.ndampx, param);
+
+    /* etay */
+    param = dt_sch*3.f*vmax*logf(1000.f)/(2.f*grid.ndampy*grid.dy);
+    float *etay =(float *) malloc(sizeof(float)*(ny+2));
+    pml_profile_init(etay, 0, grid.ny+1, grid.ndampy, grid.ndampy, param);
+
+    /* etaz */
+    param = dt_sch*3.f*vmax*logf(1000.f)/(2.f*grid.ndampz*grid.dz);
+    float *etaz =(float *) malloc(sizeof(float)*(nz+2));
+    pml_profile_init(etaz, 0, grid.nz+1, grid.ndampz, grid.ndampz, param);
+
+    (void)pml_profile_extend_all(ny, nz,
+                eta, etax, etay, etaz,
+                1, nx, 1, ny,
+                grid.x1+1, grid.x2, grid.x5+1, grid.x6,
+                grid.y1+1, grid.y2, grid.y3+1, grid.y4, grid.y5+1, grid.y6,
+                grid.z1+1, grid.z2, grid.z3+1, grid.z4, grid.z5+1, grid.z6);
+
+    free(etax);
+    free(etay);
+    free(etaz);
+}

--- a/src/fdwave_raja/pml.hpp
+++ b/src/fdwave_raja/pml.hpp
@@ -1,0 +1,11 @@
+#ifndef PML_H
+#define PML_H
+
+#include "constants.hpp"
+#include "grid.hpp"
+
+void init_eta(llint nx, llint ny, llint nz, struct grid_t grid,
+              float dt_sch,
+              float *eta);
+
+#endif

--- a/src/fdwave_raja/target_3d.cpp
+++ b/src/fdwave_raja/target_3d.cpp
@@ -1,0 +1,300 @@
+#include "target_3d.hpp"
+#include "grid.hpp"
+#include "constants.hpp"
+
+#include "memoryManager.hpp"
+#include "RAJA/RAJA.hpp"
+
+#define LAP (coef0*u[IDX3_l(i,j,k)] \
+                +coefx[1]*(u[IDX3_l(i+1,j,k)]+u[IDX3_l(i-1,j,k)]) \
+                +coefy[1]*(u[IDX3_l(i,j+1,k)]+u[IDX3_l(i,j-1,k)]) \
+                +coefz[1]*(u[IDX3_l(i,j,k+1)]+u[IDX3_l(i,j,k-1)]) \
+                +coefx[2]*(u[IDX3_l(i+2,j,k)]+u[IDX3_l(i-2,j,k)]) \
+                +coefy[2]*(u[IDX3_l(i,j+2,k)]+u[IDX3_l(i,j-2,k)]) \
+                +coefz[2]*(u[IDX3_l(i,j,k+2)]+u[IDX3_l(i,j,k-2)]) \
+                +coefx[3]*(u[IDX3_l(i+3,j,k)]+u[IDX3_l(i-3,j,k)]) \
+                +coefy[3]*(u[IDX3_l(i,j+3,k)]+u[IDX3_l(i,j-3,k)]) \
+                +coefz[3]*(u[IDX3_l(i,j,k+3)]+u[IDX3_l(i,j,k-3)]) \
+                +coefx[4]*(u[IDX3_l(i+4,j,k)]+u[IDX3_l(i-4,j,k)]) \
+                +coefy[4]*(u[IDX3_l(i,j+4,k)]+u[IDX3_l(i,j-4,k)]) \
+                +coefz[4]*(u[IDX3_l(i,j,k+4)]+u[IDX3_l(i,j,k-4)]))
+
+void compute_inner_3d(RAJA::Index_type const x3, const RAJA::Index_type x4, const RAJA::Index_type y3,
+                      RAJA::Index_type const y4, const RAJA::Index_type z3, const RAJA::Index_type z4,
+                      RAJA::Index_type const lx, const RAJA::Index_type ly, const RAJA::Index_type lz,
+                      RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefxViewConst,
+                      RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefyViewConst,
+                      RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefzViewConst,                    
+                      RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > &__restrict__ uViewConst,
+                      RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > &__restrict__ vpViewConst,
+                      RAJA::View< float, RAJA::Layout<3, RAJA::Index_type, 2> > &__restrict__ vView )
+{
+  const float coef0 = coefxViewConst(0) + coefyViewConst(0) + coefzViewConst(0);
+
+  RAJA::RangeSegment XRange(x3, x4);
+  RAJA::RangeSegment YRange(y3, y4);
+  RAJA::RangeSegment ZRange(z3, z4);
+  
+  using KJI_EXECPOL = RAJA::KernelPolicy<
+    RAJA::statement::For<0, RAJA::loop_exec,
+    RAJA::statement::For<1, RAJA::loop_exec,
+    RAJA::statement::For<2, RAJA::loop_exec,
+    RAJA::statement::Lambda<0> > > > >;
+
+    RAJA::kernel<KJI_EXECPOL>( RAJA::make_tuple(XRange, YRange, ZRange),
+                               [&coef0,lx,ly,lz,
+                                coefxViewConst,coefyViewConst,coefzViewConst,
+                                uViewConst,vpViewConst,vView] (RAJA::Index_type const i, RAJA::Index_type const j, RAJA::Index_type const k) 
+                               {
+                                 const float lap = (coef0*uViewConst(i+lx,j+ly,k+lz) 
+                                                    +coefxViewConst(1)*(uViewConst(i+1+lx,j+ly,k+lz)+uViewConst(i-1+lx,j+ly,k+lz))
+                                                    +coefyViewConst(1)*(uViewConst(i+lx,j+1+ly,k+lz)+uViewConst(i+lx,j-1+ly,k+lz))
+                                                    +coefzViewConst(1)*(uViewConst(i+lx,j+ly,k+1+lz)+uViewConst(i+lx,j+ly,k-1+lz))
+                                                    +coefxViewConst(2)*(uViewConst(i+2+lx,j+ly,k+lz)+uViewConst(i-2+lx,j+ly,k+lz))
+                                                    +coefyViewConst(2)*(uViewConst(i+lx,j+2+ly,k+lz)+uViewConst(i+lx,j-2+ly,k+lz))
+                                                    +coefzViewConst(2)*(uViewConst(i+lx,j+ly,k+2+lz)+uViewConst(i+lx,j+ly,k-2+lz))
+                                                    +coefxViewConst(3)*(uViewConst(i+3+lx,j+ly,k+lz)+uViewConst(i-3+lx,j+ly,k+lz))
+                                                    +coefyViewConst(3)*(uViewConst(i+lx,j+3+ly,k+lz)+uViewConst(i+lx,j-3+ly,k+lz))
+                                                    +coefzViewConst(3)*(uViewConst(i+lx,j+ly,k+3+lz)+uViewConst(i+lx,j+ly,k-3+lz))
+                                                    +coefxViewConst(4)*(uViewConst(i+4+lx,j+ly,k+lz)+uViewConst(i-4+lx,j+ly,k+lz))
+                                                    +coefyViewConst(4)*(uViewConst(i+lx,j+4+ly,k+lz)+uViewConst(i+lx,j-4+ly,k+lz))
+                                                    +coefzViewConst(4)*(uViewConst(i+lx,j+ly,k+4+lz)+uViewConst(i+lx,j+ly,k-4+lz)));
+                                 vView( i+lx,j+ly,k+lz ) =
+                                   2.f*uViewConst( i+lx,j+ly,k+lz )
+                                   -vView( i+lx,j+ly,k+lz )
+                                   +vpViewConst( i,j,k )*lap;
+                               } );
+
+}
+
+void target_inner_3d(llint nx, llint ny, llint nz,
+                     llint x3, llint x4, llint y3,
+                     llint y4, llint z3, llint z4,
+                     llint lx, llint ly, llint lz,
+                     const float *__restrict__ coefx,
+                     const float *__restrict__ coefy,
+                     const float *__restrict__ coefz,
+                     const float *__restrict__ u,
+                     float *__restrict__ v,
+                     const float *__restrict__ vp)
+{
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefxViewConst( coefx, 5 );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefyViewConst( coefy, 5 );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefzViewConst( coefz, 5 );
+ 
+  RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > uViewConst( u, RAJA::Layout<3>(nx+2*lx, ny+2*ly, nz+2*lz) );
+  RAJA::View< float, RAJA::Layout<3, RAJA::Index_type, 2> > vView( v, RAJA::Layout<3>(nx+2*lx, ny+2*ly, nz+2*lz) );
+  RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > vpViewConst( vp, RAJA::Layout<3>(nx, ny, nz) );    
+    
+  compute_inner_3d(RAJA::Index_type(x3), RAJA::Index_type(x4),
+                   RAJA::Index_type(y3), RAJA::Index_type(y4),
+                   RAJA::Index_type(z3), RAJA::Index_type(z4),
+                   RAJA::Index_type(lx), RAJA::Index_type(ly), RAJA::Index_type(lz),
+                   coefxViewConst, coefyViewConst, coefzViewConst,
+                   uViewConst, vpViewConst, vView );
+
+  // RAJA_UNUSED_VAR( nx );
+  // float coef0 = coefx[0] + coefy[0] + coefz[0];
+  // for (llint i = x3; i < x4; ++i) {
+  //   for (llint j = y3; j < y4; ++j) {
+  //     for (llint k = z3; k < z4; ++k) {
+  //    float lap = LAP;
+  //    v[IDX3_l(i,j,k)] = 2.f*u[IDX3_l(i,j,k)]-v[IDX3_l(i,j,k)]+vp[IDX3(i,j,k)]*lap;
+  //     }
+  //   }
+  // }
+}
+
+void compute_pml_3d(RAJA::Index_type const x3, const RAJA::Index_type x4, const RAJA::Index_type y3,
+                    RAJA::Index_type const y4, const RAJA::Index_type z3, const RAJA::Index_type z4,
+                    RAJA::Index_type const lx, const RAJA::Index_type ly, const RAJA::Index_type lz,
+                    float const & hdx_2, float const & hdy_2, float const & hdz_2,
+                    RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefxViewConst,
+                    RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefyViewConst,
+                    RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefzViewConst,                      
+                    RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > &__restrict__ uViewConst,
+                    RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > &__restrict__ vpViewConst,
+                    RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > &__restrict__ etaViewConst,             
+                    RAJA::View< float, RAJA::Layout<3, RAJA::Index_type, 2> > &__restrict__ vView,
+                    RAJA::View< float, RAJA::Layout<3, RAJA::Index_type, 2> > &__restrict__ phiView )
+{
+  const float coef0 = coefxViewConst(0) + coefyViewConst(0) + coefzViewConst(0);
+
+  RAJA::RangeSegment XRange(x3, x4);
+  RAJA::RangeSegment YRange(y3, y4);
+  RAJA::RangeSegment ZRange(z3, z4);
+  
+  using KJI_EXECPOL = RAJA::KernelPolicy<
+    RAJA::statement::For<0, RAJA::loop_exec, 
+    RAJA::statement::For<1, RAJA::loop_exec, 
+    RAJA::statement::For<2, RAJA::loop_exec, 
+    RAJA::statement::Lambda<0> > > > >;
+
+  RAJA::kernel<KJI_EXECPOL>( RAJA::make_tuple(XRange, YRange, ZRange),
+                             [&coef0,lx,ly,lz,&hdx_2,&hdy_2,&hdz_2,
+                              coefxViewConst,coefyViewConst,coefzViewConst,
+                              uViewConst,etaViewConst,vpViewConst,vView,phiView] (RAJA::Index_type const i,
+                                                                                  RAJA::Index_type const j,
+                                                                                  RAJA::Index_type const k)
+                             {
+                               const float lap = (coef0*uViewConst(i+lx,j+ly,k+lz) 
+                                                  +coefxViewConst(1)*(uViewConst(i+1+lx,j+ly,k+lz)+uViewConst(i-1+lx,j+ly,k+lz))
+                                                  +coefyViewConst(1)*(uViewConst(i+lx,j+1+ly,k+lz)+uViewConst(i+lx,j-1+ly,k+lz))
+                                                  +coefzViewConst(1)*(uViewConst(i+lx,j+ly,k+1+lz)+uViewConst(i+lx,j+ly,k-1+lz))
+                                                  +coefxViewConst(2)*(uViewConst(i+2+lx,j+ly,k+lz)+uViewConst(i-2+lx,j+ly,k+lz))
+                                                  +coefyViewConst(2)*(uViewConst(i+lx,j+2+ly,k+lz)+uViewConst(i+lx,j-2+ly,k+lz))
+                                                  +coefzViewConst(2)*(uViewConst(i+lx,j+ly,k+2+lz)+uViewConst(i+lx,j+ly,k-2+lz))
+                                                  +coefxViewConst(3)*(uViewConst(i+3+lx,j+ly,k+lz)+uViewConst(i-3+lx,j+ly,k+lz))
+                                                  +coefyViewConst(3)*(uViewConst(i+lx,j+3+ly,k+lz)+uViewConst(i+lx,j-3+ly,k+lz))
+                                                  +coefzViewConst(3)*(uViewConst(i+lx,j+ly,k+3+lz)+uViewConst(i+lx,j+ly,k-3+lz))
+                                                  +coefxViewConst(4)*(uViewConst(i+4+lx,j+ly,k+lz)+uViewConst(i-4+lx,j+ly,k+lz))
+                                                  +coefyViewConst(4)*(uViewConst(i+lx,j+4+ly,k+lz)+uViewConst(i+lx,j-4+ly,k+lz))
+                                                  +coefzViewConst(4)*(uViewConst(i+lx,j+ly,k+4+lz)+uViewConst(i+lx,j+ly,k-4+lz)));
+                               
+                               vView(i+lx,j+ly,k+lz) =
+                                 ( (2.f-etaViewConst(i+1,j+1,k+1)*etaViewConst(i+1,j+1,k+1)
+                                    +2.f*etaViewConst(i+1,j+1,k+1))*uViewConst(i+lx,j+ly,k+lz)
+                                   -vView(i+lx,j+ly,k+lz)
+                                   +vpViewConst(i,j,k)*(lap+phiView(i,j,k)) )
+                                 / (1.f+2.f*etaViewConst(i+1,j+1,k+1));
+                               phiView(i,j,k) =
+                                 ( phiView(i,j,k)-
+                                   ( (etaViewConst(i+2,j+1,k+1)-etaViewConst(i,j+1,k+1))
+                                     *(uViewConst(i+1+lx,j+ly,k+lz)-uViewConst(i-1+lx,j+ly,k+lz))*hdx_2
+                                     +(etaViewConst(i+1,j+2,k+1)-etaViewConst(i+1,j,k+1))
+                                     *(uViewConst(i+lx,j+1+ly,k+lz)-uViewConst(i+lx,j-1+ly,k+lz))*hdy_2
+                                     +(etaViewConst(i+1,j+1,k+2)-etaViewConst(i+1,j+1,k))
+                                     *(uViewConst(i+lx,j+ly,k+1+lz)-uViewConst(i+lx,j+ly,k-1+lz))*hdz_2 ) )
+                                 / (1.f+etaViewConst(i+1,j+1,k+1));
+                             });
+}
+
+void target_pml_3d(llint nx, llint ny,llint nz,
+                   llint x3, llint x4, llint y3,
+                   llint y4, llint z3, llint z4,
+                   llint lx, llint ly, llint lz,
+                   float hdx_2, float hdy_2, float hdz_2,
+                   const float *__restrict__ coefx,
+                   const float *__restrict__ coefy,
+                   const float *__restrict__ coefz,
+                   const float *__restrict__ u,
+                   float *__restrict__ v,
+                   const float *__restrict__ vp,
+                   float *__restrict__ phi,
+                   const float *__restrict__ eta)
+{
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefxViewConst( coefx, 5 );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefyViewConst( coefy, 5 );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefzViewConst( coefz, 5 );
+
+  RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > uViewConst( u, RAJA::Layout<3>(nx+2*lx, ny+2*ly, nz+2*lz) );
+  RAJA::View< float, RAJA::Layout<3, RAJA::Index_type, 2> > vView( v, RAJA::Layout<3>(nx+2*lx, ny+2*ly, nz+2*lz) );
+  RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > vpViewConst( vp, RAJA::Layout<3>(nx, ny, nz) );
+  RAJA::View< float, RAJA::Layout<3, RAJA::Index_type, 2> > phiView( phi, RAJA::Layout<3>(nx, ny, nz) );
+  RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > etaViewConst( eta, RAJA::Layout<3>(nx+2, ny+2, nz+2) );    
+
+  compute_pml_3d( RAJA::Index_type(x3), RAJA::Index_type(x4),
+                  RAJA::Index_type(y3), RAJA::Index_type(y4),
+                  RAJA::Index_type(z3), RAJA::Index_type(z4),
+                  RAJA::Index_type(lx), RAJA::Index_type(ly), RAJA::Index_type(lz),
+                  hdx_2, hdy_2, hdz_2,
+                  coefxViewConst, coefyViewConst, coefzViewConst,
+                  uViewConst, vpViewConst, etaViewConst, vView, phiView );
+  
+  // const float coef0 = coefxViewConst(0) + coefyViewConst(0) + coefzViewConst(0);
+  // RAJA_UNUSED_VAR( nx );
+  
+  //   for (llint i = x3; i < x4; ++i) {
+  //      for (llint j = y3; j < y4; ++j) {
+  //          for (llint k = z3; k < z4; ++k) {
+  //              float const lap = LAP;
+
+  //              v[IDX3_l(i,j,k)] =
+  //                  ((2.f-eta[IDX3_eta1(i,j,k)]*eta[IDX3_eta1(i,j,k)]
+  //                  +2.f*eta[IDX3_eta1(i,j,k)])*u[IDX3_l(i,j,k)]
+  //                  -v[IDX3_l(i,j,k)]
+  //                  +vp[IDX3(i,j,k)]*
+  //                  (lap+phi[IDX3(i,j,k)]))/(1.f+2.f*eta[IDX3_eta1(i,j,k)]);
+
+  //             phi[IDX3(i,j,k)]=(phi[IDX3(i,j,k)]-
+  //               ((eta[IDX3_eta1(i+1,j,k)]-eta[IDX3_eta1(i-1,j,k)])
+  //                    *(u[IDX3_l(i+1,j,k)]-u[IDX3_l(i-1,j,k)])*hdx_2
+  //                    +(eta[IDX3_eta1(i,j+1,k)]-eta[IDX3_eta1(i,j-1,k)])
+  //                    *(u[IDX3_l(i,j+1,k)]-u[IDX3_l(i,j-1,k)])*hdy_2
+  //                    +(eta[IDX3_eta1(i,j,k+1)]-eta[IDX3_eta1(i,j,k-1)])
+  //                  *(u[IDX3_l(i,j,k+1)]-u[IDX3_l(i,j,k-1)])*hdz_2))
+  //                    /(1.f+eta[IDX3_eta1(i,j,k)]);
+  //         }
+  //      }
+  //   }
+}
+
+void target_3d(llint nx, llint ny, llint nz,
+               llint x1, llint x2, llint x3,
+               llint x4, llint x5, llint x6,
+               llint y1, llint y2, llint y3,
+               llint y4, llint y5, llint y6,
+               llint z1, llint z2, llint z3,
+               llint z4, llint z5, llint z6,
+               llint lx, llint ly, llint lz,
+               float hdx_2, float hdy_2, float hdz_2,
+               const float *__restrict__ coefx,
+               const float *__restrict__ coefy,
+               const float *__restrict__ coefz,
+               const float *__restrict__ u,
+               float *__restrict__ v,
+               const float *__restrict__ vp,
+               float *__restrict__ phi,
+               const float *__restrict__ eta)
+{
+    const llint xmin = 0; const llint xmax = nx;
+    const llint ymin = 0; const llint ymax = ny;
+
+    target_pml_3d(nx,ny,nz,
+                  xmin,xmax,ymin,ymax,z1,z2,
+                  lx,ly,lz,
+                  hdx_2,hdy_2,hdz_2,
+                  coefx,coefy,coefz,
+                  u,v,vp,phi,eta);
+
+    target_pml_3d(nx,ny,nz,
+                  xmin,xmax,y1,y2,z3,z4,
+                  lx,ly,lz,
+                  hdx_2,hdy_2,hdz_2,
+                  coefx,coefy,coefz,
+                  u,v,vp,phi,eta);
+
+    target_pml_3d(nx,ny,nz,
+                  x1,x2,y3,y4,z3,z4,
+                  lx,ly,lz,
+                  hdx_2,hdy_2,hdz_2,
+                  coefx,coefy,coefz,
+                  u,v,vp,phi,eta);
+
+    target_inner_3d(nx,ny,nz,
+                    x3,x4,y3,y4,z3,z4,
+                    lx,ly,lz,
+                    coefx,coefy,coefz,
+                    u,v,vp);
+
+    target_pml_3d(nx,ny,nz,
+                  x5,x6,y3,y4,z3,z4,
+                  lx,ly,lz,
+                  hdx_2,hdy_2,hdz_2,
+                  coefx,coefy,coefz,
+                  u,v,vp,phi,eta);
+
+    target_pml_3d(nx,ny,nz,
+                  xmin,xmax,y5,y6,z3,z4,
+                  lx,ly,lz,
+                  hdx_2,hdy_2,hdz_2,
+                  coefx,coefy,coefz,
+                  u,v,vp,phi,eta);
+
+    target_pml_3d(nx,ny,nz,
+                  xmin,xmax,ymin,ymax,z5,z6,
+                  lx,ly,lz,
+                  hdx_2,hdy_2,hdz_2,
+                  coefx,coefy,coefz,
+                  u,v,vp,phi,eta);
+}

--- a/src/fdwave_raja/target_3d.cpp
+++ b/src/fdwave_raja/target_3d.cpp
@@ -6,30 +6,73 @@
 #include "RAJA/RAJA.hpp"
 
 #define LAP (coef0*u[IDX3_l(i,j,k)] \
-                +coefx[1]*(u[IDX3_l(i+1,j,k)]+u[IDX3_l(i-1,j,k)]) \
-                +coefy[1]*(u[IDX3_l(i,j+1,k)]+u[IDX3_l(i,j-1,k)]) \
-                +coefz[1]*(u[IDX3_l(i,j,k+1)]+u[IDX3_l(i,j,k-1)]) \
-                +coefx[2]*(u[IDX3_l(i+2,j,k)]+u[IDX3_l(i-2,j,k)]) \
-                +coefy[2]*(u[IDX3_l(i,j+2,k)]+u[IDX3_l(i,j-2,k)]) \
-                +coefz[2]*(u[IDX3_l(i,j,k+2)]+u[IDX3_l(i,j,k-2)]) \
-                +coefx[3]*(u[IDX3_l(i+3,j,k)]+u[IDX3_l(i-3,j,k)]) \
-                +coefy[3]*(u[IDX3_l(i,j+3,k)]+u[IDX3_l(i,j-3,k)]) \
-                +coefz[3]*(u[IDX3_l(i,j,k+3)]+u[IDX3_l(i,j,k-3)]) \
-                +coefx[4]*(u[IDX3_l(i+4,j,k)]+u[IDX3_l(i-4,j,k)]) \
-                +coefy[4]*(u[IDX3_l(i,j+4,k)]+u[IDX3_l(i,j-4,k)]) \
-                +coefz[4]*(u[IDX3_l(i,j,k+4)]+u[IDX3_l(i,j,k-4)]))
+            +coefx[1]*(u[IDX3_l(i+1,j,k)]+u[IDX3_l(i-1,j,k)]) \
+            +coefy[1]*(u[IDX3_l(i,j+1,k)]+u[IDX3_l(i,j-1,k)]) \
+            +coefz[1]*(u[IDX3_l(i,j,k+1)]+u[IDX3_l(i,j,k-1)]) \
+            +coefx[2]*(u[IDX3_l(i+2,j,k)]+u[IDX3_l(i-2,j,k)]) \
+            +coefy[2]*(u[IDX3_l(i,j+2,k)]+u[IDX3_l(i,j-2,k)]) \
+            +coefz[2]*(u[IDX3_l(i,j,k+2)]+u[IDX3_l(i,j,k-2)]) \
+            +coefx[3]*(u[IDX3_l(i+3,j,k)]+u[IDX3_l(i-3,j,k)]) \
+            +coefy[3]*(u[IDX3_l(i,j+3,k)]+u[IDX3_l(i,j-3,k)]) \
+            +coefz[3]*(u[IDX3_l(i,j,k+3)]+u[IDX3_l(i,j,k-3)]) \
+            +coefx[4]*(u[IDX3_l(i+4,j,k)]+u[IDX3_l(i-4,j,k)]) \
+            +coefy[4]*(u[IDX3_l(i,j+4,k)]+u[IDX3_l(i,j-4,k)]) \
+            +coefz[4]*(u[IDX3_l(i,j,k+4)]+u[IDX3_l(i,j,k-4)]))
+
+#define LAPVIEW (coef0*uView(IDX3_l(i,j,k)) \
+                +coefxView(1)*(uView(IDX3_l(i+1,j,k))+uView(IDX3_l(i-1,j,k))) \
+                +coefyView(1)*(uView(IDX3_l(i,j+1,k))+uView(IDX3_l(i,j-1,k))) \
+                +coefzView(1)*(uView(IDX3_l(i,j,k+1))+uView(IDX3_l(i,j,k-1))) \
+                +coefxView(2)*(uView(IDX3_l(i+2,j,k))+uView(IDX3_l(i-2,j,k))) \
+                +coefyView(2)*(uView(IDX3_l(i,j+2,k))+uView(IDX3_l(i,j-2,k))) \
+                +coefzView(2)*(uView(IDX3_l(i,j,k+2))+uView(IDX3_l(i,j,k-2))) \
+                +coefxView(3)*(uView(IDX3_l(i+3,j,k))+uView(IDX3_l(i-3,j,k))) \
+                +coefyView(3)*(uView(IDX3_l(i,j+3,k))+uView(IDX3_l(i,j-3,k))) \
+                +coefzView(3)*(uView(IDX3_l(i,j,k+3))+uView(IDX3_l(i,j,k-3))) \
+                +coefxView(4)*(uView(IDX3_l(i+4,j,k))+uView(IDX3_l(i-4,j,k))) \
+                +coefyView(4)*(uView(IDX3_l(i,j+4,k))+uView(IDX3_l(i,j-4,k))) \
+                +coefzView(4)*(uView(IDX3_l(i,j,k+4))+uView(IDX3_l(i,j,k-4))))
+
+#define VUPDATE v[IDX3_l(i,j,k)] = ( (2.f-eta[IDX3_eta1(i,j,k)]*eta[IDX3_eta1(i,j,k)] \
+                                      +2.f*eta[IDX3_eta1(i,j,k)])*u[IDX3_l(i,j,k)]    \
+                                     -v[IDX3_l(i,j,k)]                                \
+                                     +vp[IDX3(i,j,k)]*(lap+phi[IDX3(i,j,k)]) )        \
+                                     / (1.f+2.f*eta[IDX3_eta1(i,j,k)]);
+#define VVIEWUPDATE vView(IDX3_l(i,j,k)) = ( (2.f-etaView(IDX3_eta1(i,j,k))*etaView(IDX3_eta1(i,j,k)) \
+                                              +2.f*etaView(IDX3_eta1(i,j,k)))*uView(IDX3_l(i,j,k))    \
+                                              -vView(IDX3_l(i,j,k))                                   \
+                                              +vpView(IDX3(i,j,k))*(lap+phiView(IDX3(i,j,k))) )       \
+                                              /(1.f+2.f*etaView(IDX3_eta1(i,j,k))); 
+
+#define PHIUPDATE phi[IDX3(i,j,k)] = ( phi[IDX3(i,j,k)]                                     \
+                                      - ( (eta[IDX3_eta1(i+1,j,k)]-eta[IDX3_eta1(i-1,j,k)]) \
+                                        *(u[IDX3_l(i+1,j,k)]-u[IDX3_l(i-1,j,k)])*hdx_2      \
+                                        +(eta[IDX3_eta1(i,j+1,k)]-eta[IDX3_eta1(i,j-1,k)])  \
+                                        *(u[IDX3_l(i,j+1,k)]-u[IDX3_l(i,j-1,k)])*hdy_2      \
+                                        +(eta[IDX3_eta1(i,j,k+1)]-eta[IDX3_eta1(i,j,k-1)])  \
+                                        *(u[IDX3_l(i,j,k+1)]-u[IDX3_l(i,j,k-1)])*hdz_2 ) )  \
+                                        /(1.f+eta[IDX3_eta1(i,j,k)]); 
+#define PHIVIEWUPDATE phiView(IDX3(i,j,k)) = ( phiView(IDX3(i,j,k))                                        \
+                                            - ( (etaView(IDX3_eta1(i+1,j,k))-etaView(IDX3_eta1(i-1,j,k)))  \
+                                                *(uView(IDX3_l(i+1,j,k))-uView(IDX3_l(i-1,j,k)))*hdx_2     \
+                                                +(etaView(IDX3_eta1(i,j+1,k))-etaView(IDX3_eta1(i,j-1,k))) \
+                                                *(uView(IDX3_l(i,j+1,k))-uView(IDX3_l(i,j-1,k)))*hdy_2     \
+                                                +(etaView(IDX3_eta1(i,j,k+1))-etaView(IDX3_eta1(i,j,k-1))) \
+                                                *(uView(IDX3_l(i,j,k+1))-uView(IDX3_l(i,j,k-1)))*hdz_2))   \
+                                                /(1.f+etaView(IDX3_eta1(i,j,k)));
+
 
 void compute_inner_3d(RAJA::Index_type const x3, const RAJA::Index_type x4, const RAJA::Index_type y3,
                       RAJA::Index_type const y4, const RAJA::Index_type z3, const RAJA::Index_type z4,
                       RAJA::Index_type const lx, const RAJA::Index_type ly, const RAJA::Index_type lz,
-                      RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefxViewConst,
-                      RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefyViewConst,
-                      RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefzViewConst,                    
-                      RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > &__restrict__ uViewConst,
-                      RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > &__restrict__ vpViewConst,
+                      RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefxView,
+                      RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefyView,
+                      RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefzView,                    
+                      RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > &__restrict__ uView,
+                      RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > &__restrict__ vpView,
                       RAJA::View< float, RAJA::Layout<3, RAJA::Index_type, 2> > &__restrict__ vView )
 {
-  const float coef0 = coefxViewConst(0) + coefyViewConst(0) + coefzViewConst(0);
+  const float coef0 = coefxView(0) + coefyView(0) + coefzView(0);
 
   RAJA::RangeSegment XRange(x3, x4);
   RAJA::RangeSegment YRange(y3, y4);
@@ -43,26 +86,26 @@ void compute_inner_3d(RAJA::Index_type const x3, const RAJA::Index_type x4, cons
 
     RAJA::kernel<KJI_EXECPOL>( RAJA::make_tuple(XRange, YRange, ZRange),
                                [&coef0,lx,ly,lz,
-                                coefxViewConst,coefyViewConst,coefzViewConst,
-                                uViewConst,vpViewConst,vView] (RAJA::Index_type const i, RAJA::Index_type const j, RAJA::Index_type const k) 
+                                coefxView,coefyView,coefzView,
+                                uView,vpView,vView] (RAJA::Index_type const i, RAJA::Index_type const j, RAJA::Index_type const k) 
                                {
-                                 const float lap = (coef0*uViewConst(i+lx,j+ly,k+lz) 
-                                                    +coefxViewConst(1)*(uViewConst(i+1+lx,j+ly,k+lz)+uViewConst(i-1+lx,j+ly,k+lz))
-                                                    +coefyViewConst(1)*(uViewConst(i+lx,j+1+ly,k+lz)+uViewConst(i+lx,j-1+ly,k+lz))
-                                                    +coefzViewConst(1)*(uViewConst(i+lx,j+ly,k+1+lz)+uViewConst(i+lx,j+ly,k-1+lz))
-                                                    +coefxViewConst(2)*(uViewConst(i+2+lx,j+ly,k+lz)+uViewConst(i-2+lx,j+ly,k+lz))
-                                                    +coefyViewConst(2)*(uViewConst(i+lx,j+2+ly,k+lz)+uViewConst(i+lx,j-2+ly,k+lz))
-                                                    +coefzViewConst(2)*(uViewConst(i+lx,j+ly,k+2+lz)+uViewConst(i+lx,j+ly,k-2+lz))
-                                                    +coefxViewConst(3)*(uViewConst(i+3+lx,j+ly,k+lz)+uViewConst(i-3+lx,j+ly,k+lz))
-                                                    +coefyViewConst(3)*(uViewConst(i+lx,j+3+ly,k+lz)+uViewConst(i+lx,j-3+ly,k+lz))
-                                                    +coefzViewConst(3)*(uViewConst(i+lx,j+ly,k+3+lz)+uViewConst(i+lx,j+ly,k-3+lz))
-                                                    +coefxViewConst(4)*(uViewConst(i+4+lx,j+ly,k+lz)+uViewConst(i-4+lx,j+ly,k+lz))
-                                                    +coefyViewConst(4)*(uViewConst(i+lx,j+4+ly,k+lz)+uViewConst(i+lx,j-4+ly,k+lz))
-                                                    +coefzViewConst(4)*(uViewConst(i+lx,j+ly,k+4+lz)+uViewConst(i+lx,j+ly,k-4+lz)));
+                                 const float lap = (coef0*uView(i+lx,j+ly,k+lz) 
+                                                    +coefxView(1)*(uView(i+1+lx,j+ly,k+lz)+uView(i-1+lx,j+ly,k+lz))
+                                                    +coefyView(1)*(uView(i+lx,j+1+ly,k+lz)+uView(i+lx,j-1+ly,k+lz))
+                                                    +coefzView(1)*(uView(i+lx,j+ly,k+1+lz)+uView(i+lx,j+ly,k-1+lz))
+                                                    +coefxView(2)*(uView(i+2+lx,j+ly,k+lz)+uView(i-2+lx,j+ly,k+lz))
+                                                    +coefyView(2)*(uView(i+lx,j+2+ly,k+lz)+uView(i+lx,j-2+ly,k+lz))
+                                                    +coefzView(2)*(uView(i+lx,j+ly,k+2+lz)+uView(i+lx,j+ly,k-2+lz))
+                                                    +coefxView(3)*(uView(i+3+lx,j+ly,k+lz)+uView(i-3+lx,j+ly,k+lz))
+                                                    +coefyView(3)*(uView(i+lx,j+3+ly,k+lz)+uView(i+lx,j-3+ly,k+lz))
+                                                    +coefzView(3)*(uView(i+lx,j+ly,k+3+lz)+uView(i+lx,j+ly,k-3+lz))
+                                                    +coefxView(4)*(uView(i+4+lx,j+ly,k+lz)+uView(i-4+lx,j+ly,k+lz))
+                                                    +coefyView(4)*(uView(i+lx,j+4+ly,k+lz)+uView(i+lx,j-4+ly,k+lz))
+                                                    +coefzView(4)*(uView(i+lx,j+ly,k+4+lz)+uView(i+lx,j+ly,k-4+lz)));
                                  vView( i+lx,j+ly,k+lz ) =
-                                   2.f*uViewConst( i+lx,j+ly,k+lz )
+                                   2.f*uView( i+lx,j+ly,k+lz )
                                    -vView( i+lx,j+ly,k+lz )
-                                   +vpViewConst( i,j,k )*lap;
+                                   +vpView( i,j,k )*lap;
                                } );
 
 }
@@ -78,133 +121,158 @@ void target_inner_3d(llint nx, llint ny, llint nz,
                      float *__restrict__ v,
                      const float *__restrict__ vp)
 {
-  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefxViewConst( coefx, 5 );
-  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefyViewConst( coefy, 5 );
-  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefzViewConst( coefz, 5 );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefxView( coefx, 5 );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefyView( coefy, 5 );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefzView( coefz, 5 );
  
-  RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > uViewConst( u, RAJA::Layout<3>(nx+2*lx, ny+2*ly, nz+2*lz) );
+  RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > uView( u, RAJA::Layout<3>(nx+2*lx, ny+2*ly, nz+2*lz) );
   RAJA::View< float, RAJA::Layout<3, RAJA::Index_type, 2> > vView( v, RAJA::Layout<3>(nx+2*lx, ny+2*ly, nz+2*lz) );
-  RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > vpViewConst( vp, RAJA::Layout<3>(nx, ny, nz) );    
+  RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > vpView( vp, RAJA::Layout<3>(nx, ny, nz) );    
     
   compute_inner_3d(RAJA::Index_type(x3), RAJA::Index_type(x4),
                    RAJA::Index_type(y3), RAJA::Index_type(y4),
                    RAJA::Index_type(z3), RAJA::Index_type(z4),
                    RAJA::Index_type(lx), RAJA::Index_type(ly), RAJA::Index_type(lz),
-                   coefxViewConst, coefyViewConst, coefzViewConst,
-                   uViewConst, vpViewConst, vView );
+                   coefxView, coefyView, coefzView,
+                   uView, vpView, vView );
 
-  // RAJA_UNUSED_VAR( nx );
-  // float coef0 = coefx[0] + coefy[0] + coefz[0];
-  // for (llint i = x3; i < x4; ++i) {
-  //   for (llint j = y3; j < y4; ++j) {
-  //     for (llint k = z3; k < z4; ++k) {
-  //    float lap = LAP;
-  //    v[IDX3_l(i,j,k)] = 2.f*u[IDX3_l(i,j,k)]-v[IDX3_l(i,j,k)]+vp[IDX3(i,j,k)]*lap;
-  //     }
-  //   }
-  // }
 }
 
-void compute_pml_3d(RAJA::Index_type const x3, const RAJA::Index_type x4, const RAJA::Index_type y3,
+
+void compute_pml_3d(const RAJA::Index_type ny, const RAJA::Index_type nz,
+                    RAJA::Index_type const x3, const RAJA::Index_type x4, const RAJA::Index_type y3,
                     RAJA::Index_type const y4, const RAJA::Index_type z3, const RAJA::Index_type z4,
                     RAJA::Index_type const lx, const RAJA::Index_type ly, const RAJA::Index_type lz,
                     float const & hdx_2, float const & hdy_2, float const & hdz_2,
-                    RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefxViewConst,
-                    RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefyViewConst,
-                    RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefzViewConst,                      
-                    RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > &__restrict__ uViewConst,
-                    RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > &__restrict__ vpViewConst,
-                    RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > &__restrict__ etaViewConst,             
-                    RAJA::View< float, RAJA::Layout<3, RAJA::Index_type, 2> > &__restrict__ vView,
-                    RAJA::View< float, RAJA::Layout<3, RAJA::Index_type, 2> > &__restrict__ phiView )
+                    RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > & coefxView,
+                    RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > & coefyView,
+                    RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > & coefzView,                      
+                    RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > & uView,
+                    RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > & vpView,
+                    RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > & etaView,             
+                    RAJA::View< float, RAJA::Layout<1, RAJA::Index_type, 0> >  vView,
+                    RAJA::View< float, RAJA::Layout<1, RAJA::Index_type, 0> >  phiView )
 {
-  const float coef0 = coefxViewConst(0) + coefyViewConst(0) + coefzViewConst(0);
-#if 0
-  RAJA::RangeSegment XRange(x3, x4);
-  RAJA::RangeSegment YRange(y3, y4);
-  RAJA::RangeSegment ZRange(z3, z4);
-  
-  using KJI_EXECPOL = RAJA::KernelPolicy<
-    RAJA::statement::For<0, RAJA::loop_exec, 
-    RAJA::statement::For<1, RAJA::loop_exec, 
-    RAJA::statement::For<2, RAJA::loop_exec, 
-    RAJA::statement::Lambda<0> > > > >;
+  const float coef0 = coefxView(0) + coefyView(0) + coefzView(0);
 
-  RAJA::kernel<KJI_EXECPOL>( RAJA::make_tuple(XRange, YRange, ZRange),
-                             [coef0,lx,ly,lz,&hdx_2,&hdy_2,&hdz_2,
-                              coefxViewConst,coefyViewConst,coefzViewConst,
-                              uViewConst,etaViewConst,vpViewConst,vView,phiView] (RAJA::Index_type const i,
-                                                                                  RAJA::Index_type const j,
-                                                                                  RAJA::Index_type const k)
-                             {
-                               const float lap = (coef0*uViewConst(i+lx,j+ly,k+lz) 
-                                                  +coefxViewConst(1)*(uViewConst(i+1+lx,j+ly,k+lz)+uViewConst(i-1+lx,j+ly,k+lz))
-                                                  +coefyViewConst(1)*(uViewConst(i+lx,j+1+ly,k+lz)+uViewConst(i+lx,j-1+ly,k+lz))
-                                                  +coefzViewConst(1)*(uViewConst(i+lx,j+ly,k+1+lz)+uViewConst(i+lx,j+ly,k-1+lz))
-                                                  +coefxViewConst(2)*(uViewConst(i+2+lx,j+ly,k+lz)+uViewConst(i-2+lx,j+ly,k+lz))
-                                                  +coefyViewConst(2)*(uViewConst(i+lx,j+2+ly,k+lz)+uViewConst(i+lx,j-2+ly,k+lz))
-                                                  +coefzViewConst(2)*(uViewConst(i+lx,j+ly,k+2+lz)+uViewConst(i+lx,j+ly,k-2+lz))
-                                                  +coefxViewConst(3)*(uViewConst(i+3+lx,j+ly,k+lz)+uViewConst(i-3+lx,j+ly,k+lz))
-                                                  +coefyViewConst(3)*(uViewConst(i+lx,j+3+ly,k+lz)+uViewConst(i+lx,j-3+ly,k+lz))
-                                                  +coefzViewConst(3)*(uViewConst(i+lx,j+ly,k+3+lz)+uViewConst(i+lx,j+ly,k-3+lz))
-                                                  +coefxViewConst(4)*(uViewConst(i+4+lx,j+ly,k+lz)+uViewConst(i-4+lx,j+ly,k+lz))
-                                                  +coefyViewConst(4)*(uViewConst(i+lx,j+4+ly,k+lz)+uViewConst(i+lx,j-4+ly,k+lz))
-                                                  +coefzViewConst(4)*(uViewConst(i+lx,j+ly,k+4+lz)+uViewConst(i+lx,j+ly,k-4+lz)));
-                               
-                               vView(i+lx,j+ly,k+lz) =
-                                 ( (2.f-etaViewConst(i+1,j+1,k+1)*etaViewConst(i+1,j+1,k+1)
-                                    +2.f*etaViewConst(i+1,j+1,k+1))*uViewConst(i+lx,j+ly,k+lz)
-                                   -vView(i+lx,j+ly,k+lz)
-                                   +vpViewConst(i,j,k)*(lap+phiView(i,j,k)) )
-                                 / (1.f+2.f*etaViewConst(i+1,j+1,k+1));
-                               phiView(i,j,k) =
-                                 ( phiView(i,j,k)-
-                                   ( (etaViewConst(i+2,j+1,k+1)-etaViewConst(i,j+1,k+1))
-                                     *(uViewConst(i+1+lx,j+ly,k+lz)-uViewConst(i-1+lx,j+ly,k+lz))*hdx_2
-                                     +(etaViewConst(i+1,j+2,k+1)-etaViewConst(i+1,j,k+1))
-                                     *(uViewConst(i+lx,j+1+ly,k+lz)-uViewConst(i+lx,j-1+ly,k+lz))*hdy_2
-                                     +(etaViewConst(i+1,j+1,k+2)-etaViewConst(i+1,j+1,k))
-                                     *(uViewConst(i+lx,j+ly,k+1+lz)-uViewConst(i+lx,j+ly,k-1+lz))*hdz_2 ) )
-                                 / (1.f+etaViewConst(i+1,j+1,k+1));
-                             });
-#else
-  for (llint i = x3; i < x4; ++i) {
-       for (llint j = y3; j < y4; ++j) {
-           for (llint k = z3; k < z4; ++k) {
-             const float lap = (coef0*uViewConst(i+lx,j+ly,k+lz) 
-                                +coefxViewConst(1)*(uViewConst(i+1+lx,j+ly,k+lz)+uViewConst(i-1+lx,j+ly,k+lz))
-                                +coefyViewConst(1)*(uViewConst(i+lx,j+1+ly,k+lz)+uViewConst(i+lx,j-1+ly,k+lz))
-                                +coefzViewConst(1)*(uViewConst(i+lx,j+ly,k+1+lz)+uViewConst(i+lx,j+ly,k-1+lz))
-                                +coefxViewConst(2)*(uViewConst(i+2+lx,j+ly,k+lz)+uViewConst(i-2+lx,j+ly,k+lz))
-                                +coefyViewConst(2)*(uViewConst(i+lx,j+2+ly,k+lz)+uViewConst(i+lx,j-2+ly,k+lz))
-                                +coefzViewConst(2)*(uViewConst(i+lx,j+ly,k+2+lz)+uViewConst(i+lx,j+ly,k-2+lz))
-                                +coefxViewConst(3)*(uViewConst(i+3+lx,j+ly,k+lz)+uViewConst(i-3+lx,j+ly,k+lz))
-                                +coefyViewConst(3)*(uViewConst(i+lx,j+3+ly,k+lz)+uViewConst(i+lx,j-3+ly,k+lz))
-                                +coefzViewConst(3)*(uViewConst(i+lx,j+ly,k+3+lz)+uViewConst(i+lx,j+ly,k-3+lz))
-                                +coefxViewConst(4)*(uViewConst(i+4+lx,j+ly,k+lz)+uViewConst(i-4+lx,j+ly,k+lz))
-                                +coefyViewConst(4)*(uViewConst(i+lx,j+4+ly,k+lz)+uViewConst(i+lx,j-4+ly,k+lz))
-                                +coefzViewConst(4)*(uViewConst(i+lx,j+ly,k+4+lz)+uViewConst(i+lx,j+ly,k-4+lz)));
-             
-             vView(i+lx,j+ly,k+lz) =
-               ( (2.f-etaViewConst(i+1,j+1,k+1)*etaViewConst(i+1,j+1,k+1)
-                  +2.f*etaViewConst(i+1,j+1,k+1))*uViewConst(i+lx,j+ly,k+lz)
-                 -vView(i+lx,j+ly,k+lz)
-                 +vpViewConst(i,j,k)*(lap+phiView(i,j,k)) )
-               / (1.f+2.f*etaViewConst(i+1,j+1,k+1));
-             phiView(i,j,k) =
-               ( phiView(i,j,k)-
-                 ( (etaViewConst(i+2,j+1,k+1)-etaViewConst(i,j+1,k+1))
-                   *(uViewConst(i+1+lx,j+ly,k+lz)-uViewConst(i-1+lx,j+ly,k+lz))*hdx_2
-                   +(etaViewConst(i+1,j+2,k+1)-etaViewConst(i+1,j,k+1))
-                   *(uViewConst(i+lx,j+1+ly,k+lz)-uViewConst(i+lx,j-1+ly,k+lz))*hdy_2
-                   +(etaViewConst(i+1,j+1,k+2)-etaViewConst(i+1,j+1,k))
-                   *(uViewConst(i+lx,j+ly,k+1+lz)-uViewConst(i+lx,j+ly,k-1+lz))*hdz_2 ) )
-               / (1.f+etaViewConst(i+1,j+1,k+1));
-             }
-           }
-         }
-#endif
+  RAJA::RangeSegment const XRange(x3, x4);
+  RAJA::RangeSegment const YRange(y3, y4);
+  RAJA::RangeSegment const ZRange(z3, z4);
+  
+  using POLICY = RAJA::KernelPolicy<
+    RAJA::statement::For<0, RAJA::loop_exec, 
+      RAJA::statement::For<1, RAJA::loop_exec, 
+        RAJA::statement::For<2, RAJA::loop_exec, 
+          RAJA::statement::Lambda<0>
+        >
+      >
+    >
+  >;
+
+  RAJA::kernel<POLICY>( RAJA::make_tuple(XRange, YRange, ZRange),
+    [=] ( RAJA::Index_type const i, RAJA::Index_type const j, RAJA::Index_type const k)
+    {
+      float const lap = LAPVIEW;
+      VVIEWUPDATE
+      PHIVIEWUPDATE     
+    });
+
 }
+
+void compute_pml_3d_restrict(const RAJA::Index_type ny, const RAJA::Index_type nz,
+                             RAJA::Index_type const x3, const RAJA::Index_type x4, const RAJA::Index_type y3,
+                             RAJA::Index_type const y4, const RAJA::Index_type z3, const RAJA::Index_type z4,
+                             RAJA::Index_type const lx, const RAJA::Index_type ly, const RAJA::Index_type lz,
+                             float const & hdx_2, float const & hdy_2, float const & hdz_2,
+                             RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefxView,
+                             RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefyView,
+                             RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefzView,
+                             RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ uView,
+                             RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ vpView,
+                             RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ etaView,             
+                             RAJA::View< float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ vView,
+                             RAJA::View< float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ phiView )
+{
+  const float coef0 = coefxView(0) + coefyView(0) + coefzView(0);
+
+  RAJA::RangeSegment const XRange(x3, x4);
+  RAJA::RangeSegment const YRange(y3, y4);
+  RAJA::RangeSegment const ZRange(z3, z4);
+  
+  using POLICY = RAJA::KernelPolicy<
+    RAJA::statement::For<0, RAJA::loop_exec, 
+      RAJA::statement::For<1, RAJA::loop_exec, 
+        RAJA::statement::For<2, RAJA::loop_exec, 
+          RAJA::statement::Lambda<0>
+        >
+      >
+    >
+  >;
+
+  RAJA::kernel<POLICY>( RAJA::make_tuple(XRange, YRange, ZRange),
+    [=] ( RAJA::Index_type const i, RAJA::Index_type const j, RAJA::Index_type const k)
+    {
+      float const lap = LAPVIEW;
+      VVIEWUPDATE
+      PHIVIEWUPDATE     
+    });
+}
+
+void compute_pml_3d_for_restrict(const RAJA::Index_type ny, const RAJA::Index_type nz,
+                                 RAJA::Index_type const x3, const RAJA::Index_type x4, const RAJA::Index_type y3,
+                                 RAJA::Index_type const y4, const RAJA::Index_type z3, const RAJA::Index_type z4,
+                                 RAJA::Index_type const lx, const RAJA::Index_type ly, const RAJA::Index_type lz,
+                                 float const & hdx_2, float const & hdy_2, float const & hdz_2,
+                                 RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefxView,
+                                 RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefyView,
+                                 RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ coefzView,
+                                 RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ uView,
+                                 RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ vpView,
+                                 RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ etaView,             
+                                 RAJA::View< float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ vView,
+                                 RAJA::View< float, RAJA::Layout<1, RAJA::Index_type, 0> > &__restrict__ phiView )
+{
+  const float coef0 = coefxView(0) + coefyView(0) + coefzView(0);
+
+  for (llint i = x3; i < x4; ++i) {
+    for (llint j = y3; j < y4; ++j) {
+      for (llint k = z3; k < z4; ++k) {
+        float const lap = LAPVIEW;
+        VVIEWUPDATE
+        PHIVIEWUPDATE   
+      }
+    }
+  }
+}
+
+
+void compute_pml_3d_pointers(const RAJA::Index_type ny, const RAJA::Index_type nz,
+                             RAJA::Index_type const x3, const RAJA::Index_type x4, const RAJA::Index_type y3,
+                             RAJA::Index_type const y4, const RAJA::Index_type z3, const RAJA::Index_type z4,
+                             RAJA::Index_type const lx, const RAJA::Index_type ly, const RAJA::Index_type lz,
+                             float const & hdx_2, float const & hdy_2, float const & hdz_2,
+                             const float *__restrict__ coefx,
+                             const float *__restrict__ coefy,
+                             const float *__restrict__ coefz,
+                             const float *__restrict__ u,
+                             const float *__restrict__ vp,
+                             const float *__restrict__ eta,
+                             float *__restrict__ v,                          
+                             float *__restrict__ phi )
+{
+  float const coef0 = coefx[0] + coefy[0] + coefz[0];
+  
+  for (llint i = x3; i < x4; ++i) {
+    for (llint j = y3; j < y4; ++j) {
+      for (llint k = z3; k < z4; ++k) {
+        float const lap = LAP;
+        VUPDATE
+        PHIUPDATE  
+      }
+    }
+  }
+}
+
 
 void target_pml_3d(llint nx, llint ny,llint nz,
                    llint x3, llint x4, llint y3,
@@ -226,33 +294,153 @@ void target_pml_3d(llint nx, llint ny,llint nz,
   RAJA_UNUSED_VAR( nx );
   RAJA_UNUSED_VAR( coef0 );
 
-#define KERNEL_OPTION 1
+#define KERNEL_OPTION 4
 #if KERNEL_OPTION == 0
   if( !haveRun )
   {
     haveRun = true;
-    std::cout << "Using compute_pml_3d" << std::endl;
+    std::cout << "Using RAJA::kernel with RAJA:::View" << std::endl;
   }  
 
-  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefxViewConst( coefx, 5 );
-  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefyViewConst( coefy, 5 );
-  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefzViewConst( coefz, 5 );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefxView( coefx, 5 );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefyView( coefy, 5 );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefzView( coefz, 5 );
 
-  RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > uViewConst( u, RAJA::Layout<3>(nx+2*lx, ny+2*ly, nz+2*lz) );
-  RAJA::View< float, RAJA::Layout<3, RAJA::Index_type, 2> > vView( v, RAJA::Layout<3>(nx+2*lx, ny+2*ly, nz+2*lz) );
-  RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > vpViewConst( vp, RAJA::Layout<3>(nx, ny, nz) );
-  RAJA::View< float, RAJA::Layout<3, RAJA::Index_type, 2> > phiView( phi, RAJA::Layout<3>(nx, ny, nz) );
-  RAJA::View< const float, RAJA::Layout<3, RAJA::Index_type, 2> > etaViewConst( eta, RAJA::Layout<3>(nx+2, ny+2, nz+2) );  
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > uView( u, (nx+2*lx)*(ny+2*ly)*(nz+2*lz) );
+  RAJA::View< float, RAJA::Layout<1, RAJA::Index_type, 0> > vView( v, (nx+2*lx)*(ny+2*ly)*(nz+2*lz) );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > vpView( vp, nx*ny*nz );
+  RAJA::View< float, RAJA::Layout<1, RAJA::Index_type, 0> > phiView( phi, nx*ny*nz );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > etaView( eta, (nx+2)*(ny+2)*(nz+2) );  
 
-  compute_pml_3d( RAJA::Index_type(x3), RAJA::Index_type(x4),
+  RAJA::RangeSegment const XRange(x3, x4);
+  RAJA::RangeSegment const YRange(y3, y4);
+  RAJA::RangeSegment const ZRange(z3, z4);
+  
+  using POLICY = RAJA::KernelPolicy<
+    RAJA::statement::For<0, RAJA::loop_exec, 
+      RAJA::statement::For<1, RAJA::loop_exec, 
+        RAJA::statement::For<2, RAJA::loop_exec, 
+          RAJA::statement::Lambda<0>
+        >
+      >
+    >
+  >;
+
+  RAJA::kernel<POLICY>( RAJA::make_tuple(XRange, YRange, ZRange),
+    [=] ( RAJA::Index_type const i, RAJA::Index_type const j, RAJA::Index_type const k)
+    {
+      float const lap = LAPVIEW;
+      VVIEWUPDATE
+      PHIVIEWUPDATE     
+    });
+  
+#endif
+#if KERNEL_OPTION == 1
+  if( !haveRun )
+  {
+    haveRun = true;
+    std::cout << "Using for loops with RAJA::View" << std::endl;
+  }  
+
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefxView( coefx, 5 );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefyView( coefy, 5 );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefzView( coefz, 5 );
+
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > uView( u, (nx+2*lx)*(ny+2*ly)*(nz+2*lz) );
+  RAJA::View< float, RAJA::Layout<1, RAJA::Index_type, 0> > vView( v, (nx+2*lx)*(ny+2*ly)*(nz+2*lz) );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > vpView( vp, nx*ny*nz );
+  RAJA::View< float, RAJA::Layout<1, RAJA::Index_type, 0> > phiView( phi, nx*ny*nz );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > etaView( eta, (nx+2)*(ny+2)*(nz+2) );  
+
+  for (llint i = x3; i < x4; ++i) {
+    for (llint j = y3; j < y4; ++j) {
+      for (llint k = z3; k < z4; ++k) {
+        float const lap = LAPVIEW;
+        VVIEWUPDATE
+        PHIVIEWUPDATE   
+      }
+    }
+  }
+#endif
+#if KERNEL_OPTION == 2
+  if( !haveRun )
+  {
+    haveRun = true;
+    std::cout << "Using RAJA::kernel inside function (with restrict) with RAJA:::View" << std::endl;
+  }  
+
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefxView( coefx, 5 );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefyView( coefy, 5 );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefzView( coefz, 5 );
+
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > uView( u, (nx+2*lx)*(ny+2*ly)*(nz+2*lz) );
+  RAJA::View< float, RAJA::Layout<1, RAJA::Index_type, 0> > vView( v, (nx+2*lx)*(ny+2*ly)*(nz+2*lz) );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > vpView( vp, nx*ny*nz );
+  RAJA::View< float, RAJA::Layout<1, RAJA::Index_type, 0> > phiView( phi, nx*ny*nz );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > etaView( eta, (nx+2)*(ny+2)*(nz+2) );  
+
+  compute_pml_3d_restrict( RAJA::Index_type(ny), RAJA::Index_type(nz),
+                           RAJA::Index_type(x3), RAJA::Index_type(x4),
+                           RAJA::Index_type(y3), RAJA::Index_type(y4),
+                           RAJA::Index_type(z3), RAJA::Index_type(z4),
+                           RAJA::Index_type(lx), RAJA::Index_type(ly), RAJA::Index_type(lz),
+                           hdx_2, hdy_2, hdz_2,
+                           coefxView, coefyView, coefzView,
+                           uView, vpView, etaView, vView, phiView ); 
+#endif
+#if KERNEL_OPTION == 3
+  if( !haveRun )
+  {
+    haveRun = true;
+    std::cout << "Using RAJA::kernel inside function (no restrict) with RAJA:::View" << std::endl;
+  }  
+
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefxView( coefx, 5 );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefyView( coefy, 5 );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefzView( coefz, 5 );
+
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > uView( u, (nx+2*lx)*(ny+2*ly)*(nz+2*lz) );
+  RAJA::View< float, RAJA::Layout<1, RAJA::Index_type, 0> > vView( v, (nx+2*lx)*(ny+2*ly)*(nz+2*lz) );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > vpView( vp, nx*ny*nz );
+  RAJA::View< float, RAJA::Layout<1, RAJA::Index_type, 0> > phiView( phi, nx*ny*nz );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > etaView( eta, (nx+2)*(ny+2)*(nz+2) );  
+
+  compute_pml_3d( RAJA::Index_type(ny), RAJA::Index_type(nz),
+                  RAJA::Index_type(x3), RAJA::Index_type(x4),
                   RAJA::Index_type(y3), RAJA::Index_type(y4),
                   RAJA::Index_type(z3), RAJA::Index_type(z4),
                   RAJA::Index_type(lx), RAJA::Index_type(ly), RAJA::Index_type(lz),
                   hdx_2, hdy_2, hdz_2,
-                  coefxViewConst, coefyViewConst, coefzViewConst,
-                  uViewConst, vpViewConst, etaViewConst, vView, phiView );
+                  coefxView, coefyView, coefzView,
+                  uView, vpView, etaView, vView, phiView ); 
 #endif
-#if KERNEL_OPTION == 1
+#if KERNEL_OPTION == 4
+  if( !haveRun )
+  {
+    haveRun = true;
+    std::cout << "Using for loops inside function (with restrict) with RAJA:::View" << std::endl;
+  }  
+
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefxView( coefx, 5 );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefyView( coefy, 5 );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > coefzView( coefz, 5 );
+
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > uView( u, (nx+2*lx)*(ny+2*ly)*(nz+2*lz) );
+  RAJA::View< float, RAJA::Layout<1, RAJA::Index_type, 0> > vView( v, (nx+2*lx)*(ny+2*ly)*(nz+2*lz) );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > vpView( vp, nx*ny*nz );
+  RAJA::View< float, RAJA::Layout<1, RAJA::Index_type, 0> > phiView( phi, nx*ny*nz );
+  RAJA::View< const float, RAJA::Layout<1, RAJA::Index_type, 0> > etaView( eta, (nx+2)*(ny+2)*(nz+2) );  
+
+  compute_pml_3d( RAJA::Index_type(ny), RAJA::Index_type(nz),
+                  RAJA::Index_type(x3), RAJA::Index_type(x4),
+                  RAJA::Index_type(y3), RAJA::Index_type(y4),
+                  RAJA::Index_type(z3), RAJA::Index_type(z4),
+                  RAJA::Index_type(lx), RAJA::Index_type(ly), RAJA::Index_type(lz),
+                  hdx_2, hdy_2, hdz_2,
+                  coefxView, coefyView, coefzView,
+                  uView, vpView, etaView, vView, phiView ); 
+#endif
+#if KERNEL_OPTION == 5
   if( !haveRun )
   {
     haveRun = true;
@@ -277,56 +465,47 @@ void target_pml_3d(llint nx, llint ny,llint nz,
     [=] ( RAJA::Index_type const i, RAJA::Index_type const j, RAJA::Index_type const k)
     {
       float const lap = LAP;
-
-      v[IDX3_l(i,j,k)] =
-         ((2.f-eta[IDX3_eta1(i,j,k)]*eta[IDX3_eta1(i,j,k)]
-         +2.f*eta[IDX3_eta1(i,j,k)])*u[IDX3_l(i,j,k)]
-         -v[IDX3_l(i,j,k)]
-         +vp[IDX3(i,j,k)]*
-         (lap+phi[IDX3(i,j,k)]))/(1.f+2.f*eta[IDX3_eta1(i,j,k)]);
-
-      phi[IDX3(i,j,k)]=(phi[IDX3(i,j,k)]-
-        ((eta[IDX3_eta1(i+1,j,k)]-eta[IDX3_eta1(i-1,j,k)])
-             *(u[IDX3_l(i+1,j,k)]-u[IDX3_l(i-1,j,k)])*hdx_2
-             +(eta[IDX3_eta1(i,j+1,k)]-eta[IDX3_eta1(i,j-1,k)])
-             *(u[IDX3_l(i,j+1,k)]-u[IDX3_l(i,j-1,k)])*hdy_2
-             +(eta[IDX3_eta1(i,j,k+1)]-eta[IDX3_eta1(i,j,k-1)])
-           *(u[IDX3_l(i,j,k+1)]-u[IDX3_l(i,j,k-1)])*hdz_2))
-             /(1.f+eta[IDX3_eta1(i,j,k)]);
+      VUPDATE
+      PHIUPDATE 
     }
  );
 #endif
-#if KERNEL_OPTION == 2
+#if KERNEL_OPTION == 6
   if( !haveRun )
   {
     haveRun = true;
-    std::cout << "Using original for-loops" << std::endl;
+    std::cout << "Using original for-loops with pointers" << std::endl;
   }
 
     for (llint i = x3; i < x4; ++i) {
        for (llint j = y3; j < y4; ++j) {
            for (llint k = z3; k < z4; ++k) {
                float const lap = LAP;
-
-               v[IDX3_l(i,j,k)] =
-                   ((2.f-eta[IDX3_eta1(i,j,k)]*eta[IDX3_eta1(i,j,k)]
-                   +2.f*eta[IDX3_eta1(i,j,k)])*u[IDX3_l(i,j,k)]
-                   -v[IDX3_l(i,j,k)]
-                   +vp[IDX3(i,j,k)]*
-                   (lap+phi[IDX3(i,j,k)]))/(1.f+2.f*eta[IDX3_eta1(i,j,k)]);
-
-              phi[IDX3(i,j,k)]=(phi[IDX3(i,j,k)]-
-                ((eta[IDX3_eta1(i+1,j,k)]-eta[IDX3_eta1(i-1,j,k)])
-                     *(u[IDX3_l(i+1,j,k)]-u[IDX3_l(i-1,j,k)])*hdx_2
-                     +(eta[IDX3_eta1(i,j+1,k)]-eta[IDX3_eta1(i,j-1,k)])
-                     *(u[IDX3_l(i,j+1,k)]-u[IDX3_l(i,j-1,k)])*hdy_2
-                     +(eta[IDX3_eta1(i,j,k+1)]-eta[IDX3_eta1(i,j,k-1)])
-                   *(u[IDX3_l(i,j,k+1)]-u[IDX3_l(i,j,k-1)])*hdz_2))
-                     /(1.f+eta[IDX3_eta1(i,j,k)]);
+               VUPDATE
+               PHIUPDATE        
           }
        }
     }
 #endif
+#if KERNEL_OPTION == 7
+  if( !haveRun )
+  {
+    haveRun = true;
+    std::cout << "Using original for-loops inside function with pointers" << std::endl;
+  }
+
+  compute_pml_3d_pointers( RAJA::Index_type(ny), RAJA::Index_type(nz),
+                           RAJA::Index_type(x3), RAJA::Index_type(x4),
+                           RAJA::Index_type(y3), RAJA::Index_type(y4),
+                           RAJA::Index_type(z3), RAJA::Index_type(z4),
+                           RAJA::Index_type(lx), RAJA::Index_type(ly), RAJA::Index_type(lz),
+                           hdx_2, hdy_2, hdz_2,
+                           coefx, coefy, coefz,
+                           u, vp, eta, v, phi ); 
+
+  
+#endif
+    
 }
 
 void target_3d(llint nx, llint ny, llint nz,

--- a/src/fdwave_raja/target_3d.hpp
+++ b/src/fdwave_raja/target_3d.hpp
@@ -1,0 +1,17 @@
+#ifndef TARGET_3D_HPP
+#define TARGET_3D_HPP
+
+#include "constants.hpp"
+#include "grid.hpp"
+
+void target_3d(llint nx, llint ny, llint nz,
+               llint x1, llint x2, llint x3, llint x4, llint x5, llint x6,
+               llint y1, llint y2, llint y3, llint y4, llint y5, llint y6,
+               llint z1, llint z2, llint z3, llint z4, llint z5, llint z6,
+               llint lx, llint ly, llint lz,
+               float hdx_2, float hdy_2, float hdz_2,
+               const float *__restrict__ coefx, const float *coefy, const float *coefz,
+               const float *u, float *v, const float *vp,
+               float *phi, const float *eta);
+
+#endif


### PR DESCRIPTION
This PR is here for discussion but should not be reviewed/merged.

It implements an 8th finite-difference scheme for acoustic wave propagation. The goal is to test the performance of the RAJA kernels. So far the implementation is CPU only, but we also have another version based on `LvArray` that could be used on GPU.

We are trying to understand why the CPU version is slower (about two times slower) when the standard `for` loops are replaced (see question below).