### PR TITLE
Removing dead code + tiny cleanings

### DIFF
--- a/src/coreComponents/managers/ProblemManager.cpp
+++ b/src/coreComponents/managers/ProblemManager.cpp
@@ -511,7 +511,7 @@ void ProblemManager::generateMesh()
       faceManager.buildFaces( nodeManager, elemManager );
       nodeManager.setFaceMaps( meshLevel.getFaceManager() );
 
-      edgeManager.buildEdges( faceManager, nodeManager );
+      edgeManager.buildEdges( nodeManager, faceManager );
       nodeManager.setEdgeMaps( meshLevel.getEdgeManager() );
 
       domain.generateSets();

--- a/src/coreComponents/managers/ProblemManager.cpp
+++ b/src/coreComponents/managers/ProblemManager.cpp
@@ -506,13 +506,13 @@ void ProblemManager::generateMesh()
       nodeManager.constructGlobalToLocalMap();
 
       elemManager.generateMesh( cellBlockManager );
-      nodeManager.setElementMaps( meshLevel.getElemManager() );
+      nodeManager.setElementMaps( elemManager );
 
       faceManager.buildFaces( nodeManager, elemManager );
-      nodeManager.setFaceMaps( meshLevel.getFaceManager() );
+      nodeManager.setFaceMaps( faceManager );
 
       edgeManager.buildEdges( nodeManager, faceManager );
-      nodeManager.setEdgeMaps( meshLevel.getEdgeManager() );
+      nodeManager.setEdgeMaps( edgeManager );
 
       domain.generateSets();
 

--- a/src/coreComponents/mesh/CellBlock.cpp
+++ b/src/coreComponents/mesh/CellBlock.cpp
@@ -320,7 +320,6 @@ void CellBlock::calculateElementGeometricQuantities( NodeManager const & nodeMan
   } );
 }
 
-
 REGISTER_CATALOG_ENTRY( ObjectManagerBase, CellBlock, string const &, Group * const )
 
 }

--- a/src/coreComponents/mesh/CellBlock.cpp
+++ b/src/coreComponents/mesh/CellBlock.cpp
@@ -310,7 +310,7 @@ void CellBlock::setupRelatedObjectsInRelations( MeshLevel const & mesh )
 }
 
 void CellBlock::calculateElementGeometricQuantities( NodeManager const & nodeManager,
-                                                     FaceManager const & GEOSX_UNUSED_PARAM( facemanager ) )
+                                                     FaceManager const & GEOSX_UNUSED_PARAM( faceManager ) )
 {
   arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const & X = nodeManager.referencePosition();
 

--- a/src/coreComponents/mesh/CellBlock.hpp
+++ b/src/coreComponents/mesh/CellBlock.hpp
@@ -101,7 +101,7 @@ public:
   ///@{
 
   virtual void calculateElementGeometricQuantities( NodeManager const & nodeManager,
-                                                    FaceManager const & facemanager ) override;
+                                                    FaceManager const & faceManager ) override;
 
   virtual void setupRelatedObjectsInRelations( MeshLevel const & mesh ) override;
 

--- a/src/coreComponents/mesh/CellBlock.hpp
+++ b/src/coreComponents/mesh/CellBlock.hpp
@@ -105,72 +105,7 @@ public:
 
   virtual void setupRelatedObjectsInRelations( MeshLevel const & mesh ) override;
 
-public:
-  /**
-   * @brief Compute the center of each element in the subregion.
-   * @param[in] X an arrayView of (const) node positions
-   */
-  void calculateElementCenters( arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const & X ) const
-  {
-    arrayView2d< real64 > const & elementCenters = m_elementCenter;
-    localIndex nNodes = numNodesPerElement();
-
-    forAll< parallelHostPolicy >( size(), [=]( localIndex const k )
-    {
-      LvArray::tensorOps::copy< 3 >( elementCenters[ k ], X[ m_toNodesRelation( k, 0 ) ] );
-      for( localIndex a = 1; a < nNodes; ++a )
-      {
-        LvArray::tensorOps::add< 3 >( elementCenters[ k ], X[ m_toNodesRelation( k, a ) ] );
-      }
-
-      LvArray::tensorOps::scale< 3 >( elementCenters[ k ], 1.0 / nNodes );
-    } );
-  }
-
-private:
-  /**
-   * @brief Compute the volume of the k-th element in the subregion.
-   * @param[in] k the index of the element in the subregion
-   * @param[in] X an arrayView of (const) node positions
-   */
-  inline void calculateCellVolumesKernel( localIndex const k,
-                                          arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const & X ) const
-  {
-    LvArray::tensorOps::fill< 3 >( m_elementCenter[ k ], 0 );
-
-    real64 Xlocal[10][3];
-
-    for( localIndex a = 0; a < m_numNodesPerElement; ++a )
-    {
-      LvArray::tensorOps::copy< 3 >( Xlocal[ a ], X[ m_toNodesRelation( k, a ) ] );
-      LvArray::tensorOps::add< 3 >( m_elementCenter[ k ], X[ m_toNodesRelation( k, a ) ] );
-    }
-    LvArray::tensorOps::scale< 3 >( m_elementCenter[ k ], 1.0 / m_numNodesPerElement );
-
-    if( m_numNodesPerElement == 8 )
-    {
-      m_elementVolume[k] = computationalGeometry::HexVolume( Xlocal );
-    }
-    else if( m_numNodesPerElement == 4 )
-    {
-      m_elementVolume[k] = computationalGeometry::TetVolume( Xlocal );
-    }
-    else if( m_numNodesPerElement == 6 )
-    {
-      m_elementVolume[k] = computationalGeometry::WedgeVolume( Xlocal );
-    }
-    else if( m_numNodesPerElement == 5 )
-    {
-      m_elementVolume[k] = computationalGeometry::PyramidVolume( Xlocal );
-    }
-    else
-    {
-      GEOSX_ERROR( "GEOX does not support cells with " << m_numNodesPerElement << " nodes" );
-    }
-  }
-
   ///@}
-public:
   /**
    * @name Getters / Setters
    */
@@ -307,6 +242,46 @@ private:
   /// Name of the properties registered from an external mesh
   string_array m_externalPropertyNames;
 
+  /**
+   * @brief Compute the volume of the k-th element in the subregion.
+   * @param[in] k the index of the element in the subregion
+   * @param[in] X an arrayView of (const) node positions
+   */
+  inline void calculateCellVolumesKernel( localIndex const k,
+                                          arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const & X ) const
+  {
+    LvArray::tensorOps::fill< 3 >( m_elementCenter[ k ], 0 );
+
+    real64 Xlocal[10][3];
+
+    for( localIndex a = 0; a < m_numNodesPerElement; ++a )
+    {
+      LvArray::tensorOps::copy< 3 >( Xlocal[ a ], X[ m_toNodesRelation( k, a ) ] );
+      LvArray::tensorOps::add< 3 >( m_elementCenter[ k ], X[ m_toNodesRelation( k, a ) ] );
+    }
+    LvArray::tensorOps::scale< 3 >( m_elementCenter[ k ], 1.0 / m_numNodesPerElement );
+
+    if( m_numNodesPerElement == 8 )
+    {
+      m_elementVolume[k] = computationalGeometry::HexVolume( Xlocal );
+    }
+    else if( m_numNodesPerElement == 4 )
+    {
+      m_elementVolume[k] = computationalGeometry::TetVolume( Xlocal );
+    }
+    else if( m_numNodesPerElement == 6 )
+    {
+      m_elementVolume[k] = computationalGeometry::WedgeVolume( Xlocal );
+    }
+    else if( m_numNodesPerElement == 5 )
+    {
+      m_elementVolume[k] = computationalGeometry::PyramidVolume( Xlocal );
+    }
+    else
+    {
+      GEOSX_ERROR( "GEOX does not support cells with " << m_numNodesPerElement << " nodes" );
+    }
+  }
 };
 
 }

--- a/src/coreComponents/mesh/CellBlock.hpp
+++ b/src/coreComponents/mesh/CellBlock.hpp
@@ -24,9 +24,6 @@
 #include "meshUtilities/ComputationalGeometry.hpp"
 #include "rajaInterface/GEOS_RAJA_Interface.hpp"
 
-
-class StableTimeStep;
-
 namespace geosx
 {
 
@@ -108,6 +105,7 @@ public:
 
   virtual void setupRelatedObjectsInRelations( MeshLevel const & mesh ) override;
 
+public:
   /**
    * @brief Compute the center of each element in the subregion.
    * @param[in] X an arrayView of (const) node positions
@@ -129,6 +127,7 @@ public:
     } );
   }
 
+private:
   /**
    * @brief Compute the volume of the k-th element in the subregion.
    * @param[in] k the index of the element in the subregion
@@ -171,7 +170,7 @@ public:
   }
 
   ///@}
-
+public:
   /**
    * @name Getters / Setters
    */

--- a/src/coreComponents/mesh/CellElementSubRegion.cpp
+++ b/src/coreComponents/mesh/CellElementSubRegion.cpp
@@ -73,15 +73,6 @@ void CellElementSubRegion::copyFromCellBlock( CellBlock & source )
   } );
 }
 
-void CellElementSubRegion::constructSubRegionFromFaceSet( FaceManager const * const faceManager,
-                                                          string const & setName )
-{
-  SortedArrayView< localIndex const > const & targetSet = faceManager->sets().getReference< SortedArray< localIndex > >( setName );
-  m_toFacesRelation.resize( 0, 2 );
-  this->resize( targetSet.size() );
-}
-
-
 void CellElementSubRegion::addFracturedElement( localIndex const cellElemIndex,
                                                 localIndex const embSurfIndex )
 {

--- a/src/coreComponents/mesh/CellElementSubRegion.hpp
+++ b/src/coreComponents/mesh/CellElementSubRegion.hpp
@@ -64,14 +64,6 @@ public:
    */
   void copyFromCellBlock( CellBlock & source );
 
-  /**
-   * @brief Fill the CellElementSubRegion by querying a target set into the faceManager
-   * @param[in] faceManager a pointer to the faceManager
-   * @param[in] setName a reference to string containing the name of the set
-   */
-  void constructSubRegionFromFaceSet( FaceManager const * const faceManager,
-                                      string const & setName );
-
   ///@}
 
   /**

--- a/src/coreComponents/mesh/CellElementSubRegion.hpp
+++ b/src/coreComponents/mesh/CellElementSubRegion.hpp
@@ -192,6 +192,27 @@ public:
    */
   EmbSurfMapType const & embeddedSurfacesList() const { return m_toEmbeddedSurfaces; }
 
+  /**
+   * @brief Compute the center of each element in the subregion.
+   * @param[in] X an arrayView of (const) node positions
+   */
+  void calculateElementCenters( arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const & X ) const
+  {
+    arrayView2d< real64 > const & elementCenters = m_elementCenter;
+    localIndex nNodes = numNodesPerElement();
+
+    forAll< parallelHostPolicy >( size(), [=]( localIndex const k )
+    {
+      LvArray::tensorOps::copy< 3 >( elementCenters[ k ], X[ m_toNodesRelation( k, 0 ) ] );
+      for( localIndex a = 1; a < nNodes; ++a )
+      {
+        LvArray::tensorOps::add< 3 >( elementCenters[ k ], X[ m_toNodesRelation( k, a ) ] );
+      }
+
+      LvArray::tensorOps::scale< 3 >( elementCenters[ k ], 1.0 / nNodes );
+    } );
+  }
+
   /// Map used for constitutive grouping
   map< string, localIndex_array > m_constitutiveGrouping;
 

--- a/src/coreComponents/mesh/EdgeManager.cpp
+++ b/src/coreComponents/mesh/EdgeManager.cpp
@@ -397,7 +397,7 @@ void populateMaps( ArrayOfArraysView< EdgeBuilder const > const & edgesByLowestN
   } );
 }
 
-void EdgeManager::buildEdges( FaceManager & faceManager, NodeManager & nodeManager )
+void EdgeManager::buildEdges( NodeManager & nodeManager, FaceManager & faceManager )
 {
   GEOSX_MARK_FUNCTION;
 

--- a/src/coreComponents/mesh/EdgeManager.hpp
+++ b/src/coreComponents/mesh/EdgeManager.hpp
@@ -120,8 +120,8 @@ public:
 
   /**
    * @brief Build faces-to-edges and nodes-to-edges relation maps.
-   * @param[in] faceManager manager of all faces in the DomainPartition
    * @param[in] nodeManager manager of all nodes in the DomainPartition
+   * @param[in] faceManager manager of all faces in the DomainPartition
    */
   void buildEdges( NodeManager & nodeManager, FaceManager & faceManager );
 

--- a/src/coreComponents/mesh/EdgeManager.hpp
+++ b/src/coreComponents/mesh/EdgeManager.hpp
@@ -123,7 +123,7 @@ public:
    * @param[in] faceManager manager of all faces in the DomainPartition
    * @param[in] nodeManager manager of all nodes in the DomainPartition
    */
-  void buildEdges( FaceManager & faceManager, NodeManager & nodeManager );
+  void buildEdges( NodeManager & nodeManager, FaceManager & faceManager );
 
   /**
    * @brief Build faces-to-edges and nodes-to-edges relation maps.

--- a/src/coreComponents/mesh/ElementRegionBase.hpp
+++ b/src/coreComponents/mesh/ElementRegionBase.hpp
@@ -24,8 +24,6 @@
 namespace geosx
 {
 
-class StableTimeStep;
-
 class FaceManager;
 
 /**

--- a/src/coreComponents/meshUtilities/InternalMeshGenerator.cpp
+++ b/src/coreComponents/meshUtilities/InternalMeshGenerator.cpp
@@ -917,11 +917,6 @@ void InternalMeshGenerator::generateMesh( DomainPartition & domain )
       }
     }
   }
-
-  if( m_delayMeshDeformation == 0 )
-  {
-    remapMesh( domain );
-  }
 }
 
 /**
@@ -1218,47 +1213,6 @@ void InternalMeshGenerator::getElemToNodesRelationInBox( const string & elementT
     }
 
   }
-}
-
-void InternalMeshGenerator::remapMesh( dataRepository::Group & GEOSX_UNUSED_PARAM( domain ) )
-{
-  //  // Node mapping
-  //  if (!m_meshDx.empty())
-  //  {
-  //    const Table3D* tableDx =
-  // stlMapLookupPointer(TableManager::Instance().Tables<3>(), m_meshDx);
-  //
-  //    for (localIndex iN=0; iN!=nodeManager.DataLengths(); ++iN)
-  //    {
-  //      real64 dx=tableDx->Lookup(X[iN]);
-  //      X[iN][0] += dx;
-  //    }
-  //  }
-  //
-  //  if (!m_meshDy.empty())
-  //  {
-  //    const Table3D* tableDy =
-  // stlMapLookupPointer(TableManager::Instance().Tables<3>(), m_meshDy);
-  //
-  //    for (localIndex iN=0; iN!=nodeManager.DataLengths(); ++iN)
-  //    {
-  //      real64 dy=tableDy->Lookup(X[iN]);
-  //      X[iN][1] += dy;
-  //    }
-  //  }
-  //
-  //  if (!m_meshDz.empty())
-  //  {
-  //    const Table3D* tableDz =
-  // stlMapLookupPointer(TableManager::Instance().Tables<3>(), m_meshDz);
-  //
-  //    for (localIndex iN=0; iN!=nodeManager.DataLengths(); ++iN)
-  //    {
-  //      real64 dz=tableDz->Lookup(X[iN]);
-  //      X[iN][2] += dz;
-  //    }
-  //  }
-
 }
 
 REGISTER_CATALOG_ENTRY( MeshGeneratorBase, InternalMeshGenerator, string const &, Group * const )

--- a/src/coreComponents/meshUtilities/InternalMeshGenerator.cpp
+++ b/src/coreComponents/meshUtilities/InternalMeshGenerator.cpp
@@ -130,24 +130,6 @@ InternalMeshGenerator::~InternalMeshGenerator()
   // TODO Auto-generated destructor stub
 }
 
-
-/**
- * @param domain
- */
-void InternalMeshGenerator::generateElementRegions( DomainPartition & GEOSX_UNUSED_PARAM( domain ) )
-{
-  //  lvector numElements;
-  //
-  //  for( string_array::size_type r=0 ; r<m_regionNames.size() ; ++r )
-  //  {
-  //    numElements.emplace_back( 0 );
-  //  }
-  //
-  //  domain.m_feElementManager->resize( numElements, m_regionNames,
-  // m_elementType );
-
-}
-
 void InternalMeshGenerator::postProcessInput()
 {
 

--- a/src/coreComponents/meshUtilities/InternalMeshGenerator.hpp
+++ b/src/coreComponents/meshUtilities/InternalMeshGenerator.hpp
@@ -97,8 +97,6 @@ public:
 //
 //
 
-  virtual void generateElementRegions( DomainPartition & domain ) override;
-
   /**
    * @brief Create a new geometric object (box, plane, etc) as a child of this group.
    * @param childKey the catalog key of the new geometric object to create

--- a/src/coreComponents/meshUtilities/InternalMeshGenerator.hpp
+++ b/src/coreComponents/meshUtilities/InternalMeshGenerator.hpp
@@ -118,10 +118,6 @@ public:
                                              int nodeIDInBox[],
                                              const int size ) override;
 
-  virtual void remapMesh ( dataRepository::Group & domain ) override;
-
-//  int m_delayMeshDeformation;
-
 protected:
 
   void postProcessInput() override final;

--- a/src/coreComponents/meshUtilities/InternalMeshGenerator.hpp
+++ b/src/coreComponents/meshUtilities/InternalMeshGenerator.hpp
@@ -107,20 +107,26 @@ public:
 
   virtual void generateMesh( DomainPartition & domain ) override;
 
-  // virtual void GenerateNodesets( xmlWrapper::xmlNode const & targetNode,
-  //                                NodeManager * nodeManager ) override;
-
-  virtual void getElemToNodesRelationInBox ( const string & elementType,
-                                             const int index[],
-                                             const int & iEle,
-                                             int nodeIDInBox[],
-                                             const int size ) override;
-
 protected:
 
   void postProcessInput() override final;
 
 private:
+
+  /**
+   * @brief Get the label mapping of element vertices indexes onto node indexes for a type of element.
+   * @param[in] elementType the string identifier of the element type
+   * @param[in] index ndim-sptialized Element index.
+   * @param[in] iEle the index of Element begin processed
+   * @param[out] nodeIDInBox array to map element vertices index to node indexes
+   * @param[in] size the number of node on the element
+   *
+   */
+  void getElemToNodesRelationInBox( const string & elementType,
+                                    const int index[],
+                                    const int & iEle,
+                                    int nodeIDInBox[],
+                                    const int size );
 
   /// Mesh number of dimension
   int m_dim;

--- a/src/coreComponents/meshUtilities/InternalWellGenerator.hpp
+++ b/src/coreComponents/meshUtilities/InternalWellGenerator.hpp
@@ -96,9 +96,6 @@ public:
    */
   ///@{
 
-  /// not implemented
-  virtual void generateElementRegions( DomainPartition & ) override {}
-
   /**
    * @brief Creates a new sub-Group using the ObjectCatalog functionality.
    * @param[in] childKey The name of the new object type's key in the

--- a/src/coreComponents/meshUtilities/InternalWellGenerator.hpp
+++ b/src/coreComponents/meshUtilities/InternalWellGenerator.hpp
@@ -127,10 +127,6 @@ public:
                                              int const &,
                                              int *,
                                              int const ) override {}
-
-  /// not implemented
-  virtual void remapMesh ( dataRepository::Group & ) override {}
-
   ///@}
 
   /**

--- a/src/coreComponents/meshUtilities/InternalWellGenerator.hpp
+++ b/src/coreComponents/meshUtilities/InternalWellGenerator.hpp
@@ -117,13 +117,6 @@ public:
    * @param[in] domain the domain object
    */
   virtual void generateMesh( DomainPartition & domain ) override;
-
-  /// not implemented
-  virtual void getElemToNodesRelationInBox ( string const &,
-                                             int const *,
-                                             int const &,
-                                             int *,
-                                             int const ) override {}
   ///@}
 
   /**

--- a/src/coreComponents/meshUtilities/MeshGeneratorBase.cpp
+++ b/src/coreComponents/meshUtilities/MeshGeneratorBase.cpp
@@ -12,13 +12,7 @@
  * ------------------------------------------------------------------------------------------------------------
  */
 
-/**
- * @file MeshGeneratorBase.cpp
- *
- */
-
 #include "MeshGeneratorBase.hpp"
-
 
 namespace geosx
 {

--- a/src/coreComponents/meshUtilities/MeshGeneratorBase.hpp
+++ b/src/coreComponents/meshUtilities/MeshGeneratorBase.hpp
@@ -29,7 +29,6 @@ namespace geosx
 namespace dataRepository
 {}
 
-class NodeManager;
 class DomainPartition;
 
 /**

--- a/src/coreComponents/meshUtilities/MeshGeneratorBase.hpp
+++ b/src/coreComponents/meshUtilities/MeshGeneratorBase.hpp
@@ -54,7 +54,6 @@ public:
    */
   virtual ~MeshGeneratorBase();
 
-
   /**
    * @brief Return the name of the MeshGenerator in object catalog.
    * @return string that contains the catalog name of the MeshGenerator
@@ -73,9 +72,6 @@ public:
  */
   virtual void generateMesh( DomainPartition & domain ) = 0;
 
-  // virtual void GenerateNodesets( xmlWrapper::xmlNode const & targetNode,
-  //                                NodeManager * nodeManager ) = 0;
-
 /**
  * @brief Get the label mapping of element vertices indexes onto node indexes for a type of element.
  * @param[in] elementType the string identifier of the element type
@@ -90,15 +86,6 @@ public:
                                              const int & iEle,
                                              int nodeIDInBox[],
                                              const int size ) = 0;
-/**
- * @brief Re-computing mesh tables for the input domain.
- * @param[in] domain domain point whose mesh has to be remapped
- *
- */
-  virtual void remapMesh ( dataRepository::Group & domain ) = 0;
-
-  /// Integer to trigger or not mesh re-mapping at the end of GenerateMesh call
-  int m_delayMeshDeformation = 0;
 
   /// using alias for templated Catalog meshGenerator type
   using CatalogInterface = dataRepository::CatalogInterface< MeshGeneratorBase, string const &, Group * const >;

--- a/src/coreComponents/meshUtilities/MeshGeneratorBase.hpp
+++ b/src/coreComponents/meshUtilities/MeshGeneratorBase.hpp
@@ -61,12 +61,6 @@ public:
   static string catalogName() { return "MeshGeneratorBase"; }
 
 /**
- * @brief Generate the Element regions for an input Domain.
- * @param[inout] domain the Domain object on which to generate Element regions
- */
-  virtual void generateElementRegions( DomainPartition & domain ) = 0;
-
-/**
  * @brief Generate the mesh object the input mesh object.
  * @param[in] domain the domain partition from which to construct the mesh object
  */

--- a/src/coreComponents/meshUtilities/MeshGeneratorBase.hpp
+++ b/src/coreComponents/meshUtilities/MeshGeneratorBase.hpp
@@ -60,37 +60,20 @@ public:
    */
   static string catalogName() { return "MeshGeneratorBase"; }
 
-/**
- * @brief Generate the mesh object the input mesh object.
- * @param[in] domain the domain partition from which to construct the mesh object
- */
-  virtual void generateMesh( DomainPartition & domain ) = 0;
-
-/**
- * @brief Get the label mapping of element vertices indexes onto node indexes for a type of element.
- * @param[in] elementType the string identifier of the element type
- * @param[in] index ndim-sptialized Element index.
- * @param[in] iEle the index of Element begin processed
- * @param[out] nodeIDInBox array to map element vertices index to node indexes
- * @param[in] size the number of node on the element
- *
- */
-  virtual void getElemToNodesRelationInBox ( const string & elementType,
-                                             const int index[],
-                                             const int & iEle,
-                                             int nodeIDInBox[],
-                                             const int size ) = 0;
-
   /// using alias for templated Catalog meshGenerator type
   using CatalogInterface = dataRepository::CatalogInterface< MeshGeneratorBase, string const &, Group * const >;
 
-/**
- * @brief Accessor for the singleton Catalog object
- * @return a static reference to the Catalog object
- *
- */
+  /**
+   * @brief Accessor for the singleton Catalog object
+   * @return a static reference to the Catalog object
+   */
   static CatalogInterface::CatalogType & getCatalog();
 
+  /**
+   * @brief Generate the mesh object the input mesh object.
+   * @param[in] domain the domain partition from which to construct the mesh object
+   */
+  virtual void generateMesh( DomainPartition & domain ) = 0;
 };
 }
 

--- a/src/coreComponents/meshUtilities/PAMELAMeshGenerator.cpp
+++ b/src/coreComponents/meshUtilities/PAMELAMeshGenerator.cpp
@@ -376,12 +376,5 @@ void PAMELAMeshGenerator::generateMesh( DomainPartition & domain )
 
 }
 
-void PAMELAMeshGenerator::getElemToNodesRelationInBox( const string & GEOSX_UNUSED_PARAM( elementType ),
-                                                       const int GEOSX_UNUSED_PARAM( index )[],
-                                                       const int & GEOSX_UNUSED_PARAM( iEle ),
-                                                       int GEOSX_UNUSED_PARAM( nodeIDInBox )[],
-                                                       const int GEOSX_UNUSED_PARAM( node_size ) )
-{}
-
 REGISTER_CATALOG_ENTRY( MeshGeneratorBase, PAMELAMeshGenerator, string const &, Group * const )
 }

--- a/src/coreComponents/meshUtilities/PAMELAMeshGenerator.cpp
+++ b/src/coreComponents/meshUtilities/PAMELAMeshGenerator.cpp
@@ -81,11 +81,6 @@ void PAMELAMeshGenerator::postProcessInput()
                                                                PAMELA::ELEMENTS::FAMILY::POLYGON ));
 }
 
-void PAMELAMeshGenerator::remapMesh( dataRepository::Group & GEOSX_UNUSED_PARAM( domain ) )
-{
-  return;
-}
-
 Group * PAMELAMeshGenerator::createChild( string const & GEOSX_UNUSED_PARAM( childKey ), string const & GEOSX_UNUSED_PARAM( childName ) )
 {
   return nullptr;

--- a/src/coreComponents/meshUtilities/PAMELAMeshGenerator.cpp
+++ b/src/coreComponents/meshUtilities/PAMELAMeshGenerator.cpp
@@ -64,9 +64,6 @@ PAMELAMeshGenerator::PAMELAMeshGenerator( string const & name, Group * const par
 PAMELAMeshGenerator::~PAMELAMeshGenerator()
 {}
 
-void PAMELAMeshGenerator::generateElementRegions( DomainPartition & GEOSX_UNUSED_PARAM( domain ) )
-{}
-
 void PAMELAMeshGenerator::postProcessInput()
 {
   m_pamelaMesh =

--- a/src/coreComponents/meshUtilities/PAMELAMeshGenerator.hpp
+++ b/src/coreComponents/meshUtilities/PAMELAMeshGenerator.hpp
@@ -67,8 +67,6 @@ public:
   };
 /// @endcond
 
-  virtual void generateElementRegions( DomainPartition & domain ) override;
-
   /**
    * @brief Create a new geometric object (box, plane, etc) as a child of this group.
    * @param childKey the catalog key of the new geometric object to create

--- a/src/coreComponents/meshUtilities/PAMELAMeshGenerator.hpp
+++ b/src/coreComponents/meshUtilities/PAMELAMeshGenerator.hpp
@@ -85,8 +85,6 @@ public:
                                              int nodeIDInBox[],
                                              const int size ) override;
 
-  virtual void remapMesh ( dataRepository::Group & domain ) override;
-
 protected:
 
   /**

--- a/src/coreComponents/meshUtilities/PAMELAMeshGenerator.hpp
+++ b/src/coreComponents/meshUtilities/PAMELAMeshGenerator.hpp
@@ -77,12 +77,6 @@ public:
 
   virtual void generateMesh( DomainPartition & domain ) override;
 
-  virtual void getElemToNodesRelationInBox ( const string & elementType,
-                                             const int index[],
-                                             const int & iEle,
-                                             int nodeIDInBox[],
-                                             const int size ) override;
-
 protected:
 
   /**


### PR DESCRIPTION
Passing by, removing some unused code in `MeshGeneratorBase`.
Plus tiny typo corrections, visibility reductions, parameter reordering and forward declaration suppressions.