### PR TITLE
Clean silo output

### DIFF
--- a/src/coreComponents/constitutive/solid/ElasticIsotropic.cpp
+++ b/src/coreComponents/constitutive/solid/ElasticIsotropic.cpp
@@ -53,10 +53,12 @@ ElasticIsotropic::ElasticIsotropic( string const & name, Group * const parent ):
 
   registerWrapper( viewKeyStruct::bulkModulusString(), &m_bulkModulus ).
     setApplyDefaultValue( -1 ).
+    setPlotLevel( dataRepository::PlotLevel::LEVEL_0 ).
     setDescription( "Elastic Bulk Modulus Field" );
 
   registerWrapper( viewKeyStruct::shearModulusString(), &m_shearModulus ).
     setApplyDefaultValue( -1 ).
+    setPlotLevel( dataRepository::PlotLevel::LEVEL_0 ).
     setDescription( "Elastic Shear Modulus" );
 }
 

--- a/src/coreComponents/constitutive/solid/ElasticTransverseIsotropic.cpp
+++ b/src/coreComponents/constitutive/solid/ElasticTransverseIsotropic.cpp
@@ -66,22 +66,27 @@ ElasticTransverseIsotropic::ElasticTransverseIsotropic( string const & name, Gro
 
   registerWrapper( viewKeyStruct::c11String(), &m_c11 ).
     setApplyDefaultValue( -1 ).
+    setPlotLevel( dataRepository::PlotLevel::LEVEL_0 ).
     setDescription( "Elastic Bulk Modulus Field" );
 
   registerWrapper( viewKeyStruct::c13String(), &m_c13 ).
     setApplyDefaultValue( -1 ).
+    setPlotLevel( dataRepository::PlotLevel::LEVEL_0 ).
     setDescription( "Elastic Bulk Modulus Field" );
 
   registerWrapper( viewKeyStruct::c33String(), &m_c33 ).
     setApplyDefaultValue( -1 ).
+    setPlotLevel( dataRepository::PlotLevel::LEVEL_0 ).
     setDescription( "Elastic Bulk Modulus Field" );
 
   registerWrapper( viewKeyStruct::c44String(), &m_c44 ).
     setApplyDefaultValue( -1 ).
+    setPlotLevel( dataRepository::PlotLevel::LEVEL_0 ).
     setDescription( "Elastic Bulk Modulus Field" );
 
   registerWrapper( viewKeyStruct::c66String(), &m_c66 ).
     setApplyDefaultValue( -1 ).
+    setPlotLevel( dataRepository::PlotLevel::LEVEL_0 ).
     setDescription( "Elastic Bulk Modulus Field" );
 }
 

--- a/src/coreComponents/fileIO/silo/SiloFile.cpp
+++ b/src/coreComponents/fileIO/silo/SiloFile.cpp
@@ -12,10 +12,6 @@
  * ------------------------------------------------------------------------------------------------------------
  */
 
-/**
- * @file SiloFile.cpp
- */
-
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 
@@ -60,11 +56,6 @@ int MPI_Recv( void * buf, int, MPI_Datatype, int, int,
 
 namespace geosx
 {
-
-/**
- *
- * @return
- */
 
 namespace siloFileUtilities
 {
@@ -196,6 +187,7 @@ void SetVariableNames< R1Tensor >( string const & fieldName,
   varnamestring[0] = fieldName + "_1";
   varnamestring[1] = fieldName + "_2";
   varnamestring[2] = fieldName + "_3";
+
   varnames[0] = const_cast< char * >( varnamestring[0].c_str() );
   varnames[1] = const_cast< char * >( varnamestring[1].c_str() );
   varnames[2] = const_cast< char * >( varnamestring[2].c_str() );
@@ -253,6 +245,8 @@ template<> int GetTensorRank< string >()
 }
 
 } /* siloFileUtilities */
+
+
 
 using namespace dataRepository;
 
@@ -326,12 +320,6 @@ int SiloFile::groupRank( int const i ) const
   return PMPIO_GroupRank( m_baton, i );
 }
 
-/**
- * @param domainNumber
- * @param cycleNum
- * @param fileName
- * @param nsName
- */
 void SiloFile::waitForBatonWrite( int const domainNumber,
                                   int const cycleNum,
                                   integer const eventCounter,
@@ -430,21 +418,6 @@ void SiloFile::handOffBaton()
   }
 }
 
-/**
- * @param meshName
- * @param nnodes
- * @param coords
- * @param globalNodeNum
- * @param numRegions
- * @param shapecnt
- * @param meshConnectivity
- * @param globalElementNum
- * @param ghostFlag
- * @param shapetype
- * @param shapesize
- * @param cycleNumber
- * @param problemTime
- */
 void SiloFile::writeMeshObject( string const & meshName,
                                 const localIndex nnodes,
                                 real64 * coords[3],
@@ -494,7 +467,6 @@ void SiloFile::writeMeshObject( string const & meshName,
     else
       lnodelist += -shapesize[i];
   }
-
 
   if( numTotZones == 0 )
   {
@@ -681,7 +653,6 @@ void SiloFile::writePointMesh( string const & meshName,
   DBAddOption( optlist, DBOPT_DTIME, const_cast< real64 * >(&problemTime));
   DBPutPointmesh ( m_dbFilePtr, meshName.c_str(), 3, coords, numPoints, datatype, optlist );
 
-
   // Write multimesh object
   {
     int rank = 0;
@@ -693,8 +664,8 @@ void SiloFile::writePointMesh( string const & meshName,
       writeMultiXXXX( DB_POINTMESH, DBPutMultimesh, 0, meshName.c_str(), cycleNumber, "/", optlist );
     }
   }
-
 }
+
 
 void SiloFile::writeMaterialMapsFullStorage( ElementRegionBase const & elemRegion,
                                              string const & meshName,
@@ -810,7 +781,6 @@ void SiloFile::writeMaterialMapsFullStorage( ElementRegionBase const & elemRegio
   #endif
     if( rank == 0 )
     {
-
       int const size = MpiWrapper::commSize( MPI_COMM_GEOSX );
 
       array1d< string > vBlockNames( size );
@@ -850,7 +820,6 @@ void SiloFile::writeMaterialMapsFullStorage( ElementRegionBase const & elemRegio
         DBPutMultimat( m_dbBaseFilePtr, name.c_str(), size, BlockNames.data(),
                        const_cast< DBoptlist * >(optlist));
         DBFreeOptlist( optlist );
-
       }
 
       DBSetDir( m_dbBaseFilePtr, currentDirectory );
@@ -868,10 +837,8 @@ void SiloFile::writeMaterialMapsFullStorage( ElementRegionBase const & elemRegio
         shortsubdir.erase( 0, pos+1 );
       }
 
-
       makeSubDirectory( shortsubdir, rootDirectory );
       DBSetDir( m_dbFilePtr, shortsubdir.c_str());
-
     }
 
     std::set< std::pair< string, WrapperBase const * > > fieldNames;
@@ -977,6 +944,7 @@ void SiloFile::writeMaterialVarDefinition( string const & subDir,
                 defns,
                 nullptr );
 }
+
 
 void SiloFile::clearEmptiesFromMultiObjects( int const cycleNum )
 {
@@ -1224,8 +1192,9 @@ void SiloFile::writeElementRegionSilo( ElementRegionBase const & elemRegion,
 
         std::type_info const & typeID = wrapper->getTypeId();
 
-        if( typeID == typeid( array1d< real64 > ) ||
-            typeID == typeid( array2d< real64 > ) )
+        if( fieldName != "density" &&
+            fieldName != "viscosity" && 
+            fieldName != "stress" )
         {
           rtTypes::applyArrayTypeLambda2( rtTypes::typeID( typeID ),
                                           false,
@@ -1955,8 +1924,14 @@ void SiloFile::writeWrappersToSilo( string const & meshname,
       if( typeID==typeid(array1d< real64 >) )
       {
         auto const & wrapperT = dynamic_cast< dataRepository::Wrapper< array1d< real64 > > const & >( *wrapper );
-        this->writeDataField< real64 >( meshname.c_str(), fieldName,
-                                        wrapperT.reference(), centering, cycleNum, problemTime, multiRoot );
+
+        this->writeDataField< real64 >( meshname.c_str(), 
+                                        fieldName,
+                                        wrapperT.reference(), 
+                                        centering, 
+                                        cycleNum, 
+                                        problemTime, 
+                                        multiRoot );
       }
       if( typeID==typeid(array2d< real64 >) )
       {
@@ -2993,7 +2968,6 @@ void SiloFile::writeStressVarDefinition( string const & MatDir )
                   nullptr );
   }
 }
-
 
 void SiloFile::writeVectorVarDefinition( string const & fieldName,
                                          string const & subDirectory )

--- a/src/coreComponents/fileIO/silo/SiloFile.cpp
+++ b/src/coreComponents/fileIO/silo/SiloFile.cpp
@@ -16,7 +16,6 @@
  * @file SiloFile.cpp
  */
 
-
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 
@@ -34,13 +33,10 @@
 #include "mpiCommunications/MpiWrapper.hpp"
 
 #include <iostream>
-
 #include <sstream>
 #include <algorithm>
 #include <iterator>
 #include <sys/stat.h>
-
-
 
 #if !defined(GEOSX_USE_MPI)
 int MPI_Comm_size( MPI_Comm, int * size ) { *size=1; return 0; }
@@ -59,10 +55,8 @@ int MPI_Recv( void * buf, int, MPI_Datatype, int, int,
   return 0;
 }
 #endif
-#include "pmpio.h"
 
-/// forward declaration of NodeManagerT for use as a template argument
-class NodeManager;
+#include "pmpio.h"
 
 namespace geosx
 {
@@ -71,41 +65,49 @@ namespace geosx
  *
  * @return
  */
-namespace SiloFileUtilities
-{
 
+namespace siloFileUtilities
+{
 template<> int DB_TYPE< int >()
 {
   return DB_INT;
 }
+
 template<> int DB_TYPE< unsigned int >()
 {
   return DB_INT;
 }
+
 template<> int DB_TYPE< float >()
 {
   return DB_FLOAT;
 }
+
 template<> int DB_TYPE< real64 >()
 {
   return DB_DOUBLE;
 }
+
 template<> int DB_TYPE< R1Tensor >()
 {
   return DB_DOUBLE;
 }
+
 template<> int DB_TYPE< unsigned long >()
 {
   return DB_LONG;
 }
+
 template<> int DB_TYPE< long >()
 {
   return DB_LONG;
 }
+
 template<> int DB_TYPE< long long >()
 {
   return DB_LONG_LONG;
 }
+
 template<> int DB_TYPE< string >()
 {
   return DB_CHAR;
@@ -115,38 +117,47 @@ template<> int GetNumberOfVariablesInField< int >()
 {
   return 1;
 }
+
 template<> int GetNumberOfVariablesInField< unsigned int >()
 {
   return 1;
 }
+
 template<> int GetNumberOfVariablesInField< unsigned long >()
 {
   return 1;
 }
+
 template<> int GetNumberOfVariablesInField< long >()
 {
   return 1;
 }
+
 template<> int GetNumberOfVariablesInField< float >()
 {
   return 1;
 }
+
 template<> int GetNumberOfVariablesInField< real64 >()
 {
   return 1;
 }
+
 template<> int GetNumberOfVariablesInField< long long unsigned int >()
 {
   return 1;
 }
+
 template<> int GetNumberOfVariablesInField< long long int >()
 {
   return 1;
 }
+
 template<> int GetNumberOfVariablesInField< R1Tensor >()
 {
   return R1Tensor::SIZE;
 }
+
 template<> int GetNumberOfVariablesInField< string >()
 {
   return 1;
@@ -159,20 +170,22 @@ void SetVariableNames( string const & fieldName, string_array & varnamestring, c
   varnamestring[0] = fieldName;
   varnames[0] = varnamestring[0].c_str();
 }
+
 template void SetVariableNames< int >( string const & fieldName,
                                        string_array & varnamestring,
                                        char const * varnames[] );
+
 template void SetVariableNames< unsigned long >( string const & fieldName,
                                                  string_array & varnamestring,
                                                  char const * varnames[] );
+
 template void SetVariableNames< real64 >( string const & fieldName,
                                           string_array & varnamestring,
                                           char const * varnames[] );
+
 template void SetVariableNames< long long unsigned int >( string const & fieldName,
                                                           string_array & varnamestring,
                                                           char const * varnames[] );
-
-
 
 template<>
 void SetVariableNames< R1Tensor >( string const & fieldName,
@@ -193,53 +206,56 @@ template<> int GetTensorRank< int >()
 {
   return DB_VARTYPE_SCALAR;
 }
+
 template<> int GetTensorRank< unsigned int >()
 {
   return DB_VARTYPE_SCALAR;
 }
+
 template<> int GetTensorRank< long >()
 {
   return DB_VARTYPE_SCALAR;
 }
+
 template<> int GetTensorRank< unsigned long >()
 {
   return DB_VARTYPE_SCALAR;
 }
+
 template<> int GetTensorRank< real32 >()
 {
   return DB_VARTYPE_SCALAR;
 }
+
 template<> int GetTensorRank< real64 >()
 {
   return DB_VARTYPE_SCALAR;
 }
+
 template<> int GetTensorRank< R1Tensor >()
 {
   return DB_VARTYPE_VECTOR;
 }
+
 template<> int GetTensorRank< long long unsigned int >()
 {
   return DB_VARTYPE_SCALAR;
 }
+
 template<> int GetTensorRank< long long int >()
 {
   return DB_VARTYPE_SCALAR;
 }
+
 template<> int GetTensorRank< string >()
 {
   return DB_VARTYPE_SCALAR;
 }
 
+} /* siloFileUtilities */
 
-
-}
-
-
-
-using namespace constitutive;
 using namespace dataRepository;
 
-// *********************************************************************************************************************
 /// Default Constructor
 SiloFile::SiloFile():
   m_dbFilePtr( nullptr ),
@@ -253,7 +269,6 @@ SiloFile::SiloFile():
   m_fileName(),
   m_baseFileName(),
   m_emptyMeshes(),
-//  m_emptyMaterials(),
   m_emptyVariables(),
   m_writeEdgeMesh( 0 ),
   m_writeFaceMesh( 0 ),
@@ -265,16 +280,8 @@ SiloFile::SiloFile():
   DBSetAllowEmptyObjects( 1 );
 }
 
-// *********************************************************************************************************************
-/// Destructor
-SiloFile::~SiloFile()
-{}
-
-// *********************************************************************************************************************
-
 void SiloFile::makeSiloDirectories()
 {
-
   int rank=0;
 #ifdef GEOSX_USE_MPI
   MPI_Comm_rank( MPI_COMM_GEOSX, &rank );
@@ -286,9 +293,6 @@ void SiloFile::makeSiloDirectories()
   }
 }
 
-/**
- *
- */
 void SiloFile::initialize( int const MPI_PARAM( numGroups ) )
 {
   makeSiloDirectories();
@@ -300,7 +304,7 @@ void SiloFile::initialize( int const MPI_PARAM( numGroups ) )
   m_numGroups = 1;
 #endif
   MpiWrapper::bcast( &m_numGroups, 1, 0, MPI_COMM_GEOSX );
-//  MPI_Bcast( const_cast<int*>(&m_driver), 1, MPI_INT, 0, MPI_COMM_GEOSX);
+
   // Initialize PMPIO, pass a pointer to the driver type as the user data.
   m_baton = PMPIO_Init( m_numGroups,
                         PMPIO_WRITE,
@@ -312,10 +316,6 @@ void SiloFile::initialize( int const MPI_PARAM( numGroups ) )
                         const_cast< int * >(&m_driver));
 }
 
-// *********************************************************************************************************************
-/**
- *
- */
 void SiloFile::finish()
 {
   PMPIO_Finish( m_baton );
@@ -326,9 +326,7 @@ int SiloFile::groupRank( int const i ) const
   return PMPIO_GroupRank( m_baton, i );
 }
 
-// *********************************************************************************************************************
 /**
- *
  * @param domainNumber
  * @param cycleNum
  * @param fileName
@@ -348,8 +346,6 @@ void SiloFile::waitForBatonWrite( int const domainNumber,
   char fileName[200] = { 0 };
   char baseFileName[200] = { 0 };
   char dirName[200] = { 0 };
-
-
 
   if( isRestart )
   {
@@ -383,14 +379,11 @@ void SiloFile::waitForBatonWrite( int const domainNumber,
   if( rank==0 )
   {
     m_dbBaseFilePtr = DBCreate( (m_siloDirectory + "/"+ m_baseFileName).c_str(), DB_CLOBBER, DB_LOCAL, nullptr, DB_HDF5 );
-//    m_dbBaseFilePtr = DBOpen( m_baseFileName.c_str(), DB_HDF5, DB_APPEND );
   }
 }
 
-
 void SiloFile::waitForBaton( int const domainNumber, string const & restartFileName )
 {
-
   int rank = 0;
 #ifdef GEOSX_USE_MPI
   MPI_Comm_rank( MPI_COMM_GEOSX, &rank );
@@ -399,7 +392,6 @@ void SiloFile::waitForBaton( int const domainNumber, string const & restartFileN
   char fileName[200] = { 0 };
   char baseFileName[200] = { 0 };
   char dirName[200] = { 0 };
-
 
   sprintf( baseFileName, "%s", restartFileName.c_str());
   if( groupRank == 0 )
@@ -414,7 +406,6 @@ void SiloFile::waitForBaton( int const domainNumber, string const & restartFileN
     {
       sprintf( fileName, "%s%s%s.%03d", m_siloDirectory.c_str(), "/", restartFileName.c_str(), groupRank );
     }
-
   }
 
   sprintf( dirName, "domain_%05d", domainNumber );
@@ -424,9 +415,7 @@ void SiloFile::waitForBaton( int const domainNumber, string const & restartFileN
   m_fileName = fileName;
   m_baseFileName = baseFileName;
 }
-/**
- *
- */
+
 void SiloFile::handOffBaton()
 {
   PMPIO_HandOffBaton( m_baton, m_dbFilePtr );
@@ -442,7 +431,6 @@ void SiloFile::handOffBaton()
 }
 
 /**
- *
  * @param meshName
  * @param nnodes
  * @param coords
@@ -472,7 +460,6 @@ void SiloFile::writeMeshObject( string const & meshName,
                                 int const cycleNumber,
                                 real64 const problemTime )
 {
-
   const DBdatatype datatype = DB_DOUBLE;
   int const one = 1;
 
@@ -500,6 +487,7 @@ void SiloFile::writeMeshObject( string const & meshName,
   for( int i = 0; i < numShapes; ++i )
   {
     numTotZones += shapecnt[i];
+
     //  if shapesize <= 0, that signals that we are using arbitrary polygons.
     if( shapesize[i] > 0 )
       lnodelist += shapecnt[i] * shapesize[i];
@@ -518,7 +506,6 @@ void SiloFile::writeMeshObject( string const & meshName,
   }
   else
   {
-
     string zonelistName;
     zonelistName = meshName + "_zonelist";
 
@@ -578,7 +565,6 @@ void SiloFile::writeMeshObject( string const & meshName,
 
     int hi_offset = 0;
 
-
     if( m_ghostFlags )
     {
       DBAddOption( optlist, DBOPT_GHOST_ZONE_LABELS, const_cast< char * >( ghostZoneFlag ) );
@@ -607,7 +593,6 @@ void SiloFile::writeMeshObject( string const & meshName,
 
   DBFreeOptlist( optlist );
 }
-
 
 void SiloFile::writeBeamMesh( string const & meshName,
                               const localIndex nnodes,
@@ -666,7 +651,7 @@ void SiloFile::writeBeamMesh( string const & meshName,
                 "zonelist", nullptr, datatype, nullptr );
   DBClearOptlist( optlist );
 
-  //----write multimesh object
+  // Write multimesh object
   {
     int rank = 0;
   #ifdef GEOSX_USE_MPI
@@ -680,11 +665,9 @@ void SiloFile::writeBeamMesh( string const & meshName,
     }
   }
 
-  //---free the option list
+  // Free the option list
   DBFreeOptlist( optlist );
 }
-
-
 
 void SiloFile::writePointMesh( string const & meshName,
                                const localIndex numPoints,
@@ -699,7 +682,7 @@ void SiloFile::writePointMesh( string const & meshName,
   DBPutPointmesh ( m_dbFilePtr, meshName.c_str(), 3, coords, numPoints, datatype, optlist );
 
 
-  //----write multimesh object
+  // Write multimesh object
   {
     int rank = 0;
   #ifdef GEOSX_USE_MPI
@@ -795,15 +778,6 @@ void SiloFile::writeMaterialMapsFullStorage( ElementRegionBase const & elemRegio
       } );
     }
 
-//    if( nmat == 0 )
-//    {
-//      char pwd[256];
-//      DBGetDir(m_dbFilePtr, pwd);
-//      string emptyObject = pwd;
-//      emptyObject += "/" + fieldName;
-//      m_emptyVariables.emplace_back(emptyObject);
-//    }
-//    else
     {
       DBoptlist * optlist = DBMakeOptlist( 3 );
       DBAddOption( optlist, DBOPT_MATNAMES, materialNames.data());
@@ -828,6 +802,7 @@ void SiloFile::writeMaterialMapsFullStorage( ElementRegionBase const & elemRegio
 
       DBFreeOptlist( optlist );
     }
+
     // write multimesh object
     int rank = 0;
   #ifdef GEOSX_USE_MPI
@@ -850,7 +825,7 @@ void SiloFile::writeMaterialMapsFullStorage( ElementRegionBase const & elemRegio
       {
         int groupRank = PMPIO_GroupRank( m_baton, i );
 
-        /* this mesh block is another file */
+        // this mesh block is another file
         sprintf( tempBuffer,
                  "%s%s%s.%03d:/domain_%05d/%s",
                  m_siloDataSubDirectory.c_str(),
@@ -879,9 +854,7 @@ void SiloFile::writeMaterialMapsFullStorage( ElementRegionBase const & elemRegio
       }
 
       DBSetDir( m_dbBaseFilePtr, currentDirectory );
-
     }
-
 
     string subDirectory = meshName + "_MaterialFields";
     string rootDirectory = "/" + subDirectory;
@@ -959,9 +932,7 @@ void SiloFile::writeMaterialMapsFullStorage( ElementRegionBase const & elemRegio
                                                     rootDirectory,
                                                     regionMaterialList );
       }
-
     }
-
 
     if( rank == 0 )
     {
@@ -1015,7 +986,6 @@ void SiloFile::clearEmptiesFromMultiObjects( int const cycleNum )
 
   string sendbufferVars;
   string sendbufferMesh;
-//  string sendbufferMaterials;
 
   if( rank != 0 )
   {
@@ -1028,13 +998,6 @@ void SiloFile::clearEmptiesFromMultiObjects( int const cycleNum )
     {
       sendbufferMesh += emptyObject + ' ';
     }
-
-//    for( string_array::const_iterator emptyObject=m_emptyMaterials.begin() ;
-//         emptyObject!=m_emptyMaterials.end() ; ++emptyObject )
-//    {
-//      sendbufferMesh += *emptyObject + ' ';
-//    }
-
   }
 
   int sizeOfSendBufferVars = sendbufferVars.size();
@@ -1061,7 +1024,6 @@ void SiloFile::clearEmptiesFromMultiObjects( int const cycleNum )
                         0,
                         MPI_COMM_GEOSX );
 
-
   MpiWrapper::gather( &sizeOfSendBufferMesh, 1, rcounts.data(), 1, 0, MPI_COMM_GEOSX );
 
   int sizeOfReceiveBufferMesh = 0;
@@ -1080,8 +1042,6 @@ void SiloFile::clearEmptiesFromMultiObjects( int const cycleNum )
                         displs.data(),
                         0,
                         MPI_COMM_GEOSX );
-
-
 
   if( rank== 0 )
   {
@@ -1134,8 +1094,6 @@ void SiloFile::clearEmptiesFromMultiObjects( int const cycleNum )
 
         DBoptlist *optlist = DBMakeOptlist( 5 );
         DBAddOption( optlist, DBOPT_CYCLE, const_cast< int * >(&cycleNum));
-        //      DBAddOption( optlist, DBOPT_DTIME,
-        // const_cast<real64*>(&problemTime) );
         DBAddOption( optlist, DBOPT_REGION_PNAMES, multiVar->region_pnames );
         DBAddOption( optlist, DBOPT_TENSOR_RANK, &multiVar->tensor_rank );
         DBAddOption( optlist, DBOPT_MMESH_NAME, multiVar->mmesh_name );
@@ -1146,7 +1104,6 @@ void SiloFile::clearEmptiesFromMultiObjects( int const cycleNum )
         DBFreeMultivar( multiVar );
       }
     }
-
 
     for( string const & emptyObject : m_emptyMeshes )
     {
@@ -1171,7 +1128,6 @@ void SiloFile::clearEmptiesFromMultiObjects( int const cycleNum )
 
         for( int i = 0; i < multiMesh->nblocks; ++i )
         {
-
           string path( multiMesh->meshnames[i] );
           if( path.find( domainString ) != string::npos )
           {
@@ -1185,7 +1141,6 @@ void SiloFile::clearEmptiesFromMultiObjects( int const cycleNum )
 
         DBoptlist *optlist = DBMakeOptlist( 2 );
         DBAddOption( optlist, DBOPT_CYCLE, const_cast< int * >(&cycleNum));
-//        DBAddOption( optlist, DBOPT_DTIME, const_cast<real64*>(&problemTime) );
 
         DBPutMultimesh( siloFile, varName.c_str(), multiMesh->nblocks,
                         const_cast< char * * >(newmeshnames.data()), multiMesh->meshtypes, optlist );
@@ -1197,7 +1152,6 @@ void SiloFile::clearEmptiesFromMultiObjects( int const cycleNum )
   }
   m_emptyVariables.clear();
   m_emptyMeshes.clear();
-
 }
 
 void SiloFile::writeGroupSilo( Group const & group,
@@ -1209,7 +1163,6 @@ void SiloFile::writeGroupSilo( Group const & group,
                                bool const isRestart,
                                const localIndex_array & mask )
 {
-
   string subDirectory = siloDirName;
   string rootDirectory = "/" + siloDirName;
 
@@ -1235,10 +1188,7 @@ void SiloFile::writeGroupSilo( Group const & group,
                                  rootDirectory,
                                  mask );
 
-
-
   DBSetDir( m_dbFilePtr, ".." );
-
 }
 
 void SiloFile::writeElementRegionSilo( ElementRegionBase const & elemRegion,
@@ -1277,19 +1227,19 @@ void SiloFile::writeElementRegionSilo( ElementRegionBase const & elemRegion,
         if( typeID == typeid( array1d< real64 > ) ||
             typeID == typeid( array2d< real64 > ) )
         {
-        rtTypes::applyArrayTypeLambda2( rtTypes::typeID( typeID ),
-                                        false,
-                                        [&]( auto array, auto GEOSX_UNUSED_PARAM( Type ) )
-        {
-          typedef decltype( array ) arrayType;
-          Wrapper< arrayType > const & sourceWrapper = dynamicCast< Wrapper< arrayType > const & >( *wrapper );
-          traits::ViewTypeConst< arrayType > const sourceArray = sourceWrapper.reference();
+          rtTypes::applyArrayTypeLambda2( rtTypes::typeID( typeID ),
+                                          false,
+                                          [&]( auto array, auto GEOSX_UNUSED_PARAM( Type ) )
+          {
+            typedef decltype( array ) arrayType;
+            Wrapper< arrayType > const & sourceWrapper = dynamicCast< Wrapper< arrayType > const & >( *wrapper );
+            traits::ViewTypeConst< arrayType > const sourceArray = sourceWrapper.reference();
 
-          Wrapper< arrayType > & newWrapper = fakeGroup.registerWrapper< arrayType >( fieldName );
-          newWrapper.setPlotLevel( PlotLevel::LEVEL_0 );
-          arrayType & newarray = newWrapper.reference();
-          newarray.resize( arrayType::NDIM, sourceArray.dims() );
-        } );
+            Wrapper< arrayType > & newWrapper = fakeGroup.registerWrapper< arrayType >( fieldName );
+            newWrapper.setPlotLevel( PlotLevel::LEVEL_0 );
+            arrayType & newarray = newWrapper.reference();
+            newarray.resize( arrayType::NDIM, sourceArray.dims() );
+          } );
         }
       }
     }
@@ -1358,17 +1308,9 @@ void SiloFile::writeDomainPartition( DomainPartition const & domain,
                                      real64 const problemTime,
                                      bool const isRestart )
 {
-
   MeshLevel const & mesh = domain.getMeshBody( 0 ).getMeshLevel( 0 );
   writeMeshLevel( mesh, cycleNum, problemTime, isRestart );
-
-  if( isRestart )
-  {
-//    siloFile.DBWriteWrapper("m_globalDomainNumber",m_globalDomainNumber);
-  }
-
 }
-
 
 void SiloFile::writeElementMesh( ElementRegionBase const & elementRegion,
                                  NodeManager const & nodeManager,
@@ -1390,7 +1332,6 @@ void SiloFile::writeElementMesh( ElementRegionBase const & elementRegion,
     numElements += subRegion.size();
   } );
 
-  //if( numElements>0 )
   {
     array1d< localIndex * > meshConnectivity( numElementShapes );
     array1d< globalIndex * > globalElementNumbers( numElementShapes );
@@ -1398,7 +1339,6 @@ void SiloFile::writeElementMesh( ElementRegionBase const & elementRegion,
     array1d< integer > shapetype( numElementShapes );
     array1d< integer > shapesize( numElementShapes );
     array1d< char > ghostZoneFlag;
-
 
     std::vector< FixedOneToManyRelation > elementToNodeMap( numElementShapes );
 
@@ -1414,7 +1354,6 @@ void SiloFile::writeElementMesh( ElementRegionBase const & elementRegion,
       elementToNodeMap[count].resize( elementSubRegion.size(), elementSubRegion.numNodesPerElement( 0 ) );
 
       arrayView1d< integer const > const & elemGhostRank = elementSubRegion.ghostRank();
-
 
       string const & elementType = elementSubRegion.getElementTypeString();
       std::vector< int > const & nodeOrdering = elementSubRegion.getVTKNodeOrdering();
@@ -1438,9 +1377,7 @@ void SiloFile::writeElementMesh( ElementRegionBase const & elementRegion,
 
       meshConnectivity[count] = elementToNodeMap[count].data();
 
-      //        globalElementNumbers[count] = elementRegion.localToGlobalMap().data();
       shapecnt[count] = static_cast< int >(elementSubRegion.size());
-
 
       if( !elementType.compare( 0, 4, "C3D8" ) )
       {
@@ -1504,7 +1441,7 @@ void SiloFile::writeElementMesh( ElementRegionBase const & elementRegion,
                        LvArray::integerConversion< int >( numElementShapes ),
                        shapecnt.data(),
                        meshConnectivity.data(),
-                       nullptr /*globalElementNumbers.data()*/,
+                       nullptr,
                        shapetype.data(),
                        shapesize.data(),
                        cycleNumber,
@@ -1539,7 +1476,7 @@ void SiloFile::writeElementMesh( ElementRegionBase const & elementRegion,
                        LvArray::integerConversion< int >( numElementShapes ),
                        shapecnt.data(),
                        meshConnectivity.data(),
-                       nullptr /*globalElementNumbers.data()*/,
+                       nullptr,
                        shapetype.data(),
                        shapesize.data(),
                        cycleNumber,
@@ -1564,7 +1501,7 @@ void SiloFile::writeElementMesh( ElementRegionBase const & elementRegion,
                        LvArray::integerConversion< int >( numElementShapes ),
                        shapecnt.data(),
                        meshConnectivity.data(),
-                       nullptr /*globalElementNumbers.data()*/,
+                       nullptr,
                        shapetype.data(),
                        shapesize.data(),
                        cycleNumber,
@@ -1589,7 +1526,7 @@ void SiloFile::writeElementMesh( ElementRegionBase const & elementRegion,
                        LvArray::integerConversion< int >( numElementShapes ),
                        shapecnt.data(),
                        meshConnectivity.data(),
-                       nullptr /*globalElementNumbers.data()*/,
+                       nullptr,
                        shapetype.data(),
                        shapesize.data(),
                        cycleNumber,
@@ -1609,10 +1546,8 @@ void SiloFile::writeMeshLevel( MeshLevel const & meshLevel,
                                real64 const problemTime,
                                bool const isRestart )
 {
-
   NodeManager const & nodeManager = meshLevel.getNodeManager();
   localIndex const numNodes = nodeManager.size();
-
 
   string const ghostNodeName = "ghostNodeFlag";
   string const ghostZoneName = "ghostZoneFlag";
@@ -1658,8 +1593,6 @@ void SiloFile::writeMeshLevel( MeshLevel const & meshLevel,
   coords[1] = ycoords.data();
   coords[2] = zcoords.data();
 
-
-
   ElementRegionManager const & elementManager = meshLevel.getElemManager();
   elementManager.forElementRegions( [&]( ElementRegionBase const & elemRegion )
   {
@@ -1676,7 +1609,6 @@ void SiloFile::writeMeshLevel( MeshLevel const & meshLevel,
                       problemTime,
                       writeArbitraryPolygon );
   } );
-
 
   if( m_writeFaceMesh )
   {
@@ -1724,8 +1656,6 @@ void SiloFile::writeMeshLevel( MeshLevel const & meshLevel,
                               nodeManager.localToGlobalMap().data(), numFaceTypes,
                               fshapecnt.data(), faceConnectivity.data(), globalFaceNumbers.data(),
                               nullptr, fshapetype.data(), fshapesize.data(), cycleNum, problemTime, lnodelist );
-
-
     }
     else  //The old way
     {
@@ -1752,7 +1682,6 @@ void SiloFile::writeMeshLevel( MeshLevel const & meshLevel,
       std::vector< int > fshapesize( numFaceTypes );
 
       array1d< array2d< localIndex > > faceToNodeMapCopy( numFaceTypes );
-
 
       for( int faceType = 0; faceType < numFaceTypes; ++faceType )
       {
@@ -1877,7 +1806,6 @@ void SiloFile::writeMeshLevel( MeshLevel const & meshLevel,
                     isRestart,
                     localIndex_array());
   }
-
 }
 
 // Arbitrary polygon. Have to deal with this separately
@@ -1896,16 +1824,9 @@ void SiloFile::writePolygonMeshObject( const string & meshName,
                                        const real64 problemTime,
                                        const int lnodelist )
 {
-
   const DBdatatype datatype = DB_DOUBLE;
 
-
-//  DBfacelist* facelist;
-//  string facelistName;
-//  facelistName = meshName + "_facelist";
-
   DBoptlist * optlist = DBMakeOptlist( 4 );
-//  DBAddOption(optlist, DBOPT_NODENUM, const_cast<globalIndex*> (globalNodeNum));
   DBAddOption( optlist, DBOPT_CYCLE, const_cast< int * >(&cycleNumber));
   DBAddOption( optlist, DBOPT_DTIME, const_cast< real64 * >(&problemTime));
 
@@ -1922,7 +1843,6 @@ void SiloFile::writePolygonMeshObject( const string & meshName,
   {
     string zonelistName;
     zonelistName = meshName + "_zonelist";
-
 
     DBPutUcdmesh( m_dbFilePtr, meshName.c_str(), 3, nullptr, (float * *) coords, nnodes, numTotZones,
                   zonelistName.c_str(), nullptr, datatype, optlist );
@@ -1945,14 +1865,8 @@ void SiloFile::writePolygonMeshObject( const string & meshName,
         {
           globalZoneNumber[elemCount++] = globalElementNum[0][j];
         }
-        // write zonelist
-        //      DBAddOption(optlist, DBOPT_ZONENUM, const_cast<globalIndex*> (globalZoneNumber.data()));
-//        if (type_name<globalIndex>::name() == type_name<long long>::name())
-//          DBAddOption(optlist, DBOPT_LLONGNZNUM, const_cast<int*> (&one));
       }
     }
-
-
 
     int hi_offset = 0;
 
@@ -1972,7 +1886,6 @@ void SiloFile::writePolygonMeshObject( const string & meshName,
                     optlist );
 
     DBClearOptlist( optlist );
-
   }
 
   // write multimesh object
@@ -2053,7 +1966,6 @@ void SiloFile::writeWrappersToSilo( string const & meshname,
         this->writeDataField< real64 >( meshname.c_str(),
                                         fieldName,
                                         array,
-//                                      getTensorRankOfArray(array),
                                         centering,
                                         cycleNum,
                                         problemTime,
@@ -2070,7 +1982,6 @@ void SiloFile::writeWrappersToSilo( string const & meshname,
         this->writeDataField< real64 >( meshname.c_str(),
                                         fieldName,
                                         array,
-//                                      getTensorRankOfArray(array),
                                         centering,
                                         cycleNum,
                                         problemTime,
@@ -2110,7 +2021,6 @@ void SiloFile::writeWrappersToSilo( string const & meshname,
     }
   }
 }
-
 
 template< typename CBF >
 void SiloFile::writeMultiXXXX( const DBObjectType type,
@@ -2167,12 +2077,10 @@ void SiloFile::writeMultiXXXX( const DBObjectType type,
                 const_cast< DBoptlist * >(optlist));
 
   DBSetDir( m_dbBaseFilePtr, currentDirectory );
-
 }
 
 
 /**
- *
  * @param meshName
  * @param fieldName
  * @param field
@@ -2189,11 +2097,10 @@ void SiloFile::writeDataField( string const & meshName,
                                real64 const problemTime,
                                string const & multiRoot )
 {
-  int const nvars = SiloFileUtilities::GetNumberOfVariablesInField< TYPE >();
+  int const nvars = siloFileUtilities::GetNumberOfVariablesInField< TYPE >();
   int nels = LvArray::integerConversion< int >( field.size());
 
   int const meshType = getMeshType( meshName );
-
 
   DBoptlist *optlist = DBMakeOptlist( 5 );
   DBAddOption( optlist, DBOPT_CYCLE, const_cast< int * >(&cycleNumber));
@@ -2202,10 +2109,8 @@ void SiloFile::writeDataField( string const & meshName,
   array1d< char const * > varnames( nvars );
   array1d< void * > vars( nvars );
 
-
   string_array varnamestring( nvars );
   array1d< array1d< OUTTYPE > > castedField( nvars );
-
 
   for( int i = 0; i < nvars; ++i )
   {
@@ -2219,7 +2124,7 @@ void SiloFile::writeDataField( string const & meshName,
       vars[i] = static_cast< void * >( (castedField[i]).data() );
       for( int k = 0; k < nels; ++k )
       {
-        castedField[i][k] = SiloFileUtilities::CastField< OUTTYPE >( field[k], i );
+        castedField[i][k] = siloFileUtilities::CastField< OUTTYPE >( field[k], i );
       }
     }
   }
@@ -2237,13 +2142,8 @@ void SiloFile::writeDataField( string const & meshName,
   }
   else
   {
-
-    SiloFileUtilities::SetVariableNames< TYPE >( fieldName, varnamestring, varnames.data() );
-
-
+    siloFileUtilities::SetVariableNames< TYPE >( fieldName, varnamestring, varnames.data() );
     int err = -2;
-//    if( meshType == DB_UCDMESH )
-//    {
     err = DBPutUcdvar( m_dbFilePtr,
                        fieldName.c_str(),
                        meshName.c_str(),
@@ -2253,21 +2153,9 @@ void SiloFile::writeDataField( string const & meshName,
                        nels,
                        nullptr,
                        0,
-                       SiloFileUtilities::DB_TYPE< OUTTYPE >(),
+                       siloFileUtilities::DB_TYPE< OUTTYPE >(),
                        centering,
                        optlist );
-//    }
-//    else if( meshType == DB_POINTMESH )
-//    {
-//      err = DBPutPointvar( m_dbFilePtr,
-//                           fieldName.c_str(),
-//                           meshName.c_str(),
-//                           nvars,
-//                           reinterpret_cast<float**>(vars.data()),
-//                           nels,
-//                           SiloFileUtilities::DB_TYPE<OUTTYPE>(),
-//                           optlist);
-//    }
     if( err < 0 )
     {
       if( err < -1 )
@@ -2288,7 +2176,7 @@ void SiloFile::writeDataField( string const & meshName,
 #endif
   if( rank == 0 )
   {
-    int tensorRank = SiloFileUtilities::GetTensorRank< TYPE >();
+    int tensorRank = siloFileUtilities::GetTensorRank< TYPE >();
     DBAddOption( optlist, DBOPT_TENSOR_RANK, const_cast< int * >(&tensorRank));
     DBAddOption( optlist, DBOPT_MMESH_NAME, const_cast< char * >(meshName.c_str()));
 
@@ -2311,13 +2199,11 @@ void SiloFile::writeDataField( string const & meshName,
       vartype = DB_UCDVAR;
     }
 
-
     writeMultiXXXX( vartype, DBPutMultivar, centering, fieldName.c_str(), cycleNumber, multiRoot,
                     optlist );
   }
 
   DBFreeOptlist( optlist );
-
 }
 
 template< typename OUTTYPE, typename TYPE, int USD >
@@ -2341,6 +2227,7 @@ void SiloFile::writeDataField( string const & meshName,
   for( localIndex ivar = 0; ivar < nvar; ++ivar )
   {
     indices[secondaryDimIndex] = ivar;
+
     // make a copy of the ivar'th slice of data
     for( localIndex ip = 0; ip < npts; ++ip )
     {
@@ -2383,6 +2270,7 @@ void SiloFile::writeDataField( string const & meshName,
     for( localIndex jvar = 0; jvar < nvar2; ++jvar )
     {
       indices[secondaryDimIndex2] = jvar;
+
       // make a copy of the ivar/jvar'th slice of data
       for( localIndex ip = 0; ip < npts; ++ip )
       {
@@ -2399,7 +2287,6 @@ void SiloFile::writeDataField( string const & meshName,
     }
   }
 }
-
 
 template< typename OUTTYPE, typename TYPE, int USD >
 void createSiloVarArrays( ArrayView< TYPE const, 1, USD > const & field,
@@ -2449,7 +2336,6 @@ void createSiloVarArrays( ArrayView< TYPE const, 3, USD > const & field,
   }
 }
 
-
 template< typename OUTTYPE, typename TYPE, int NDIM, int USD >
 void SiloFile::writeDataField( string const & meshName,
                                string const & fieldName,
@@ -2494,8 +2380,6 @@ void SiloFile::writeDataField( string const & meshName,
   }
   else
   {
-
-
     varnamestring.resize( nvars );
     for( int i=0; i<nvars; ++i )
     {
@@ -2503,12 +2387,10 @@ void SiloFile::writeDataField( string const & meshName,
       varnames[i] = const_cast< char * >( varnamestring[i].c_str() );
     }
 
-    SiloFileUtilities::SetVariableNames< TYPE >( fieldName, varnamestring, varnames.data() );
-
+    siloFileUtilities::SetVariableNames< TYPE >( fieldName, varnamestring, varnames.data() );
 
     int err = -2;
-//    if( meshType == DB_UCDMESH )
-//    {
+
     err = DBPutUcdvar( m_dbFilePtr,
                        fieldName.c_str(),
                        meshName.c_str(),
@@ -2518,21 +2400,10 @@ void SiloFile::writeDataField( string const & meshName,
                        nels,
                        nullptr,
                        0,
-                       SiloFileUtilities::DB_TYPE< OUTTYPE >(),
+                       siloFileUtilities::DB_TYPE< OUTTYPE >(),
                        centering,
                        optlist );
-//    }
-//    else if( meshType == DB_POINTMESH )
-//    {
-//      err = DBPutPointvar( m_dbFilePtr,
-//                           fieldName.c_str(),
-//                           meshName.c_str(),
-//                           nvars,
-//                           reinterpret_cast<float**>(vars.data()),
-//                           nels,
-//                           SiloFileUtilities::DB_TYPE<OUTTYPE>(),
-//                           optlist);
-//    }
+
     if( err < 0 )
     {
       if( err < -1 )
@@ -2553,8 +2424,6 @@ void SiloFile::writeDataField( string const & meshName,
 #endif
   if( rank == 0 )
   {
-//    int tensorRank = siloTensorRank;
-//    DBAddOption(optlist, DBOPT_TENSOR_RANK, const_cast<int*> (&tensorRank));
     DBAddOption( optlist, DBOPT_MMESH_NAME, const_cast< char * >(meshName.c_str()));
 
     DBObjectType vartype = DB_INVALID_OBJECT;
@@ -2576,15 +2445,12 @@ void SiloFile::writeDataField( string const & meshName,
       vartype = DB_UCDVAR;
     }
 
-
     writeMultiXXXX( vartype, DBPutMultivar, centering, fieldName.c_str(), cycleNumber, multiRoot,
                     optlist );
   }
 
   DBFreeOptlist( optlist );
-
 }
-
 
 template< typename OUTTYPE, typename TYPE >
 void SiloFile::writeMaterialDataField2d( string const & meshName,
@@ -2651,14 +2517,12 @@ void SiloFile::writeMaterialDataField( string const & meshName,
                                        string const & multiRoot,
                                        string_array const & materialNames )
 {
-  int const nvars = SiloFileUtilities::GetNumberOfVariablesInField< TYPE >();
+  int const nvars = siloFileUtilities::GetNumberOfVariablesInField< TYPE >();
   int const meshType = getMeshType( meshName );
 
-//  double missingValue = 0.0;
   DBoptlist *optlist = DBMakeOptlist( 5 );
   DBAddOption( optlist, DBOPT_CYCLE, const_cast< int * >(&cycleNumber));
   DBAddOption( optlist, DBOPT_DTIME, const_cast< real64 * >(&problemTime));
-//  DBAddOption(optlist, DBOPT_MISSING_VALUE, &missingValue);
 
   char * regionpnames[ 100 ];
 
@@ -2684,7 +2548,7 @@ void SiloFile::writeMaterialDataField( string const & meshName,
     string_array varnamestring( nvars );
     array1d< char const * > varnames( nvars );
 
-    SiloFileUtilities::SetVariableNames< TYPE >( fieldName, varnamestring, varnames.data() );
+    siloFileUtilities::SetVariableNames< TYPE >( fieldName, varnamestring, varnames.data() );
 
     int nels = 0;
     localIndex mixlen = 0;
@@ -2731,8 +2595,8 @@ void SiloFile::writeMaterialDataField( string const & meshName,
             mixvarsData[i][mixlen2[i]] = 0;
             for( localIndex q=0; q < numQ; ++q )
             {
-              varsData[i][nels2[i]] += SiloFileUtilities::CastField< OUTTYPE >( field[esr][0][k][q], i );
-              mixvarsData[i][mixlen2[i]] += SiloFileUtilities::CastField< OUTTYPE >( field[esr][0][k][q], i );
+              varsData[i][nels2[i]] += siloFileUtilities::CastField< OUTTYPE >( field[esr][0][k][q], i );
+              mixvarsData[i][mixlen2[i]] += siloFileUtilities::CastField< OUTTYPE >( field[esr][0][k][q], i );
             }
             varsData[i][nels2[i]] /= numQ;
             mixvarsData[i][mixlen2[i]] /= numQ;
@@ -2756,7 +2620,7 @@ void SiloFile::writeMaterialDataField( string const & meshName,
                 mixvarsData[i][mixlen2[i]] = 0;
                 for( localIndex q=0; q < numQ; ++q )
                 {
-                  mixvarsData[i][mixlen2[i]] = SiloFileUtilities::CastField< OUTTYPE >( field[esr][a][k][q], i );
+                  mixvarsData[i][mixlen2[i]] = siloFileUtilities::CastField< OUTTYPE >( field[esr][a][k][q], i );
                 }
                 mixvarsData[i][mixlen2[i]] /= numQ;
                 ++mixlen2[i];
@@ -2773,7 +2637,7 @@ void SiloFile::writeMaterialDataField( string const & meshName,
               varsData[i][nels2[i]] = 0;
               for( localIndex q=0; q < numQ; ++q )
               {
-                varsData[i][nels2[i]] += SiloFileUtilities::CastField< OUTTYPE >( field[esr][0][k][q], i );
+                varsData[i][nels2[i]] += siloFileUtilities::CastField< OUTTYPE >( field[esr][0][k][q], i );
               }
               varsData[i][nels2[i]] /= numQ;
               ++nels2[i];
@@ -2795,8 +2659,7 @@ void SiloFile::writeMaterialDataField( string const & meshName,
     DBAddOption( optlist, DBOPT_REGION_PNAMES, &regionpnames );
 
     int err = -2;
-//    if( meshType == DB_UCDMESH )
-//    {
+
     err = DBPutUcdvar( m_dbFilePtr,
                        fieldName.c_str(),
                        meshName.c_str(),
@@ -2806,21 +2669,10 @@ void SiloFile::writeMaterialDataField( string const & meshName,
                        nels,
                        mixvars.data(),
                        mixlen,
-                       SiloFileUtilities::DB_TYPE< OUTTYPE >(),
+                       siloFileUtilities::DB_TYPE< OUTTYPE >(),
                        centering,
                        optlist );
-//    }
-//    else if( meshType == DB_POINTMESH )
-//    {
-//      err = DBPutPointvar( m_dbFilePtr,
-//                           fieldName.c_str(),
-//                           meshName.c_str(),
-//                           nvars,
-//                           vars.data(),
-//                           nels,
-//                           SiloFileUtilities::DB_TYPE<OUTTYPE>(),
-//                           optlist);
-//    }
+
     if( err < 0 )
     {
       if( err < -1 )
@@ -2841,7 +2693,7 @@ void SiloFile::writeMaterialDataField( string const & meshName,
 #endif
   if( rank == 0 )
   {
-    int tensorRank = SiloFileUtilities::GetTensorRank< TYPE >();
+    int tensorRank = siloFileUtilities::GetTensorRank< TYPE >();
     DBAddOption( optlist, DBOPT_TENSOR_RANK, const_cast< int * >(&tensorRank));
     DBAddOption( optlist, DBOPT_MMESH_NAME, const_cast< char * >(meshName.c_str()));
 
@@ -2862,7 +2714,6 @@ void SiloFile::writeMaterialDataField( string const & meshName,
     else
     {
       vartype = DB_UCDVAR;
-//      GEOSX_ERROR("unhandled case in SiloFile::WriteDataField B\n");
     }
 
     writeMultiXXXX( vartype, DBPutMultivar, centering, fieldName.c_str(), cycleNumber, multiRoot,
@@ -3183,8 +3034,6 @@ void SiloFile::writeVectorVarDefinition( string const & fieldName,
 
     DBSetDir( m_dbBaseFilePtr, ".." );
   }
-
-
 }
 
 
@@ -3215,5 +3064,5 @@ int SiloFile::getMeshType( string const & meshName ) const
   return meshType;
 }
 
-}
+} /* namespace geosx */
 #pragma GCC diagnostic pop

--- a/src/coreComponents/fileIO/silo/SiloFile.cpp
+++ b/src/coreComponents/fileIO/silo/SiloFile.cpp
@@ -1131,7 +1131,7 @@ void SiloFile::writeGroupSilo( Group const & group,
                                bool const isRestart,
                                const localIndex_array & mask )
 {
-  string subDirectory = siloDirName;
+  //string subDirectory = siloDirName;
   string rootDirectory = "/" + siloDirName;
 
   {
@@ -1897,6 +1897,7 @@ int getTensorRankOfArray( ArrayView< TYPE const, NDIM, USD > const & field )
   return rval;
 }
 
+
 template< typename OUTPUTTYPE >
 void SiloFile::writeWrappersToSilo( string const & meshname,
                                     const dataRepository::Group::wrapperMap & wrappers,
@@ -1925,7 +1926,7 @@ void SiloFile::writeWrappersToSilo( string const & meshname,
       {
         auto const & wrapperT = dynamic_cast< dataRepository::Wrapper< array1d< real64 > > const & >( *wrapper );
 
-        this->writeDataField< real64 >( meshname.c_str(), 
+        this->writeDataField< OUTPUTTYPE >( meshname.c_str(), 
                                         fieldName,
                                         wrapperT.reference(), 
                                         centering, 
@@ -2789,6 +2790,7 @@ void SiloFile::writeMaterialDataField3d( string const & meshName,
         component = "12";
       }
     }
+
     string componentFieldName = fieldName + "_" + component;
     writeMaterialDataField< real64 >( meshName,
                                       componentFieldName,
@@ -2888,6 +2890,7 @@ void SiloFile::writeStressVarDefinition( string const & MatDir )
     const char * expObjName = expressionName.c_str();
     const char * const names[1] = { expObjName };
     int const types[1] = { DB_VARTYPE_TENSOR };
+
     string const definition = "{{<"+ MatDir + "/stress_11>,<"+ MatDir + "/stress_12>,<"+ MatDir + "/stress_13>},"
                                                                                                   "{<"+ MatDir + "/stress_12>,<"+ MatDir + "/stress_22>,<"+ MatDir + "/stress_23>},"
                                                                                                                                                                      "{<"+ MatDir + "/stress_13>,<"+
@@ -2994,8 +2997,11 @@ void SiloFile::writeVectorVarDefinition( string const & fieldName,
       const char * expObjName = expressionName.c_str();
       const char * const names[1] = { expObjName };
       int const types[1] = { DB_VARTYPE_VECTOR };
-      string const definition = "{<"+ subDirectory + "/" + fieldName + "_0>,<"+ subDirectory + "/" + fieldName + "_1>,<"+ subDirectory + "/" + fieldName +
-                                "_2>}";
+
+      string const definition = "{<"+ subDirectory + "/" + fieldName + "_0>,"
+                                 "<"+ subDirectory + "/" + fieldName + "_1>,"
+                                 "<"+ subDirectory + "/" + fieldName + "_2>}";
+
       const char * const defns[1] = { definition.c_str() };
       DBPutDefvars( m_dbBaseFilePtr,
                     expObjName,

--- a/src/coreComponents/fileIO/silo/SiloFile.cpp
+++ b/src/coreComponents/fileIO/silo/SiloFile.cpp
@@ -1274,6 +1274,9 @@ void SiloFile::writeElementRegionSilo( ElementRegionBase const & elemRegion,
 
         std::type_info const & typeID = wrapper->getTypeId();
 
+        if( typeID == typeid( array1d< real64 > ) ||
+            typeID == typeid( array2d< real64 > ) )
+        {
         rtTypes::applyArrayTypeLambda2( rtTypes::typeID( typeID ),
                                         false,
                                         [&]( auto array, auto GEOSX_UNUSED_PARAM( Type ) )
@@ -1287,6 +1290,7 @@ void SiloFile::writeElementRegionSilo( ElementRegionBase const & elemRegion,
           arrayType & newarray = newWrapper.reference();
           newarray.resize( arrayType::NDIM, sourceArray.dims() );
         } );
+        }
       }
     }
   } );

--- a/src/coreComponents/fileIO/silo/SiloFile.hpp
+++ b/src/coreComponents/fileIO/silo/SiloFile.hpp
@@ -288,6 +288,7 @@ public:
                       real64 const problemTime );
 
   /**
+   * @brief write material fields
    * @param elementRegion the element region that holds the data to be written to the silo file
    * @param meshName name of the mesh to write
    * @param regionMaterialList  region material list
@@ -319,6 +320,7 @@ public:
                        const localIndex_array & mask );
 
   /**
+   * @brief write element fields
    * @param elemRegion the element region that holds the data to be written to the silo file
    * @param siloDirName the name of the silo directory to put this data into (i.e. nodalFields, elemFields)
    * @param meshName the name of the mesh attach this write to

--- a/src/coreComponents/fileIO/silo/SiloFile.hpp
+++ b/src/coreComponents/fileIO/silo/SiloFile.hpp
@@ -38,18 +38,8 @@ typedef _PMPIO_baton_t PMPIO_baton_t;
 namespace geosx
 {
 
-class DomainPartition;
-class MeshLevel;
-
-namespace constitutive
-{
-class ConstitutiveManager;
-}
-
-// *********************************************************************************************************************
-// *********************************************************************************************************************
 /**
- * This class serves as a wrapper to isolate the code from the specifics of SILO
+ * This class serves as a wrapper to isolate the code from the specifics of SILO 
  * output/input. Its members contain all the necessary information for reading/writing a group of SILO files.
  */
 class SiloFile
@@ -61,7 +51,7 @@ public:
   SiloFile();
 
   /// Destructor
-  virtual ~SiloFile();
+  virtual ~SiloFile() = default;
 
   /**
    * @brief function to setup directories where silo files will be written
@@ -72,7 +62,7 @@ public:
    * @brief Initializes silo for input/output
    * @param numGroups number of individual Silo files to generate
    */
-  void initialize( int const numGroups=1 );
+  void initialize( int const numGroups = 1 );
 
   /**
    * @brief finishes/closes up the silo interface
@@ -123,14 +113,11 @@ public:
   {
     int const rank = MpiWrapper::commRank( MPI_COMM_GEOSX );
 
-    // char dirname[100];
     if( rank == 0 )
     {
-//      DBGetDir(m_dbBaseFilePtr, dirname );
       DBMkDir( m_dbBaseFilePtr, rootdir.c_str());
     }
 
-//    DBGetDir (m_dbFilePtr, dirname );
     DBMkDir( m_dbFilePtr, subdir.c_str());
   }
 
@@ -313,7 +300,6 @@ public:
                                      int const cycleNumber,
                                      real64 const problemTime );
   /**
-   *
    * @param group the group that holds the data to be written to the silo file
    * @param siloDirName the name of the silo directory to put this data into (i.e. nodalFields, elemFields)
    * @param meshname the name of the mesh attach this write to
@@ -369,7 +355,6 @@ public:
                             const localIndex_array & mask );
 
   /**
-   *
    * @param meshName the name of the mesh attach this write to
    * @param fieldName name of the field to write
    * @param field field data
@@ -388,7 +373,6 @@ public:
                        string const & multiRoot );
 
   /**
-   *
    * @param meshName the name of the mesh attach this write to
    * @param fieldName name of the field to write
    * @param field field data
@@ -583,7 +567,6 @@ public:
   /**
    * function to clear any empty multi-objects
    * @param cycleNum
-   *
    * When we write our multimesh and multivar objects, we do it assuming that there is a non-empty multimesh
    * or multivar object on each domain. This is incorrect, so we must modify the rootfile to remove empty references
    * to the multivar or multimesh objects and replace their path with "EMPTY"
@@ -693,12 +676,15 @@ private:
   string m_baseFileName;
 
   std::vector< string > m_emptyMeshes;
-//  string_array m_emptyMaterials;
+
   std::vector< string > m_emptyVariables;
 
   integer m_writeEdgeMesh;
+
   integer m_writeFaceMesh;
+
   integer m_writeCellElementMesh;
+
   integer m_writeFaceElementMesh;
 
   dataRepository::PlotLevel m_plotLevel;
@@ -709,7 +695,7 @@ private:
 /**
  * Namespace to hold some utilities needed by the functions in SiloFile.
  */
-namespace SiloFileUtilities
+namespace siloFileUtilities
 {
 /**
  * @tparam OUTTYPE the type of data to write out (int,float,real64)
@@ -864,10 +850,8 @@ template<> inline float CastField< float, real64 >( const real64 & field, int co
 template< typename TYPE >
 void SetVariableNames( string const & fieldName, string_array & varnamestring, char const * varnames[] );
 
+} /* namespace siloFileUtilities */
 
-}
+} /* namespace geosx */
 
-
-
-}
 #endif /* GEOSX_FILEIO_SILO_SILOFILE_HPP_ */


### PR DESCRIPTION
Silo output is actually kind of a mess because of the issues listed below. This PR aims to improve this.
- [x] Redundant output stresses components for all the Gauss points in `ElementFields` (see Fig 1a). 
- [x] Similar redundant outputs can be found there for density and viscosity, etc (Fig. 1b). Also, a density_magnitude was accidently calculated, i.e. the density is wrongly considered as a vector. This issue can be also observed for other scalar properties such as viscosity, ....
- [ ] Output fields are not well located: stress components `sigma_11`, `sigma_22`, etc. should be placed in `ElementFields`, but actually they are placed in `MaterialFields` (see Fig. 2). Also, important element field as strain is missing.
- [ ] Other redundant outputs in mesh_quality, operators, time_derivative (see Fig. 3): they do not have any use and some of them cannot be plotted.
- [ ] The code in SiloFile.cpp/hpp itself contains a lot of zombie code, TODO, "hack", etc. They need to be cleaned/completed.
- [x] Solid material properties such as Bulk modulus, Shear modulus, stiffnesses Cij are missing. After setup a model with heterogeneous properties, it is important to plot these properties to verify if the setting is correct. But actually it is not possible to plot for example the Bulk modulus. The right location for these properties is in `MaterialFields`
- [ ] Similar plot for other coupling parameters that are defined as heterogeneous
- [ ] Output fluid velocity is missing, this data is important to visualize local fluid flow. For example, we want to observe if fluid is flowing from a reservoir to a wellbore (see issue #1370 ).

**Fig. 1: Redundant stress output**

![image](https://user-images.githubusercontent.com/45685596/112606968-f70b3c00-8e18-11eb-923b-212309042e3f.png)

**Fig. 1b: Redundant density output for all the Gauss points**

![image](https://user-images.githubusercontent.com/45685596/112613171-18bbf180-8e20-11eb-9062-13933dceb16a.png)

**Fig.2: Stress components are placed in `MaterialFields`**

![image](https://user-images.githubusercontent.com/45685596/112607657-bcee6a00-8e19-11eb-8a33-d9120f694095.png)

**Fig. 3: Other redundant outputs**

![image](https://user-images.githubusercontent.com/45685596/112608584-c88e6080-8e1a-11eb-8f25-93c96c6c2c0b.png)
