### PR TITLE
Reducing visibility of neighborRank in NeighborCommunicator

### DIFF
--- a/src/coreComponents/mpiCommunications/NeighborCommunicator.cpp
+++ b/src/coreComponents/mpiCommunications/NeighborCommunicator.cpp
@@ -12,25 +12,19 @@
  * ------------------------------------------------------------------------------------------------------------
  */
 
-/**
- * @file NeighborCommunicator.cpp
- *
- */
-
 #include "mpiCommunications/NeighborCommunicator.hpp"
 
 #include "common/TimingMacros.hpp"
 #include "managers/ObjectManagerBase.hpp"
 #include "mesh/MeshLevel.hpp"
-#include <sys/time.h>
 
 namespace geosx
 {
 
 using namespace dataRepository;
 
-NeighborCommunicator::NeighborCommunicator():
-  m_neighborRank( -1 ),
+NeighborCommunicator::NeighborCommunicator( int rank ):
+  m_neighborRank( rank ),
   m_sendBufferSize(),
   m_receiveBufferSize(),
   m_sendBuffer{ maxComm },

--- a/src/coreComponents/mpiCommunications/NeighborCommunicator.hpp
+++ b/src/coreComponents/mpiCommunications/NeighborCommunicator.hpp
@@ -12,10 +12,6 @@
  * ------------------------------------------------------------------------------------------------------------
  */
 
-/**
- * @file NeighborCommunicator.hpp
- */
-
 #ifndef GEOSX_MPICOMMUNICATIONS_NEIGHBORCOMMUNICATOR_HPP_
 #define GEOSX_MPICOMMUNICATIONS_NEIGHBORCOMMUNICATOR_HPP_
 
@@ -39,16 +35,14 @@ inline int CommTag( int const GEOSX_UNUSED_PARAM( senderRank ),
 }
 
 class MeshLevel;
-class ObjectManagerBase;
 class NeighborCommunicator
 {
 public:
 
-  NeighborCommunicator();
+  explicit NeighborCommunicator( int rank );
 
-  NeighborCommunicator( int rank ):
-    NeighborCommunicator()
-  { setNeighborRank( rank ); }
+  NeighborCommunicator():
+    NeighborCommunicator( -1 ){};
 
   void mpiISendReceive( buffer_unit_type const * const sendBuffer,
                         int const sendSize,
@@ -286,7 +280,6 @@ public:
                             bool onDevice,
                             parallelDeviceEvents & events );
 
-  void setNeighborRank( int const rank ) { m_neighborRank = rank; }
   int neighborRank() const { return m_neighborRank; }
 
   void clear();
@@ -310,7 +303,6 @@ public:
   {
     return m_receiveBufferSize[commID];
   }
-
 
   buffer_type const & sendBuffer( int commID ) const
   {
@@ -336,6 +328,7 @@ public:
   void addNeighborGroupToMesh( MeshLevel & mesh ) const;
 
 private:
+
   int m_neighborRank;
 
   int m_sendBufferSize[maxComm];

--- a/src/coreComponents/mpiCommunications/SpatialPartition.hpp
+++ b/src/coreComponents/mpiCommunications/SpatialPartition.hpp
@@ -15,10 +15,9 @@
 #ifndef GEOSX_MPICOMMUNICATIONS_SPATIALPARTITION_HPP_
 #define GEOSX_MPICOMMUNICATIONS_SPATIALPARTITION_HPP_
 
-#include <map>
-
 #include "mpiCommunications/PartitionBase.hpp"
 
+#include <map>
 
 constexpr int nsdof = 3;
 namespace geosx
@@ -33,24 +32,11 @@ public:
   SpatialPartition();
   virtual ~SpatialPartition();
 
-//  void ReadXML( xmlWrapper::xmlNode const & targetNode );
-
-/**
- * @brief Initialise Metis partitioning.
- *
- * @note Unused
- */
-  virtual void initializeMetis();
-
-  /**
-   * @brief Adds some neighbors to the neighbor communicators.
-   * @param neighborList The neighbors to add.
-   */
-  void addNeighborsMetis( SortedArray< globalIndex > & neighborList );
   virtual bool isCoordInPartition( const real64 & coord, const int dir );
   virtual bool isCoordInPartition( real64 const ( &coordinates )[ 3 ] );
   virtual bool isCoordInPartition( real64 const ( &coordinates )[ 3 ],
                                    const int numDistPartition );
+
   /**
    * @brief Variant of IsCoordInPartition with intervals closed at both ends
    * @param coordinates The point coordinates.
@@ -73,9 +59,6 @@ public:
 
   void setSizes( real64 const ( &min )[ 3 ],
                  real64 const ( &max )[ 3 ] );
-
-//  void setGlobalDomainSizes( real64 const ( & min )[ 3 ],
-//                             real64 const ( & max )[ 3 ] );
 
   /**
    * @brief Defines the boundaries of the partition
@@ -115,16 +98,6 @@ public:
   }
 
   virtual void setContactGhostRange( const real64 bufferSize );
-
-//  virtual void ResetSinglePartitionGlobalToLocalMap(PhysicalDomainT& domain);
-
-//  virtual void SetPeriodicDomainBoundaryObjects(PhysicalDomainT& domain);
-//  virtual void CorrectReferencePositionsForPeriodicBoundaries(
-//      PhysicalDomainT& domain);
-
-//  void CreateSinglePartitionGhostObjects(PhysicalDomainT& domain,
-//      const bool contactActive, const int elementGhostingDepth);
-//  void SetSinglePartitionGhostArrays(PhysicalDomainT& domain);
 
   int getColor();
 


### PR DESCRIPTION
Reducing visibility of `m_neighborRank`.
Inverting `NeighborCommunicator`'s constructor dependency.

`m_neighborRank` could be modified by a public setter while it's unnecessary.
Generic constructor of `NeighborCommunicator` was depending on specialized constructor: dependency inverted.
Remove useless forward declarations.
Deleted commented code.