### PR TITLE
Consider the effect of confining stress on SIF calculation

### DIFF
--- a/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
@@ -3044,6 +3044,11 @@ void SurfaceGenerator::calculateNodeAndFaceSif( DomainPartition & domain,
           tipNodeSIF = pow( (fabs( tipNodeForce[0] * trailingNodeDisp[0] / 2.0 / tipArea ) + fabs( tipNodeForce[1] * trailingNodeDisp[1] / 2.0 / tipArea )
                              + fabs( tipNodeForce[2] * trailingNodeDisp[2] / 2.0 / tipArea )), 0.5 );
 
+          if ( LvArray::tensorOps::AiBi< 3 >( trailingNodeDisp, faceNormalVector ) < 0.0)  //In case the aperture is negative with the presence of confining stress.
+          {
+            tipNodeSIF *= -1;
+          }
+
           SIFNode_All[nodeIndex].emplace_back( tipNodeSIF );
 
 

--- a/src/coreComponents/schema/docs/BlackOilFluid_other.rst
+++ b/src/coreComponents/schema/docs/BlackOilFluid_other.rst
@@ -1,0 +1,33 @@
+
+
+====================================== ============================================================================================== ========================== 
+Name                                   Type                                                                                           Description                
+====================================== ============================================================================================== ========================== 
+dPhaseCompFraction_dGlobalCompFraction LvArray_Array< double, 5, camp_int_seq< long, 0l, 1l, 2l, 3l, 4l >, long, LvArray_ChaiBuffer > (no description available) 
+dPhaseCompFraction_dPressure           LvArray_Array< double, 4, camp_int_seq< long, 0l, 1l, 2l, 3l >, long, LvArray_ChaiBuffer >     (no description available) 
+dPhaseCompFraction_dTemperature        LvArray_Array< double, 4, camp_int_seq< long, 0l, 1l, 2l, 3l >, long, LvArray_ChaiBuffer >     (no description available) 
+dPhaseDensity_dGlobalCompFraction      LvArray_Array< double, 4, camp_int_seq< long, 0l, 1l, 2l, 3l >, long, LvArray_ChaiBuffer >     (no description available) 
+dPhaseDensity_dPressure                real64_array3d                                                                                 (no description available) 
+dPhaseDensity_dTemperature             real64_array3d                                                                                 (no description available) 
+dPhaseFraction_dGlobalCompFraction     LvArray_Array< double, 4, camp_int_seq< long, 0l, 1l, 2l, 3l >, long, LvArray_ChaiBuffer >     (no description available) 
+dPhaseFraction_dPressure               real64_array3d                                                                                 (no description available) 
+dPhaseFraction_dTemperature            real64_array3d                                                                                 (no description available) 
+dPhaseMassDensity_dGlobalCompFraction  LvArray_Array< double, 4, camp_int_seq< long, 0l, 1l, 2l, 3l >, long, LvArray_ChaiBuffer >     (no description available) 
+dPhaseMassDensity_dPressure            real64_array3d                                                                                 (no description available) 
+dPhaseMassDensity_dTemperature         real64_array3d                                                                                 (no description available) 
+dPhaseViscosity_dGlobalCompFraction    LvArray_Array< double, 4, camp_int_seq< long, 0l, 1l, 2l, 3l >, long, LvArray_ChaiBuffer >     (no description available) 
+dPhaseViscosity_dPressure              real64_array3d                                                                                 (no description available) 
+dPhaseViscosity_dTemperature           real64_array3d                                                                                 (no description available) 
+dTotalDensity_dGlobalCompFraction      real64_array3d                                                                                 (no description available) 
+dTotalDensity_dPressure                real64_array2d                                                                                 (no description available) 
+dTotalDensity_dTemperature             real64_array2d                                                                                 (no description available) 
+phaseCompFraction                      LvArray_Array< double, 4, camp_int_seq< long, 0l, 1l, 2l, 3l >, long, LvArray_ChaiBuffer >     (no description available) 
+phaseDensity                           real64_array3d                                                                                 (no description available) 
+phaseFraction                          real64_array3d                                                                                 (no description available) 
+phaseMassDensity                       real64_array3d                                                                                 (no description available) 
+phaseViscosity                         real64_array3d                                                                                 (no description available) 
+totalDensity                           real64_array2d                                                                                 (no description available) 
+useMass                                integer                                                                                        (no description available) 
+====================================== ============================================================================================== ========================== 
+
+


### PR DESCRIPTION
In the presence of confining stress, a negative aperture might be possible in the SIF calculation of the SurfaceGenerator.cpp. Since the SIF equation (tipNodeSIF = pow( (fabs...) always give a positive value, the SIF will be extremely large under high confining stress, and the fracture will propagate, which is unphysical.

We manually multiply the SIF by -1 in case of negative aperture to avoid fracture propagation under very high confining stress.