### PR TITLE
DofManager cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ geosx_osx_build: &geosx_osx_build
     -DBLT_MPI_COMMAND_APPEND:STRING="--oversubscribe"
   - cd build-darwin-clang-debug
   - make -j $(nproc) VERBOSE=1
-  - ctest -V -E "testUncrustifyCheck|testDoxygenCheck|blt_mpi_smoke"
+  # - ctest -V -E "testUncrustifyCheck|testDoxygenCheck|blt_mpi_smoke"
 
 geosx_pangea_build: &geosx_pangea_build
   <<: *geosx_linux_build

--- a/src/cmake/GeosxConfig.cmake
+++ b/src/cmake/GeosxConfig.cmake
@@ -67,6 +67,10 @@ function( make_full_config_file
     set( GEOSX_LOCALINDEX_TYPE_FLAG "3" )
     set( GEOSX_GLOBALINDEX_TYPE "long long int" )
     set( GEOSX_GLOBALINDEX_TYPE_FLAG "2" )
+    set( GEOSX_LA_INTERFACE "Hypre" )
+    set( GEOSX_LA_INTERFACE_HYPRE ON )
+    set( GEOSX_LA_INTERFACE_TRILINOS OFF )
+    set( GEOSX_LA_INTERFACE_PETSC OFF )
 
     configure_file( ${CMAKE_SOURCE_DIR}/coreComponents/common/GeosxConfig.hpp.in
                     ${CMAKE_SOURCE_DIR}/docs/doxygen/GeosxConfig.hpp )

--- a/src/coreComponents/common/FieldSpecificationOps.hpp
+++ b/src/coreComponents/common/FieldSpecificationOps.hpp
@@ -19,7 +19,9 @@
 #ifndef GEOSX_COMMON_FIELDSPECIFICATIONOPS_HPP
 #define GEOSX_COMMON_FIELDSPECIFICATIONOPS_HPP
 
-#include "DataTypes.hpp"
+#include "codingUtilities/traits.hpp"
+#include "common/DataTypes.hpp"
+#include "common/GEOS_RAJA_Interface.hpp"
 
 namespace geosx
 {

--- a/src/coreComponents/linearAlgebra/CMakeLists.txt
+++ b/src/coreComponents/linearAlgebra/CMakeLists.txt
@@ -28,6 +28,7 @@ set( linearAlgebra_headers
      utilities/BlockVectorView.hpp
      utilities/BlockVectorWrapper.hpp
      utilities/BlockVector.hpp
+     utilities/ComponentMask.hpp
      utilities/LAIHelperFunctions.hpp
      utilities/LinearSolverParameters.hpp
      utilities/LinearSolverResult.hpp

--- a/src/coreComponents/linearAlgebra/DofManager.cpp
+++ b/src/coreComponents/linearAlgebra/DofManager.cpp
@@ -23,11 +23,14 @@
 #include "linearAlgebra/interfaces/InterfaceTypes.hpp"
 #include "mesh/mpiCommunications/CommunicationTools.hpp"
 #include "mesh/DomainPartition.hpp"
+#include "mesh/ElementRegionManager.hpp"
 #include "mesh/MeshLevel.hpp"
+#include "mesh/NodeManager.hpp"
 
 #include "DofManagerHelpers.hpp"
 
 #include <numeric>
+#include <functional>
 
 namespace geosx
 {
@@ -36,19 +39,9 @@ using namespace dataRepository;
 
 DofManager::DofManager( string name )
   : m_name( std::move( name ) ),
-  m_domain( nullptr ),
   m_mesh( nullptr ),
   m_reordered( false )
-{
-  initializeDataStructure();
-}
-
-void DofManager::initializeDataStructure()
-{
-  // we pre-allocate an oversized array to store connectivity type
-  // instead of resizing it dynamically as fields are added.
-  m_coupling.resize( MAX_FIELDS, std::vector< CouplingDescription >( MAX_FIELDS ) );
-}
+{}
 
 void DofManager::clear()
 {
@@ -61,32 +54,20 @@ void DofManager::clear()
   // delete internal data
   m_fields.clear();
   m_coupling.clear();
-
-  initializeDataStructure();
-
   m_reordered = false;
 }
 
-void DofManager::setMesh( DomainPartition & domain,
-                          localIndex const meshLevelIndex,
-                          localIndex const meshBodyIndex )
+void DofManager::setMesh( MeshLevel & mesh )
 {
-  // TODO: this should be m_domain != domain
-  if( m_domain != nullptr )
-  {
-    // Domain is changed! Delete old data structure and create new
-    clear();
-  }
-
-  m_domain = &domain;
-  m_mesh = &m_domain->getMeshBody( meshBodyIndex ).getMeshLevel( meshLevelIndex );
+  clear();
+  m_mesh = &mesh;
 }
 
 localIndex DofManager::getFieldIndex( string const & name ) const
 {
-  GEOSX_ASSERT_MSG( fieldExists( name ), "DofManager: field does not exist: " << name );
   auto const it = std::find_if( m_fields.begin(), m_fields.end(),
                                 [&]( FieldDescription const & f ) { return f.name == name; } );
+  GEOSX_ASSERT_MSG( it != m_fields.end(), "DofManager: field does not exist: " << name );
   return std::distance( m_fields.begin(), it );
 }
 
@@ -104,88 +85,63 @@ string const & DofManager::getKey( string const & fieldName ) const
 
 globalIndex DofManager::numGlobalDofs( string const & fieldName ) const
 {
-  if( !fieldName.empty() )
-  {
-    return m_fields[getFieldIndex( fieldName )].numGlobalDof;
-  }
-  else
-  {
-    return std::accumulate( m_fields.begin(), m_fields.end(), globalIndex( 0 ),
-                            []( globalIndex const & n, FieldDescription const & f ) { return n + f.numGlobalDof; } );
-  }
+  return m_fields[getFieldIndex( fieldName )].numGlobalDof;
+}
+
+globalIndex DofManager::numGlobalDofs() const
+{
+  return std::accumulate( m_fields.begin(), m_fields.end(), globalIndex( 0 ),
+                          []( globalIndex const n, FieldDescription const & f ) { return n + f.numGlobalDof; } );
 }
 
 localIndex DofManager::numLocalDofs( string const & fieldName ) const
 {
-  if( !fieldName.empty() )
-  {
-    return m_fields[getFieldIndex( fieldName )].numLocalDof;
-  }
-  else
-  {
-    return std::accumulate( m_fields.begin(), m_fields.end(), localIndex( 0 ),
-                            []( globalIndex const & n, FieldDescription const & f ) { return n + f.numLocalDof; } );
-  }
+  return m_fields[getFieldIndex( fieldName )].numLocalDof;
 }
 
-array1d< localIndex > DofManager::numLocalDofsPerField() const
+localIndex DofManager::numLocalDofs() const
 {
-  array1d< localIndex > ret( m_fields.size() );
-  std::transform( m_fields.begin(), m_fields.end(), ret.begin(),
-                  []( FieldDescription const & f ){ return f.numLocalDof; } );
-  return ret;
+  return std::accumulate( m_fields.begin(), m_fields.end(), localIndex( 0 ),
+                          []( globalIndex const n, FieldDescription const & f ) { return n + f.numLocalDof; } );
 }
 
 globalIndex DofManager::rankOffset( string const & fieldName ) const
 {
-  if( !fieldName.empty() )
-  {
-    return m_fields[getFieldIndex( fieldName )].rankOffset;
-  }
-  else
-  {
-    return std::accumulate( m_fields.begin(), m_fields.end(), globalIndex( 0 ),
-                            []( globalIndex const & n, FieldDescription const & f ) { return n + f.rankOffset; } );
-  }
+  return m_fields[getFieldIndex( fieldName )].rankOffset;
 }
 
-localIndex DofManager::numComponents( string const & fieldName ) const
+globalIndex DofManager::rankOffset() const
 {
-  if( !fieldName.empty() )
-  {
-    return m_fields[getFieldIndex( fieldName )].numComponents;
-  }
-  else
-  {
-    return std::accumulate( m_fields.begin(), m_fields.end(), localIndex( 0 ),
-                            []( globalIndex const & n, FieldDescription const & f ) { return n + f.numComponents; } );
-  }
-
+  return std::accumulate( m_fields.begin(), m_fields.end(), globalIndex( 0 ),
+                          []( globalIndex const n, FieldDescription const & f ) { return n + f.rankOffset; } );
 }
 
-array1d< localIndex > DofManager::numComponentsPerField() const
+integer DofManager::numComponents( string const & fieldName ) const
 {
-  array1d< localIndex > ret( m_fields.size() );
-  std::transform( m_fields.begin(), m_fields.end(), ret.begin(),
-                  []( FieldDescription const & f ){ return f.numComponents; } );
+  return m_fields[getFieldIndex( fieldName )].numComponents;
+}
+
+integer DofManager::numComponents() const
+{
+  return std::accumulate( m_fields.begin(), m_fields.end(), localIndex( 0 ),
+                          []( globalIndex const n, FieldDescription const & f ) { return n + f.numComponents; } );
+}
+
+array1d< integer > DofManager::numComponentsPerField() const
+{
+  array1d< integer > ret( m_fields.size() );
+  std::transform( m_fields.begin(), m_fields.end(), ret.begin(), std::mem_fn( &FieldDescription::numComponents ) );
   return ret;
 }
 
-localIndex DofManager::numLocalSupport( string const & fieldName ) const
-{
-  FieldDescription const & field = m_fields[getFieldIndex( fieldName )];
-  return field.numLocalDof / field.numComponents;
-}
-
-globalIndex DofManager::numGlobalSupport( string const & fieldName ) const
-{
-  FieldDescription const & field = m_fields[getFieldIndex( fieldName )];
-  return field.numGlobalDof / field.numComponents;
-}
-
-DofManager::Location DofManager::getLocation( string const & fieldName ) const
+DofManager::Location DofManager::location( string const & fieldName ) const
 {
   return m_fields[getFieldIndex( fieldName )].location;
+}
+
+std::vector< string > const & DofManager::regions( string const & fieldName ) const
+{
+  return m_fields[getFieldIndex( fieldName )].regions;
 }
 
 globalIndex DofManager::globalOffset( string const & fieldName ) const
@@ -194,45 +150,30 @@ globalIndex DofManager::globalOffset( string const & fieldName ) const
   return m_fields[getFieldIndex( fieldName )].globalOffset;
 }
 
-void DofManager::createIndexArray( FieldDescription & field )
+void DofManager::createIndexArray( FieldDescription const & field )
 {
-  bool const success = LocationSwitch( field.location, [&]( auto const loc )
+  LocationSwitch( field.location, [&]( auto const loc )
   {
     Location constexpr LOC = decltype(loc)::value;
-    using helper = IndexArrayHelper< globalIndex, LOC >;
+    using helper = ArrayHelper< globalIndex, LOC >;
 
-    // 0. register index arrays
-    helper::template create<>( m_mesh, field.key, field.docstring, field.regions );
-    typename helper::Accessor & indexArray = helper::get( m_mesh, field.key );
+    // register index array
+    helper::template create<>( *m_mesh, field.key, field.docstring, field.regions );
+    typename helper::Accessor indexArray = helper::get( *m_mesh, field.key );
 
-    // step 1. loop over all active regions, determine number of local mesh objects
-    localIndex numLocalNodes = 0;
-    forMeshLocation< LOC, false >( m_mesh, field.regions, [&]( auto const locIdx )
+    // populate index array using a sequential counter
+    localIndex index = 0;
+    forMeshLocation< LOC, false, serialPolicy >( *m_mesh, field.regions, [&]( auto const locIdx )
     {
-      helper::reference( indexArray, locIdx ) = field.numComponents * numLocalNodes++;
-    } );
-    field.numLocalDof = field.numComponents * numLocalNodes;
-
-    // step 2. gather row counts across ranks
-    field.rankOffset = MpiWrapper::prefixSum< globalIndex >( field.numLocalDof );
-
-    field.numGlobalDof = field.rankOffset + field.numLocalDof;
-    MpiWrapper::broadcast( field.numGlobalDof, MpiWrapper::commSize() - 1 );
-
-    // step 3. adjust local dof offsets to reflect processor offset
-    forMeshLocation< LOC, false >( m_mesh, field.regions, [&]( auto const locIdx )
-    {
-      helper::reference( indexArray, locIdx ) += field.rankOffset;
+      helper::reference( indexArray, locIdx ) = field.rankOffset + field.numComponents * index++;
     } );
 
-    // step 4. synchronize across ranks
+    // synchronize across ranks
     std::map< string, string_array > fieldNames;
-    fieldNames[ MeshHelper< LOC >::syncObjName ].emplace_back( field.key );
-
-    CommunicationTools::getInstance().
-      synchronizeFields( fieldNames, *m_mesh, m_domain->getNeighbors(), false );
+    fieldNames[MeshHelper< LOC >::syncObjName].emplace_back( field.key );
+    DomainPartition & domain = dynamicCast< DomainPartition & >( m_mesh->getParent().getParent().getParent() );
+    CommunicationTools::getInstance().synchronizeFields( fieldNames, *m_mesh, domain.getNeighbors(), false );
   } );
-  GEOSX_ERROR_IF( !success, "Invalid location type: " << static_cast< int >(field.location) );
 }
 
 void DofManager::removeIndexArray( FieldDescription const & field )
@@ -240,104 +181,190 @@ void DofManager::removeIndexArray( FieldDescription const & field )
   LocationSwitch( field.location, [&]( auto const loc )
   {
     Location constexpr LOC = decltype(loc)::value;
-    IndexArrayHelper< globalIndex, LOC >::template remove<>( m_mesh, field.key, field.regions );
+    ArrayHelper< globalIndex, LOC >::template remove<>( *m_mesh, field.key, field.regions );
   } );
 }
 
-// Just an interface to allow only three parameters
-void DofManager::addField( string const & fieldName,
-                           Location const location )
+namespace
 {
-  addField( fieldName, location, 1, arrayView1d< string const >() );
-}
 
-// Just another interface to allow four parameters (no regions)
-void DofManager::addField( string const & fieldName,
-                           Location const location,
-                           localIndex const components )
+std::vector< string > processFieldRegionList( MeshLevel const & mesh,
+                                              std::vector< string > const & inputList )
 {
-  addField( fieldName, location, components, arrayView1d< string const >() );
-}
+  std::vector< string > regions( inputList );
+  ElementRegionManager const & elemManager = mesh.getElemManager();
 
-// Just another interface to allow four parameters (no components)
-void DofManager::addField( string const & fieldName,
-                           Location const location,
-                           arrayView1d< string const > const & regions )
-{
-  addField( fieldName, location, 1, regions );
-}
-
-// The real function, allowing the creation of self-connected blocks
-void DofManager::addField( string const & fieldName,
-                           Location const location,
-                           localIndex const components,
-                           arrayView1d< string const > const & regions )
-{
-  GEOSX_ERROR_IF( m_reordered, "Cannot add fields after reorderByRank() has been called." );
-  GEOSX_ERROR_IF( fieldExists( fieldName ), "Requested field name '" << fieldName << "' already exists." );
-  GEOSX_ERROR_IF( m_fields.size() >= MAX_FIELDS, "Limit on DofManager's MAX_NUM_FIELDS exceeded." );
-
-  localIndex fieldIndex = m_fields.size();
-  m_fields.resize( fieldIndex + 1 );
-
-  string suffix;
-  for( string const & regionName : regions )
-  {
-    suffix.append( "_" + regionName );
-  }
-
-  FieldDescription & field = m_fields.back();
-
-  field.name = fieldName;
-  field.location = location;
-  field.regions.resize( regions.size() );
-  std::copy( regions.begin(), regions.end(), field.regions.begin() );
-  field.numComponents = components;
-  field.key = m_name + '_' + fieldName + "_dofIndex" + suffix;
-  field.docstring = fieldName + " DoF indices";
-
-  if( components > 1 )
-  {
-    field.docstring += " (with " + std::to_string( components ) + "-component blocks)";
-  }
-
-  ElementRegionManager & elemManager = m_mesh->getElemManager();
-  if( field.regions.empty() )
+  if( regions.empty() )
   {
     elemManager.forElementRegions( [&]( ElementRegionBase const & region )
     {
-      field.regions.emplace_back( region.getName() );
+      regions.push_back( region.getName() );
     } );
   }
   else
   {
-    for( string const & regionName : field.regions )
+    for( string const & regionName : regions )
     {
+      // Check existence, discard return value
       elemManager.getRegion( regionName );
     }
   }
 
-  // sort and remove duplicates
-  std::sort( field.regions.begin(), field.regions.end() );
-  auto const end_it = std::unique( field.regions.begin(), field.regions.end() );
-  field.regions.resize( std::distance( field.regions.begin(), end_it ) );
+  // sort region names and remove duplicates
+  std::sort( regions.begin(), regions.end() );
+  regions.erase( std::unique( regions.begin(), regions.end() ), regions.end() );
 
-  m_coupling[fieldIndex][fieldIndex].regions = field.regions;
+  return regions;
+}
 
-  // based on location, allocate an index array for this field
-  createIndexArray( field );
-
-  // determine field's global offset
-  if( fieldIndex > 0 )
+std::vector< string > processCouplingRegionList( std::vector< string > const & inputList,
+                                                 std::vector< string > const & rowFieldRegions,
+                                                 std::vector< string > const & colFieldRegions )
+{
+  std::vector< string > regions( inputList );
+  if( regions.empty() )
   {
-    FieldDescription & prev = m_fields[fieldIndex - 1];
-    field.blockOffset = prev.blockOffset + prev.numGlobalDof;
+    // Populate with regions common between two fields
+    regions.resize( std::min( rowFieldRegions.size(), colFieldRegions.size() ) );
+    auto const it = std::set_intersection( rowFieldRegions.begin(), rowFieldRegions.end(),
+                                           colFieldRegions.begin(), colFieldRegions.end(),
+                                           regions.begin() );
+    regions.resize( std::distance( regions.begin(), it ) );
   }
   else
   {
-    field.blockOffset = 0;
+    // Sort alphabetically and remove possible duplicates in user input
+    std::sort( regions.begin(), regions.end() );
+    regions.resize( std::distance( regions.begin(), std::unique( regions.begin(), regions.end() ) ) );
+
+    // Check that both fields exist on all regions in the list
+    for( string const & regionName : regions )
+    {
+      GEOSX_ERROR_IF( !std::binary_search( rowFieldRegions.begin(), rowFieldRegions.end(), regionName ),
+                      "Region '" << regionName << "' does not belong to the domain of first field" );
+      GEOSX_ERROR_IF( !std::binary_search( colFieldRegions.begin(), colFieldRegions.end(), regionName ),
+                      "Region '" << regionName << "' does not belong to the domain of second field" );
+    }
   }
-  field.globalOffset = -1; // to be calculated in reorderByRank()
+
+  return regions;
+}
+
+} // namespace
+
+void DofManager::computeFieldDimensions( localIndex const fieldIndex )
+{
+  FieldDescription & field = m_fields[fieldIndex];
+
+  // determine number of local support points
+  localIndex const numLocalSupport = countMeshObjects< false >( field.location, *m_mesh, field.regions );
+  field.numLocalDof = field.numComponents * numLocalSupport;
+
+  // gather dof counts across ranks
+  field.rankOffset = MpiWrapper::prefixSum< globalIndex >( field.numLocalDof );
+  field.numGlobalDof = field.rankOffset + field.numLocalDof;
+  MpiWrapper::broadcast( field.numGlobalDof, MpiWrapper::commSize() - 1 );
+
+  // determine field's offsets
+  if( fieldIndex > 0 )
+  {
+    FieldDescription const & prev = m_fields[fieldIndex - 1];
+    field.blockOffset = prev.blockOffset + prev.numGlobalDof;
+  }
+  field.globalOffset = field.rankOffset; // actual value computed in reorderByRank()
+}
+
+void DofManager::addField( string const & fieldName,
+                           Location const location,
+                           integer const components,
+                           std::vector< string > const & regions )
+{
+  GEOSX_ASSERT_MSG( m_mesh != nullptr, "Mesh has not been set" );
+  GEOSX_ERROR_IF( m_reordered, "Cannot add fields after reorderByRank() has been called." );
+  GEOSX_ERROR_IF( fieldExists( fieldName ), "Requested field name '" << fieldName << "' already exists." );
+  GEOSX_ERROR_IF_GT_MSG( components, MAX_COMP, "Number of components limit exceeded" );
+
+  m_fields.emplace_back();
+  FieldDescription & field = m_fields.back();
+
+  // populate basic info
+  field.name = fieldName;
+  field.location = location;
+  field.numComponents = components;
+  field.key = m_name + '_' + fieldName + "_dofIndex";
+  field.docstring = fieldName + " DoF indices";
+
+  // advanced processing
+  field.regions = processFieldRegionList( *m_mesh, regions );
+  computeFieldDimensions( static_cast< localIndex >( m_fields.size() ) - 1 );
+
+  // allocate and fill index array
+  createIndexArray( field );
+}
+
+void DofManager::addField( string const & fieldName,
+                           Location const location,
+                           integer const components,
+                           arrayView1d< string const > const & regions )
+{
+  std::vector< string > regionsVec( regions.size() );
+  std::copy( regions.begin(), regions.end(), regionsVec.begin() );
+  addField( fieldName, location, components, regionsVec );
+}
+
+void DofManager::addCoupling( string const & rowFieldName,
+                              string const & colFieldName,
+                              Connector const connectivity,
+                              std::vector< string > const & regions,
+                              bool const symmetric )
+{
+  GEOSX_ASSERT_MSG( m_mesh != nullptr, "Mesh has not been set" );
+  localIndex const rowFieldIndex = getFieldIndex( rowFieldName );
+  localIndex const colFieldIndex = getFieldIndex( colFieldName );
+
+  // Check if already defined
+  GEOSX_ASSERT_MSG( m_coupling.count( {rowFieldIndex, colFieldIndex} ) == 0, "addCoupling: coupling already defined" );
+
+  CouplingDescription & coupling = m_coupling[ { rowFieldIndex, colFieldIndex } ];
+  coupling.connector = connectivity;
+  if( connectivity == Connector::None && rowFieldIndex == colFieldIndex )
+  {
+    coupling.connector = static_cast< Connector >( m_fields[rowFieldIndex].location );
+  }
+
+  // Make a list of regions on which coupling is defined
+  coupling.regions = processCouplingRegionList( regions, m_fields[rowFieldIndex].regions, m_fields[colFieldIndex].regions );
+
+  // Set connectivity with active symmetry flag
+  if( symmetric && colFieldIndex != rowFieldIndex )
+  {
+    m_coupling.insert( { { colFieldIndex, rowFieldIndex }, coupling } );
+  }
+}
+
+void DofManager::addCoupling( string const & rowFieldName,
+                              string const & colFieldName,
+                              Connector const connectivity,
+                              arrayView1d< string const > const & regions,
+                              bool const symmetric )
+{
+  std::vector< string > regionsVec( regions.size() );
+  std::copy( regions.begin(), regions.end(), regionsVec.begin() );
+  addCoupling( rowFieldName, colFieldName, connectivity, regionsVec, symmetric );
+}
+
+void DofManager::addCoupling( string const & fieldName,
+                              FluxApproximationBase const & stencils )
+{
+  localIndex const fieldIndex = getFieldIndex( fieldName );
+  FieldDescription const & field = m_fields[fieldIndex];
+
+  GEOSX_ERROR_IF( field.location != Location::Elem, "Field must be supported on elements in order to use stencil sparsity" );
+
+  CouplingDescription & coupling = m_coupling[ {fieldIndex, fieldIndex} ];
+  coupling.connector = Connector::Stencil;
+  coupling.regions = field.regions;
+  coupling.stencils = &stencils;
 }
 
 namespace
@@ -361,23 +388,23 @@ namespace
 template< DofManager::Location LOC, DofManager::Location CONN, typename ... SUBREGIONTYPES >
 struct ConnLocPatternBuilder
 {
-  static void build( MeshLevel * const mesh,
+  static void build( MeshLevel const & mesh,
                      string const & key,
                      localIndex const numComp,
                      std::vector< string > const & regions,
                      localIndex const rowOffset,
                      SparsityPattern< globalIndex > & connLocPattern )
   {
-    using ArrayHelper = IndexArrayHelper< globalIndex const, LOC >;
-    typename ArrayHelper::Accessor dofIndexArray = ArrayHelper::get( mesh, key );
+    using helper = ArrayHelper< globalIndex const, LOC >;
+    typename helper::Accessor dofIndexArray = helper::get( mesh, key );
     auto connIdxPrev = MeshHelper< CONN >::invalid_local_index;
 
     localIndex connectorCount = -1;
 
-    forMeshLocation< CONN, LOC, true, SUBREGIONTYPES... >( mesh, regions,
-                                                           [&]( auto const & connIdx,
-                                                                auto const & locIdx,
-                                                                localIndex const GEOSX_UNUSED_PARAM( k ) )
+    forMeshLocation< CONN, LOC, true, serialPolicy, SUBREGIONTYPES... >( mesh, regions,
+                                                                         [&]( auto const & connIdx,
+                                                                              auto const & locIdx,
+                                                                              localIndex const GEOSX_UNUSED_PARAM( k ) )
     {
       if( connIdx != connIdxPrev )
       {
@@ -385,7 +412,7 @@ struct ConnLocPatternBuilder
         connIdxPrev = connIdx;
       }
 
-      globalIndex const dofOffset = ArrayHelper::value( dofIndexArray, locIdx );
+      globalIndex const dofOffset = helper::value( dofIndexArray, locIdx );
       if( dofOffset >= 0 )
       {
         for( localIndex c = 0; c < numComp; ++c )
@@ -409,7 +436,7 @@ struct ConnLocPatternBuilder
 template< typename ... SUBREGIONTYPES >
 struct ConnLocPatternBuilder< DofManager::Location::Elem, DofManager::Location::Edge, SUBREGIONTYPES... >
 {
-  static void build( MeshLevel * const mesh,
+  static void build( MeshLevel const & mesh,
                      string const & key,
                      localIndex const numComp,
                      std::vector< string > const & regions,
@@ -419,8 +446,8 @@ struct ConnLocPatternBuilder< DofManager::Location::Elem, DofManager::Location::
     DofManager::Location constexpr ELEM  = DofManager::Location::Elem;
     DofManager::Location constexpr EDGE = DofManager::Location::Edge;
 
-    EdgeManager const & edgeManager = mesh->getEdgeManager();
-    ElementRegionManager const & elemManager = mesh->getElemManager();
+    EdgeManager const & edgeManager = mesh.getEdgeManager();
+    ElementRegionManager const & elemManager = mesh.getElemManager();
 
     ElementRegionManager::ElementViewAccessor< arrayView1d< globalIndex const > > dofIndex =
       elemManager.constructViewAccessor< array1d< globalIndex >, arrayView1d< globalIndex const > >( key );
@@ -429,15 +456,15 @@ struct ConnLocPatternBuilder< DofManager::Location::Elem, DofManager::Location::
     edgeConnectorIndex.setValues< serialPolicy >( -1 );
 
     localIndex edgeCount = 0;
-    forMeshLocation< EDGE, true, SUBREGIONTYPES... >( mesh, regions, [&] ( localIndex const edgeIdx )
+    forMeshLocation< EDGE, true, serialPolicy, SUBREGIONTYPES... >( mesh, regions, [&] ( localIndex const edgeIdx )
     {
       edgeConnectorIndex[edgeIdx] = edgeCount++;
     } );
 
-    forMeshLocation< ELEM, EDGE, true, SUBREGIONTYPES... >( mesh, regions,
-                                                            [&]( auto const & elemIdx,
-                                                                 auto const & edgeIdx,
-                                                                 localIndex const GEOSX_UNUSED_PARAM( k ) )
+    forMeshLocation< ELEM, EDGE, true, serialPolicy, SUBREGIONTYPES... >( mesh, regions,
+                                                                          [&]( auto const & elemIdx,
+                                                                               auto const & edgeIdx,
+                                                                               localIndex const GEOSX_UNUSED_PARAM( k ) )
     {
       globalIndex const dofOffset = dofIndex[elemIdx[0]][elemIdx[1]][elemIdx[2]];
       if( dofOffset >= 0 )
@@ -452,7 +479,7 @@ struct ConnLocPatternBuilder< DofManager::Location::Elem, DofManager::Location::
 };
 
 template< DofManager::Location LOC, DofManager::Location CONN >
-void makeConnLocPattern( MeshLevel * const mesh,
+void makeConnLocPattern( MeshLevel const & mesh,
                          string const & key,
                          localIndex const numComp,
                          globalIndex const numGlobalDof,
@@ -489,224 +516,19 @@ void makeConnLocPattern( MeshLevel * const mesh,
 
 } // namespace
 
-template< typename MATRIX >
-void DofManager::setSparsityPatternFromStencil( MATRIX & pattern,
+void DofManager::setSparsityPatternFromStencil( SparsityPatternView< globalIndex > const & pattern,
                                                 localIndex const fieldIndex ) const
 {
   FieldDescription const & field = m_fields[fieldIndex];
-  CouplingDescription const & coupling = m_coupling[fieldIndex][fieldIndex];
-  localIndex const NC = field.numComponents;
-
-  ElementRegionManager::ElementViewAccessor< arrayView1d< globalIndex const > > dofNumber =
-    m_mesh->getElemManager().constructViewAccessor< array1d< globalIndex >, arrayView1d< globalIndex const > >( field.key );
-
-  array1d< globalIndex > rowIndices( NC );
-  array1d< globalIndex > colIndices( NC );
-  array2d< real64 > values( NC, NC );
-  values.setValues< serialPolicy >( 1.0 );
-
-  // 1. Insert diagonal blocks, in case there are elements not included in stencil
-  // (e.g. a single fracture element not connected to any other)
-  forMeshLocation< Location::Elem, false >( m_mesh, field.regions,
-                                            [&]( auto const & elemIdx )
-  {
-    for( localIndex c = 0; c < NC; ++c )
-    {
-      rowIndices[c] = dofNumber[elemIdx[0]][elemIdx[1]][elemIdx[2]] + c;
-    }
-    pattern.insert( rowIndices, rowIndices, values );
-  } );
-
-  // 2. Assemble diagonal and off-diagonal blocks for elements in stencil
-  MATRIX * const pattern_ptr = &pattern;
-  coupling.stencils->forAllStencils( *m_mesh, [&]( auto const & stencil )
-  {
-    using StenciType = typename std::decay< decltype( stencil ) >::type;
-    constexpr localIndex maxNumFluxElems = StenciType::NUM_POINT_IN_FLUX;
-    constexpr localIndex maxStencilSize = StenciType::MAX_STENCIL_SIZE;
-
-    typename StenciType::IndexContainerViewConstType const & seri = stencil.getElementRegionIndices();
-    typename StenciType::IndexContainerViewConstType const & sesri = stencil.getElementSubRegionIndices();
-    typename StenciType::IndexContainerViewConstType const & sei = stencil.getElementIndices();
-
-    rowIndices.reserve( maxNumFluxElems * NC );
-    colIndices.reserve( maxStencilSize * NC );
-    values.reserve( maxNumFluxElems * NC * maxStencilSize * NC );
-
-    forAll< serialPolicy >( stencil.size(), [&]( localIndex iconn )
-    {
-      localIndex const numFluxElems = stencil.stencilSize( iconn );
-      localIndex const stencilSize  = numFluxElems;
-
-      rowIndices.resize( numFluxElems * NC );
-      for( localIndex i = 0; i < numFluxElems; ++i )
-      {
-        for( localIndex c = 0; c < NC; ++c )
-        {
-          rowIndices[i * NC + c] = dofNumber[seri( iconn, i )][sesri( iconn, i )][sei( iconn, i )] + c;
-        }
-      }
-
-      colIndices.resize( stencilSize * NC );
-      for( localIndex i = 0; i < stencilSize; ++i )
-      {
-        for( localIndex c = 0; c < NC; ++c )
-        {
-          colIndices[i * NC + c] = dofNumber[seri( iconn, i )][sesri( iconn, i )][sei( iconn, i )] + c;
-        }
-      }
-
-      values.resize( numFluxElems * NC, stencilSize * NC );
-      values.setValues< serialPolicy >( 1.0 );
-
-      pattern_ptr->insert( rowIndices, colIndices, values );
-    } );
-  } );
-}
-
-template< typename MATRIX >
-void DofManager::setSparsityPatternOneBlock( MATRIX & pattern,
-                                             localIndex const rowFieldIndex,
-                                             localIndex const colFieldIndex ) const
-{
-  GEOSX_ASSERT( rowFieldIndex >= 0 );
-  GEOSX_ASSERT( colFieldIndex >= 0 );
-
-  FieldDescription const & rowField = m_fields[rowFieldIndex];
-  FieldDescription const & colField = m_fields[colFieldIndex];
-
-  Connector conn = m_coupling[rowFieldIndex][colFieldIndex].connector;
-
-  // Special treatment for stencil-based sparsity
-  if( rowFieldIndex == colFieldIndex && conn == Connector::Stencil )
-  {
-    setSparsityPatternFromStencil( pattern, rowFieldIndex );
-    return;
-  }
-
-  SparsityPattern< globalIndex > connLocRow( 0, 0, 0 ), connLocCol( 0, 0, 0 );
-
-  localIndex maxDofRow = 0;
-  LocationSwitch( rowField.location, static_cast< Location >( conn ),
-                  [&]( auto const locType, auto const connType )
-  {
-    Location constexpr LOC  = decltype(locType)::value;
-    Location constexpr CONN = decltype(connType)::value;
-
-    makeConnLocPattern< LOC, CONN >( m_mesh,
-                                     rowField.key,
-                                     rowField.numComponents,
-                                     rowField.numGlobalDof,
-                                     m_coupling[rowFieldIndex][colFieldIndex].regions,
-                                     connLocRow );
-
-    maxDofRow = MeshIncidence< CONN, LOC >::max * rowField.numComponents;
-  } );
-
-  localIndex maxDofCol = 0;
-  if( colFieldIndex == rowFieldIndex )
-  {
-    connLocCol = connLocRow; // TODO avoid copying
-    maxDofCol = maxDofRow;
-  }
-  else
-  {
-    LocationSwitch( colField.location, static_cast< Location >( conn ),
-                    [&]( auto const locType, auto const connType )
-    {
-      Location constexpr LOC = decltype(locType)::value;
-      Location constexpr CONN = decltype(connType)::value;
-
-      makeConnLocPattern< LOC, CONN >( m_mesh,
-                                       colField.key,
-                                       colField.numComponents,
-                                       colField.numGlobalDof,
-                                       m_coupling[rowFieldIndex][colFieldIndex].regions,
-                                       connLocCol );
-
-      maxDofCol = MeshIncidence< CONN, LOC >::max * colField.numComponents;
-    } );
-  }
-  GEOSX_ASSERT_EQ( connLocRow.numRows(), connLocCol.numRows() );
-
-  array1d< globalIndex > dofIndicesRow( maxDofRow );
-  array1d< globalIndex > dofIndicesCol( maxDofCol );
-  array2d< real64 > values( maxDofRow, maxDofCol );
-
-  // Perform assembly/multiply patterns
-  for( localIndex irow = 0; irow < connLocRow.numRows(); ++irow )
-  {
-    localIndex const numDofRow = connLocRow.numNonZeros( irow );
-    dofIndicesRow.resize( numDofRow );
-    for( localIndex j = 0; j < numDofRow; ++j )
-    {
-      dofIndicesRow[j] = connLocRow.getColumns( irow )[j];
-    }
-
-    localIndex const numDofCol = connLocCol.numNonZeros( irow );
-    dofIndicesCol.resize( numDofCol );
-    for( localIndex j = 0; j < numDofCol; ++j )
-    {
-      dofIndicesCol[j] = connLocCol.getColumns( irow )[j];
-    }
-
-    values.resize( numDofRow, numDofCol );
-    values.setValues< serialPolicy >( 1.0 );
-    pattern.insert( dofIndicesRow, dofIndicesCol, values );
-  }
-}
-
-// Create the sparsity pattern (location-location). Low level interface
-template< typename MATRIX >
-void DofManager::setSparsityPattern( MATRIX & matrix,
-                                     bool const closePattern ) const
-{
-  GEOSX_MARK_FUNCTION;
-  GEOSX_ERROR_IF( !m_reordered, "Cannot set monolithic sparsity pattern before reorderByRank() has been called." );
-
-  matrix.open();
-  localIndex const numFields = LvArray::integerConversion< localIndex >( m_fields.size() );
-  for( localIndex blockRow = 0; blockRow < numFields; ++blockRow )
-  {
-    for( localIndex blockCol = 0; blockCol < numFields; ++blockCol )
-    {
-      setSparsityPatternOneBlock( matrix, blockRow, blockCol );
-    }
-  }
-  if( closePattern )
-  {
-    matrix.close();
-  }
-}
-
-// Create the sparsity pattern (location-location). High level interface
-template< typename MATRIX >
-void DofManager::setSparsityPattern( MATRIX & matrix,
-                                     string const & rowFieldName,
-                                     string const & colFieldName,
-                                     bool const closePattern ) const
-{
-  GEOSX_ERROR_IF( m_reordered, "Cannot set single block sparsity pattern after reorderByRank() has been called." );
-  setSparsityPatternOneBlock( matrix, getFieldIndex( rowFieldName ), getFieldIndex( colFieldName ) );
-  if( closePattern )
-  {
-    matrix.close();
-  }
-}
-
-void DofManager::setSparsityPatternFromStencil( SparsityPattern< globalIndex > & pattern,
-                                                localIndex const fieldIndex ) const
-{
-  FieldDescription const & field = m_fields[fieldIndex];
-  CouplingDescription const & coupling = m_coupling[fieldIndex][fieldIndex];
-  localIndex const NC = field.numComponents;
+  CouplingDescription const & coupling = m_coupling.at( {fieldIndex, fieldIndex} );
+  localIndex const numComp = field.numComponents;
   globalIndex const rankDofOffset = rankOffset();
 
   ElementRegionManager::ElementViewAccessor< arrayView1d< globalIndex const > > dofNumber =
     m_mesh->getElemManager().constructViewAccessor< array1d< globalIndex >, arrayView1d< globalIndex const > >( field.key );
 
-  array1d< globalIndex > rowDofIndices( NC );
-  array1d< globalIndex > colDofIndices( NC );
+  array1d< globalIndex > rowDofIndices( numComp );
+  array1d< globalIndex > colDofIndices( numComp );
 
   // 1. Assemble diagonal and off-diagonal blocks for elements in stencil
   coupling.stencils->forAllStencils( *m_mesh, [&]( auto const & stencil )
@@ -720,7 +542,7 @@ void DofManager::setSparsityPatternFromStencil( SparsityPattern< globalIndex > &
     typename StenciType::IndexContainerViewConstType const & sei = stencil.getElementIndices();
 
     rowDofIndices.reserve( maxNumFluxElems );
-    colDofIndices.reserve( maxStencilSize * NC );
+    colDofIndices.reserve( maxStencilSize * numComp );
 
     forAll< serialPolicy >( stencil.size(), [&]( localIndex const iconn )
     {
@@ -735,12 +557,12 @@ void DofManager::setSparsityPatternFromStencil( SparsityPattern< globalIndex > &
         rowDofIndices[i] = dofNumber[seri( iconn, i )][sesri( iconn, i )][sei( iconn, i )];
       }
 
-      colDofIndices.resize( stencilSize * NC );
+      colDofIndices.resize( stencilSize * numComp );
       for( localIndex i = 0; i < stencilSize; ++i )
       {
-        for( localIndex c = 0; c < NC; ++c )
+        for( localIndex c = 0; c < numComp; ++c )
         {
-          colDofIndices[i * NC + c] = dofNumber[seri( iconn, i )][sesri( iconn, i )][sei( iconn, i )] + c;
+          colDofIndices[i * numComp + c] = dofNumber[seri( iconn, i )][sesri( iconn, i )][sei( iconn, i )] + c;
         }
       }
 
@@ -751,7 +573,7 @@ void DofManager::setSparsityPatternFromStencil( SparsityPattern< globalIndex > &
         localIndex const localDofNumber = rowDofIndices[i] - rankDofOffset;
         if( localDofNumber >= 0 && localDofNumber < pattern.numRows() )
         {
-          for( localIndex c = 0; c < NC; ++c )
+          for( localIndex c = 0; c < numComp; ++c )
           {
             pattern.insertNonZeros( localDofNumber + c, colDofIndices.begin(), colDofIndices.end() );
           }
@@ -762,16 +584,17 @@ void DofManager::setSparsityPatternFromStencil( SparsityPattern< globalIndex > &
 
   // 2. Insert diagonal blocks, in case there are elements not included in stencil
   // (e.g. a single fracture element not connected to any other)
-  colDofIndices.resize( NC );
-  forMeshLocation< Location::Elem, false >( m_mesh, field.regions,
-                                            [&]( auto const & elemIdx )
+  auto dofNumberView = dofNumber.toNestedViewConst();
+  colDofIndices.resize( numComp );
+  forMeshLocation< Location::Elem, false, parallelHostPolicy >( *m_mesh, field.regions,
+                                                                [=]( auto const & elemIdx )
   {
-    globalIndex const elemDof = dofNumber[elemIdx[0]][elemIdx[1]][elemIdx[2]];
-    for( localIndex c = 0; c < NC; ++c )
+    globalIndex const elemDof = dofNumberView[elemIdx[0]][elemIdx[1]][elemIdx[2]];
+    for( localIndex c = 0; c < numComp; ++c )
     {
       colDofIndices[c] = elemDof + c;
     }
-    for( localIndex c = 0; c < NC; ++c )
+    for( localIndex c = 0; c < numComp; ++c )
     {
       pattern.insertNonZeros( elemDof - rankDofOffset + c, colDofIndices.begin(), colDofIndices.end() );
     }
@@ -786,9 +609,9 @@ GEOSX_HOST_DEVICE inline
 localIndex
 getNeighborNodes( localIndex (& neighborNodes )[N],
                   arrayView1d< arrayView1d< arrayView2d< localIndex const, cells::NODE_MAP_USD > const > const > const & elemsToNodes,
-                  arraySlice1d< localIndex const > const nodeRegions,
-                  arraySlice1d< localIndex const > const nodeSubRegions,
-                  arraySlice1d< localIndex const > const nodeElems )
+                  arraySlice1d< localIndex const > const & nodeRegions,
+                  arraySlice1d< localIndex const > const & nodeSubRegions,
+                  arraySlice1d< localIndex const > const & nodeElems )
 {
   localIndex numNeighbors = 0;
   for( localIndex localElem = 0; localElem < nodeRegions.size(); ++localElem )
@@ -815,10 +638,6 @@ void DofManager::setFiniteElementSparsityPattern( SparsityPattern< globalIndex >
   GEOSX_MARK_FUNCTION;
 
   FieldDescription const & field = m_fields[fieldIndex];
-
-  //constexpr int MAX_ELEMS_PER_NODE = 8;
-  //constexpr int MAX_NODES_PER_ELEM = 8;
-  //constexpr int MAX_NODE_NEIGHBORS = 27;
 
   ElementRegionManager const & elemManager = m_mesh->getElemManager();
   NodeManager const & nodeManager = m_mesh->getNodeManager();
@@ -927,7 +746,7 @@ void DofManager::setFiniteElementSparsityPattern( SparsityPattern< globalIndex >
   }
 }
 
-void DofManager::setSparsityPatternOneBlock( SparsityPattern< globalIndex > & pattern,
+void DofManager::setSparsityPatternOneBlock( SparsityPatternView< globalIndex > const & pattern,
                                              localIndex const rowFieldIndex,
                                              localIndex const colFieldIndex ) const
 {
@@ -937,10 +756,14 @@ void DofManager::setSparsityPatternOneBlock( SparsityPattern< globalIndex > & pa
   FieldDescription const & rowField = m_fields[rowFieldIndex];
   FieldDescription const & colField = m_fields[colFieldIndex];
 
-  Connector conn = m_coupling[rowFieldIndex][colFieldIndex].connector;
+  if( m_coupling.count( {rowFieldIndex, colFieldIndex} ) == 0 )
+  {
+    return;
+  }
+  CouplingDescription const & coupling = m_coupling.at( {rowFieldIndex, colFieldIndex} );
 
   // Special treatment for stencil-based sparsity
-  if( rowFieldIndex == colFieldIndex && conn == Connector::Stencil )
+  if( rowFieldIndex == colFieldIndex && coupling.connector == Connector::Stencil )
   {
     setSparsityPatternFromStencil( pattern, rowFieldIndex );
     return;
@@ -950,7 +773,7 @@ void DofManager::setSparsityPatternOneBlock( SparsityPattern< globalIndex > & pa
   // TODO: separate counting/resizing from filling in order to enable this in coupled patterns
 #if 0 // uncomment to re-enable faster sparsity construction algorithm for FEM single-physics
   if( m_fields.size() == 1 && rowFieldIndex == colFieldIndex &&
-      rowField.location == Location::Node && conn == Connector::Elem )
+      rowField.location == Location::Node && coupling.connector == Connector::Elem )
   {
     switch( rowField.numComponents )
     {
@@ -971,17 +794,17 @@ void DofManager::setSparsityPatternOneBlock( SparsityPattern< globalIndex > & pa
   SparsityPattern< globalIndex > connLocRow( 0, 0, 0 ), connLocCol( 0, 0, 0 );
 
   localIndex maxDofRow = 0;
-  LocationSwitch( rowField.location, static_cast< Location >( conn ),
+  LocationSwitch( rowField.location, static_cast< Location >( coupling.connector ),
                   [&]( auto const locType, auto const connType )
   {
     Location constexpr LOC  = decltype(locType)::value;
     Location constexpr CONN = decltype(connType)::value;
 
-    makeConnLocPattern< LOC, CONN >( m_mesh,
+    makeConnLocPattern< LOC, CONN >( *m_mesh,
                                      rowField.key,
                                      rowField.numComponents,
                                      rowField.numGlobalDof,
-                                     m_coupling[rowFieldIndex][colFieldIndex].regions,
+                                     coupling.regions,
                                      connLocRow );
 
     maxDofRow = MeshIncidence< CONN, LOC >::max * rowField.numComponents;
@@ -995,17 +818,17 @@ void DofManager::setSparsityPatternOneBlock( SparsityPattern< globalIndex > & pa
   }
   else
   {
-    LocationSwitch( colField.location, static_cast< Location >( conn ),
+    LocationSwitch( colField.location, static_cast< Location >( coupling.connector ),
                     [&]( auto const locType, auto const connType )
     {
       Location constexpr LOC = decltype(locType)::value;
       Location constexpr CONN = decltype(connType)::value;
 
-      makeConnLocPattern< LOC, CONN >( m_mesh,
+      makeConnLocPattern< LOC, CONN >( *m_mesh,
                                        colField.key,
                                        colField.numComponents,
                                        colField.numGlobalDof,
-                                       m_coupling[rowFieldIndex][colFieldIndex].regions,
+                                       coupling.regions,
                                        connLocCol );
 
       maxDofCol = MeshIncidence< CONN, LOC >::max * colField.numComponents;
@@ -1013,52 +836,36 @@ void DofManager::setSparsityPatternOneBlock( SparsityPattern< globalIndex > & pa
   }
   GEOSX_ASSERT_EQ( connLocRow.numRows(), connLocCol.numRows() );
 
-  globalIndex const globalDofOffset = rankOffset();
-
-  array1d< globalIndex > dofIndicesRow( maxDofRow );
-  array1d< globalIndex > dofIndicesCol( maxDofCol );
-
   // Perform assembly/multiply patterns
-  for( localIndex irow = 0; irow < connLocRow.numRows(); ++irow )
+  globalIndex const globalDofOffset = rankOffset();
+  forAll< serialPolicy >( connLocRow.numRows(), [&]( localIndex const irow )
   {
-    localIndex const numDofRow = connLocRow.numNonZeros( irow );
-    dofIndicesRow.resize( numDofRow );
-    for( localIndex j = 0; j < numDofRow; ++j )
+    arraySlice1d< globalIndex const > const dofIndicesRow = connLocRow.getColumns( irow );
+    arraySlice1d< globalIndex const > const dofIndicesCol = connLocCol.getColumns( irow );
+    for( globalIndex const globalRow : dofIndicesRow )
     {
-      dofIndicesRow[j] = connLocRow.getColumns( irow )[j];
-    }
-
-    localIndex const numDofCol = connLocCol.numNonZeros( irow );
-    dofIndicesCol.resize( numDofCol );
-    for( localIndex j = 0; j < numDofCol; ++j )
-    {
-      dofIndicesCol[j] = connLocCol.getColumns( irow )[j];
-    }
-
-    for( localIndex j = 0; j < numDofRow; ++j )
-    {
-      localIndex const localRow = dofIndicesRow[j] - globalDofOffset;
+      localIndex const localRow = globalRow - globalDofOffset;
       if( localRow >= 0 && localRow < pattern.numRows() )
       {
         pattern.insertNonZeros( localRow, dofIndicesCol.begin(), dofIndicesCol.end() );
       }
     }
-  }
+  } );
 }
 
 void DofManager::countRowLengthsFromStencil( arrayView1d< localIndex > const & rowLengths,
                                              localIndex const fieldIndex ) const
 {
   FieldDescription const & field = m_fields[fieldIndex];
-  CouplingDescription const & coupling = m_coupling[fieldIndex][fieldIndex];
-  localIndex const NC = field.numComponents;
+  CouplingDescription const & coupling = m_coupling.at( {fieldIndex, fieldIndex} );
+  GEOSX_ASSERT( coupling.connector == Connector::Stencil );
+  GEOSX_ASSERT( coupling.stencils != nullptr );
+
+  localIndex const numComp = field.numComponents;
   globalIndex const rankDofOffset = rankOffset();
 
-  ElementRegionManager::ElementViewAccessor< arrayView1d< globalIndex const > > dofNumber =
+  ElementRegionManager::ElementViewAccessor< arrayView1d< globalIndex const > > dofNumberAccessor =
     m_mesh->getElemManager().constructViewAccessor< array1d< globalIndex >, arrayView1d< globalIndex const > >( field.key );
-
-  array1d< globalIndex > rowDofIndices( NC );
-  array1d< globalIndex > colDofIndices( NC );
 
   // 1. Count row contributions from stencil
   coupling.stencils->forAllStencils( *m_mesh, [&]( auto const & stencil )
@@ -1068,7 +875,7 @@ void DofManager::countRowLengthsFromStencil( arrayView1d< localIndex > const & r
     typename StenciType::IndexContainerViewConstType const & sesri = stencil.getElementSubRegionIndices();
     typename StenciType::IndexContainerViewConstType const & sei = stencil.getElementIndices();
 
-    forAll< serialPolicy >( stencil.size(), [&]( localIndex const iconn )
+    forAll< parallelHostPolicy >( stencil.size(), [&]( localIndex const iconn )
     {
       // This weirdness is because of fracture stencils, which don't have separate
       // getters for num flux elems vs stencil size... it won't work for MPFA though
@@ -1077,12 +884,12 @@ void DofManager::countRowLengthsFromStencil( arrayView1d< localIndex > const & r
 
       for( localIndex i = 0; i < numFluxElems; ++i )
       {
-        localIndex const localDofNumber = dofNumber[seri( iconn, i )][sesri( iconn, i )][sei( iconn, i )] - rankDofOffset;
+        localIndex const localDofNumber = dofNumberAccessor[seri( iconn, i )][sesri( iconn, i )][sei( iconn, i )] - rankDofOffset;
         if( localDofNumber >= 0 && localDofNumber < rowLengths.size() )
         {
-          for( localIndex c = 0; c < NC; ++c )
+          for( localIndex c = 0; c < numComp; ++c )
           {
-            rowLengths[localDofNumber + c] += ( stencilSize - 1 ) * NC;
+            RAJA::atomicAdd( parallelHostAtomic{}, &rowLengths[localDofNumber + c], ( stencilSize - 1 ) * numComp );
           }
         }
       }
@@ -1090,15 +897,21 @@ void DofManager::countRowLengthsFromStencil( arrayView1d< localIndex > const & r
   } );
 
   // 2. Add diagonal contributions to account for elements not in stencil
-  forMeshLocation< Location::Elem, false >( m_mesh, field.regions,
-                                            [&]( auto const & elemIdx )
+  m_mesh->getElemManager().forElementSubRegions( field.regions, [&]( localIndex const, ElementSubRegionBase const & subRegion )
   {
-    globalIndex const globalDofNumber = dofNumber[elemIdx[0]][elemIdx[1]][elemIdx[2]];
-    localIndex const localDofNumber = globalDofNumber - rankDofOffset;
-    for( localIndex c = 0; c < NC; ++c )
+    arrayView1d< integer const > const ghostRank = subRegion.ghostRank();
+    arrayView1d< globalIndex const > const dofNumber = subRegion.getReference< array1d< globalIndex > >( field.key );
+    forAll< parallelHostPolicy >( subRegion.size(), [&]( localIndex const ei )
     {
-      rowLengths[localDofNumber + c] += NC;
-    }
+      if( ghostRank[ei] < 0 )
+      {
+        localIndex const localDofNumber = dofNumber[ei] - rankDofOffset;
+        for( localIndex c = 0; c < numComp; ++c )
+        {
+          rowLengths[localDofNumber + c] += numComp;
+        }
+      }
+    } );
   } );
 }
 
@@ -1112,8 +925,13 @@ void DofManager::countRowLengthsOneBlock( arrayView1d< localIndex > const & rowL
   FieldDescription const & rowField = m_fields[rowFieldIndex];
   FieldDescription const & colField = m_fields[colFieldIndex];
 
-  Connector conn = m_coupling[rowFieldIndex][colFieldIndex].connector;
-  if( rowFieldIndex == colFieldIndex && conn == Connector::Stencil )
+  if( m_coupling.count( {rowFieldIndex, colFieldIndex} ) == 0 )
+  {
+    return;
+  }
+  CouplingDescription const & coupling = m_coupling.at( {rowFieldIndex, colFieldIndex} );
+
+  if( rowFieldIndex == colFieldIndex && coupling.connector == Connector::Stencil )
   {
     countRowLengthsFromStencil( rowLengths, rowFieldIndex );
     return;
@@ -1122,17 +940,17 @@ void DofManager::countRowLengthsOneBlock( arrayView1d< localIndex > const & rowL
   SparsityPattern< globalIndex > connLocRow( 0, 0, 0 ), connLocCol( 0, 0, 0 );
 
   localIndex maxDofRow = 0;
-  LocationSwitch( rowField.location, static_cast< Location >( conn ),
+  LocationSwitch( rowField.location, static_cast< Location >( coupling.connector ),
                   [&]( auto const locType, auto const connType )
   {
     Location constexpr LOC  = decltype(locType)::value;
     Location constexpr CONN = decltype(connType)::value;
 
-    makeConnLocPattern< LOC, CONN >( m_mesh,
+    makeConnLocPattern< LOC, CONN >( *m_mesh,
                                      rowField.key,
                                      rowField.numComponents,
                                      rowField.numGlobalDof,
-                                     m_coupling[rowFieldIndex][colFieldIndex].regions,
+                                     coupling.regions,
                                      connLocRow );
 
     maxDofRow = MeshIncidence< CONN, LOC >::max * rowField.numComponents;
@@ -1141,22 +959,22 @@ void DofManager::countRowLengthsOneBlock( arrayView1d< localIndex > const & rowL
   localIndex maxDofCol = 0;
   if( colFieldIndex == rowFieldIndex )
   {
-    connLocCol = connLocRow; // TODO avoid copying
+    connLocCol = connLocRow;
     maxDofCol = maxDofRow;
   }
   else
   {
-    LocationSwitch( colField.location, static_cast< Location >( conn ),
+    LocationSwitch( colField.location, static_cast< Location >( coupling.connector ),
                     [&]( auto const locType, auto const connType )
     {
       Location constexpr LOC = decltype(locType)::value;
       Location constexpr CONN = decltype(connType)::value;
 
-      makeConnLocPattern< LOC, CONN >( m_mesh,
+      makeConnLocPattern< LOC, CONN >( *m_mesh,
                                        colField.key,
                                        colField.numComponents,
                                        colField.numGlobalDof,
-                                       m_coupling[rowFieldIndex][colFieldIndex].regions,
+                                       coupling.regions,
                                        connLocCol );
 
       maxDofCol = MeshIncidence< CONN, LOC >::max * colField.numComponents;
@@ -1164,21 +982,20 @@ void DofManager::countRowLengthsOneBlock( arrayView1d< localIndex > const & rowL
   }
   GEOSX_ASSERT_EQ( connLocRow.numRows(), connLocCol.numRows() );
 
+  // Estimate an upper bound on row length by adding adjacent entries on a connector
   globalIndex const rankDofOffset = rankOffset();
-
-  // Estimate an upper bound on row length by adding
-  for( localIndex iconn = 0; iconn < connLocRow.numRows(); ++iconn )
+  forAll< parallelHostPolicy >( connLocRow.numRows(), [&]( localIndex const iconn )
   {
-    localIndex const numDofRow = connLocRow.numNonZeros( iconn );
-    for( localIndex j = 0; j < numDofRow; ++j )
+    arraySlice1d< globalIndex const > const dofIndicesRow = connLocRow.getColumns( iconn );
+    for( globalIndex const globalRow : dofIndicesRow )
     {
-      localIndex const localRow = connLocRow.getColumns( iconn )[j] - rankDofOffset;
+      localIndex const localRow = globalRow - rankDofOffset;
       if( localRow >= 0 && localRow < rowLengths.size() )
       {
-        rowLengths[localRow] += connLocCol.numNonZeros( iconn );
+        RAJA::atomicAdd( parallelHostAtomic{}, &rowLengths[localRow], connLocCol.numNonZeros( iconn ) );
       }
     }
-  }
+  } );
 }
 
 // Create the sparsity pattern (location-location). Low level interface
@@ -1207,21 +1024,12 @@ void DofManager::setSparsityPattern( SparsityPattern< globalIndex > & pattern ) 
   {
     for( localIndex blockCol = 0; blockCol < numFields; ++blockCol )
     {
-      setSparsityPatternOneBlock( pattern, blockRow, blockCol );
+      setSparsityPatternOneBlock( pattern.toView(), blockRow, blockCol );
     }
   }
 
   // Step 4. Compress to remove unused space between rows
   pattern.compress();
-}
-
-// Create the sparsity pattern (location-location). High level interface
-void DofManager::setSparsityPattern( SparsityPattern< globalIndex > & pattern,
-                                     string const & rowFieldName,
-                                     string const & colFieldName ) const
-{
-  GEOSX_ERROR_IF( m_reordered, "Cannot set single block sparsity pattern after reorderByRank() has been called." );
-  setSparsityPatternOneBlock( pattern, getFieldIndex( rowFieldName ), getFieldIndex( colFieldName ) );
 }
 
 namespace
@@ -1234,21 +1042,22 @@ void vectorToFieldKernel( LOCAL_VECTOR const localVector,
                           arrayView1d< integer const > const & ghostRank,
                           real64 const scalingFactor,
                           localIndex const dofOffset,
-                          localIndex const loComp,
-                          localIndex const hiComp )
+                          DofManager::CompMask const mask )
 {
   forAll< POLICY >( dofNumber.size(), [=] GEOSX_HOST_DEVICE ( localIndex const i )
   {
     if( ghostRank[i] < 0 && dofNumber[i] >= 0 )
     {
       localIndex const lid = dofNumber[i] - dofOffset;
-      GEOSX_ASSERT( lid >= 0 );
-      for( localIndex c = loComp; c < hiComp; ++c )
+      GEOSX_ASSERT_GE( lid, 0 );
+
+      integer fieldComp = 0;
+      for( integer const vecComp : mask )
       {
         FIELD_OP::template SpecifyFieldValue( field,
                                               i,
-                                              LvArray::integerConversion< integer >( c - loComp ),
-                                              scalingFactor * localVector[lid + c] );
+                                              fieldComp++,
+                                              scalingFactor * localVector[lid + vecComp] );
       }
     }
   } );
@@ -1261,8 +1070,7 @@ void vectorToFieldImpl( LOCAL_VECTOR const localVector,
                         string const & fieldName,
                         real64 const scalingFactor,
                         localIndex const dofOffset,
-                        localIndex const loComp,
-                        localIndex const hiComp )
+                        DofManager::CompMask const mask )
 {
   arrayView1d< globalIndex const > const dofNumber = manager.getReference< array1d< globalIndex > >( dofKey );
   arrayView1d< integer const > const ghostRank = manager.ghostRank();
@@ -1284,8 +1092,7 @@ void vectorToFieldImpl( LOCAL_VECTOR const localVector,
                                              ghostRank,
                                              scalingFactor,
                                              dofOffset,
-                                             loComp,
-                                             hiComp );
+                                             mask );
   } );
 }
 
@@ -1296,21 +1103,22 @@ void fieldToVectorKernel( LOCAL_VECTOR localVector,
                           arrayView1d< integer const > const & ghostRank,
                           real64 const GEOSX_UNUSED_PARAM( scalingFactor ),
                           localIndex const dofOffset,
-                          localIndex const loComp,
-                          localIndex const hiComp )
+                          DofManager::CompMask const mask )
 {
   forAll< POLICY >( dofNumber.size(), [=] GEOSX_HOST_DEVICE ( localIndex const i )
   {
     if( ghostRank[i] < 0 && dofNumber[i] >= 0 )
     {
       localIndex const lid = dofNumber[i] - dofOffset;
-      GEOSX_ASSERT( lid >= 0 );
-      for( localIndex c = loComp; c < hiComp; ++c )
+      GEOSX_ASSERT_GE( lid, 0 );
+
+      integer fieldComp = 0;
+      for( integer const vecComp : mask )
       {
         FIELD_OP::template readFieldValue( field,
                                            i,
-                                           LvArray::integerConversion< integer >( c - loComp ),
-                                           localVector[lid + c] );
+                                           fieldComp++,
+                                           localVector[lid + vecComp] );
       }
     }
   } );
@@ -1323,8 +1131,7 @@ void fieldToVectorImpl( LOCAL_VECTOR localVector,
                         string const & fieldName,
                         real64 const scalingFactor,
                         localIndex const dofOffset,
-                        localIndex const loComp,
-                        localIndex const hiComp )
+                        DofManager::CompMask const mask )
 {
   arrayView1d< globalIndex const > const & dofNumber = manager.getReference< array1d< globalIndex > >( dofKey );
   arrayView1d< integer const > const & ghostRank = manager.ghostRank();
@@ -1346,8 +1153,7 @@ void fieldToVectorImpl( LOCAL_VECTOR localVector,
                                              ghostRank,
                                              scalingFactor,
                                              dofOffset,
-                                             loComp,
-                                             hiComp );
+                                             mask );
   } );
 }
 
@@ -1358,20 +1164,15 @@ void DofManager::vectorToField( LOCAL_VECTOR const localVector,
                                 string const & srcFieldName,
                                 string const & dstFieldName,
                                 real64 const scalingFactor,
-                                localIndex const loCompIndex,
-                                localIndex const hiCompIndex ) const
+                                CompMask mask ) const
 {
   FieldDescription const & fieldDesc = m_fields[getFieldIndex( srcFieldName )];
-
-  localIndex const loComp = loCompIndex;
-  localIndex const hiComp = (hiCompIndex >= 0) ? hiCompIndex : fieldDesc.numComponents;
-  GEOSX_ASSERT( loComp >= 0 && hiComp <= fieldDesc.numComponents && loComp < hiComp );
+  mask.setNumComp( fieldDesc.numComponents );
 
   if( fieldDesc.location == Location::Elem )
   {
     m_mesh->getElemManager().forElementSubRegions< ElementSubRegionBase >( fieldDesc.regions,
-                                                                           [&]( localIndex const,
-                                                                                ElementSubRegionBase & subRegion )
+                                                                           [&]( localIndex const, ElementSubRegionBase & subRegion )
     {
       vectorToFieldImpl< FIELD_OP, POLICY >( localVector,
                                              subRegion,
@@ -1379,20 +1180,18 @@ void DofManager::vectorToField( LOCAL_VECTOR const localVector,
                                              dstFieldName,
                                              scalingFactor,
                                              rankOffset(),
-                                             loComp,
-                                             hiComp );
+                                             mask );
     } );
   }
   else
   {
     vectorToFieldImpl< FIELD_OP, POLICY >( localVector,
-                                           getObjectManager( fieldDesc.location, m_mesh ),
+                                           getObjectManager( fieldDesc.location, *m_mesh ),
                                            fieldDesc.key,
                                            dstFieldName,
                                            scalingFactor,
                                            rankOffset(),
-                                           loComp,
-                                           hiComp );
+                                           mask );
   }
 }
 
@@ -1402,30 +1201,26 @@ void DofManager::copyVectorToField( VECTOR const & vector,
                                     string const & srcFieldName,
                                     string const & dstFieldName,
                                     real64 const scalingFactor,
-                                    localIndex const loCompIndex,
-                                    localIndex const hiCompIndex ) const
+                                    CompMask const mask ) const
 {
   vectorToField< FieldSpecificationEqual, parallelHostPolicy >( vector.extractLocalVector(),
                                                                 srcFieldName,
                                                                 dstFieldName,
                                                                 scalingFactor,
-                                                                loCompIndex,
-                                                                hiCompIndex );
+                                                                mask );
 }
 
 void DofManager::copyVectorToField( arrayView1d< real64 const > const & localVector,
                                     string const & srcFieldName,
                                     string const & dstFieldName,
                                     real64 const scalingFactor,
-                                    localIndex const loCompIndex,
-                                    localIndex const hiCompIndex ) const
+                                    CompMask const mask ) const
 {
   vectorToField< FieldSpecificationEqual, parallelDevicePolicy<> >( localVector,
                                                                     srcFieldName,
                                                                     dstFieldName,
                                                                     scalingFactor,
-                                                                    loCompIndex,
-                                                                    hiCompIndex );
+                                                                    mask );
 }
 
 // Copy values from DOFs to nodes
@@ -1434,30 +1229,26 @@ void DofManager::addVectorToField( VECTOR const & vector,
                                    string const & srcFieldName,
                                    string const & dstFieldName,
                                    real64 const scalingFactor,
-                                   localIndex const loCompIndex,
-                                   localIndex const hiCompIndex ) const
+                                   CompMask const mask ) const
 {
   vectorToField< FieldSpecificationAdd, parallelHostPolicy >( vector.extractLocalVector(),
                                                               srcFieldName,
                                                               dstFieldName,
                                                               scalingFactor,
-                                                              loCompIndex,
-                                                              hiCompIndex );
+                                                              mask );
 }
 
 void DofManager::addVectorToField( arrayView1d< real64 const > const & localVector,
                                    string const & srcFieldName,
                                    string const & dstFieldName,
                                    real64 const scalingFactor,
-                                   localIndex const loCompIndex,
-                                   localIndex const hiCompIndex ) const
+                                   CompMask const mask ) const
 {
   vectorToField< FieldSpecificationAdd, parallelDevicePolicy<> >( localVector,
                                                                   srcFieldName,
                                                                   dstFieldName,
                                                                   scalingFactor,
-                                                                  loCompIndex,
-                                                                  hiCompIndex );
+                                                                  mask );
 }
 
 template< typename FIELD_OP, typename POLICY, typename LOCAL_VECTOR >
@@ -1465,20 +1256,15 @@ void DofManager::fieldToVector( LOCAL_VECTOR localVector,
                                 string const & srcFieldName,
                                 string const & dstFieldName,
                                 real64 const scalingFactor,
-                                localIndex const loCompIndex,
-                                localIndex const hiCompIndex ) const
+                                CompMask mask ) const
 {
   FieldDescription const & fieldDesc = m_fields[getFieldIndex( srcFieldName )];
-
-  localIndex const loComp = loCompIndex;
-  localIndex const hiComp = (hiCompIndex >= 0) ? hiCompIndex : fieldDesc.numComponents;
-  GEOSX_ASSERT( loComp >= 0 && hiComp <= fieldDesc.numComponents && loComp < hiComp );
+  mask.setNumComp( fieldDesc.numComponents );
 
   if( fieldDesc.location == Location::Elem )
   {
     m_mesh->getElemManager().forElementSubRegions< ElementSubRegionBase >( fieldDesc.regions,
-                                                                           [&]( localIndex const,
-                                                                                ElementSubRegionBase const & subRegion )
+                                                                           [&]( localIndex const, ElementSubRegionBase const & subRegion )
     {
       fieldToVectorImpl< FIELD_OP, POLICY >( localVector,
                                              subRegion,
@@ -1486,20 +1272,18 @@ void DofManager::fieldToVector( LOCAL_VECTOR localVector,
                                              dstFieldName,
                                              scalingFactor,
                                              rankOffset(),
-                                             loComp,
-                                             hiComp );
+                                             mask );
     } );
   }
   else
   {
     fieldToVectorImpl< FIELD_OP, POLICY >( localVector,
-                                           getObjectManager( fieldDesc.location, m_mesh ),
+                                           getObjectManager( fieldDesc.location, *m_mesh ),
                                            fieldDesc.key,
                                            dstFieldName,
                                            scalingFactor,
                                            rankOffset(),
-                                           loComp,
-                                           hiComp );
+                                           mask );
   }
 }
 
@@ -1509,30 +1293,26 @@ void DofManager::copyFieldToVector( VECTOR & vector,
                                     string const & srcFieldName,
                                     string const & dstFieldName,
                                     real64 const scalingFactor,
-                                    localIndex const loCompIndex,
-                                    localIndex const hiCompIndex ) const
+                                    CompMask const mask ) const
 {
   fieldToVector< FieldSpecificationEqual, parallelHostPolicy >( vector.extractLocalVector(),
                                                                 srcFieldName,
                                                                 dstFieldName,
                                                                 scalingFactor,
-                                                                loCompIndex,
-                                                                hiCompIndex );
+                                                                mask );
 }
 
 void DofManager::copyFieldToVector( arrayView1d< real64 > const & localVector,
                                     string const & srcFieldName,
                                     string const & dstFieldName,
                                     real64 const scalingFactor,
-                                    localIndex const loCompIndex,
-                                    localIndex const hiCompIndex ) const
+                                    CompMask const mask ) const
 {
   fieldToVector< FieldSpecificationEqual, parallelDevicePolicy<> >( localVector,
                                                                     srcFieldName,
                                                                     dstFieldName,
                                                                     scalingFactor,
-                                                                    loCompIndex,
-                                                                    hiCompIndex );
+                                                                    mask );
 }
 
 // Copy values from nodes to DOFs
@@ -1541,135 +1321,26 @@ void DofManager::addFieldToVector( VECTOR & vector,
                                    string const & srcFieldName,
                                    string const & dstFieldName,
                                    real64 const scalingFactor,
-                                   localIndex const loCompIndex,
-                                   localIndex const hiCompIndex ) const
+                                   CompMask const mask ) const
 {
   fieldToVector< FieldSpecificationAdd, parallelHostPolicy >( vector.extractLocalVector(),
                                                               srcFieldName,
                                                               dstFieldName,
                                                               scalingFactor,
-                                                              loCompIndex,
-                                                              hiCompIndex );
+                                                              mask );
 }
 
 void DofManager::addFieldToVector( arrayView1d< real64 > const & localVector,
                                    string const & srcFieldName,
                                    string const & dstFieldName,
                                    real64 const scalingFactor,
-                                   localIndex const loCompIndex,
-                                   localIndex const hiCompIndex ) const
+                                   CompMask const mask ) const
 {
   fieldToVector< FieldSpecificationAdd, parallelDevicePolicy<> >( localVector,
                                                                   srcFieldName,
                                                                   dstFieldName,
                                                                   scalingFactor,
-                                                                  loCompIndex,
-                                                                  hiCompIndex );
-}
-
-// Just an interface to allow only three parameters
-void DofManager::addCoupling( string const & rowFieldName,
-                              string const & colFieldName,
-                              Connector const connectivity )
-{
-  addCoupling( rowFieldName, colFieldName, connectivity, {}, true );
-}
-
-// Just another interface to allow four parameters (no symmetry)
-void DofManager::addCoupling( string const & rowFieldName,
-                              string const & colFieldName,
-                              Connector const connectivity,
-                              arrayView1d< string const > const & regions )
-{
-  addCoupling( rowFieldName, colFieldName, connectivity, regions, true );
-}
-
-// Just another interface to allow four parameters (no regions)
-void DofManager::addCoupling( string const & rowFieldName,
-                              string const & colFieldName,
-                              Connector const connectivity,
-                              bool const symmetric )
-{
-  addCoupling( rowFieldName, colFieldName, connectivity, {}, symmetric );
-}
-
-// The real function, allowing the creation of coupling blocks
-void DofManager::addCoupling( string const & rowFieldName,
-                              string const & colFieldName,
-                              Connector const connectivity,
-                              arrayView1d< string const > const & regions,
-                              bool const symmetric )
-{
-  localIndex const rowFieldIndex = getFieldIndex( rowFieldName );
-  localIndex const colFieldIndex = getFieldIndex( colFieldName );
-
-  // Check if already defined
-  if( m_coupling[rowFieldIndex][colFieldIndex].connector != Connector::None )
-  {
-    GEOSX_ERROR( "addCoupling: coupling already defined with another connectivity" );
-    return;
-  }
-
-  // get row/col field regions
-  std::vector< string > const & rowRegions = m_fields[rowFieldIndex].regions;
-  std::vector< string > const & colRegions = m_fields[colFieldIndex].regions;
-  std::vector< string > & regionList = m_coupling[rowFieldIndex][colFieldIndex].regions;
-
-  if( regions.empty() )
-  {
-    // Populate with regions common between two fields
-    regionList.resize( std::min( rowRegions.size(), colRegions.size() ) );
-    auto it = std::set_intersection( rowRegions.begin(), rowRegions.end(),
-                                     colRegions.begin(), colRegions.end(),
-                                     regionList.begin() );
-    regionList.resize( std::distance( regionList.begin(), it ) );
-  }
-  else
-  {
-    // Sort alphabetically and remove possible duplicates in user input
-    regionList.resize( regions.size() );
-    std::copy( regions.begin(), regions.end(), regionList.begin() );
-    std::sort( regionList.begin(), regionList.end() );
-    regionList.resize( std::distance( regionList.begin(), std::unique( regionList.begin(), regionList.end() ) ) );
-
-    // Check that both fields exist on all regions in the list
-    for( string const & regionName : regionList )
-    {
-      GEOSX_ERROR_IF( std::find( rowRegions.begin(), rowRegions.end(), regionName ) == rowRegions.end(),
-                      "Region '" << regionName << "' does not belong to the domain of field '" << rowFieldName << "'" );
-      GEOSX_ERROR_IF( std::find( colRegions.begin(), colRegions.end(), regionName ) == colRegions.end(),
-                      "Region '" << regionName << "' does not belong to the domain of field '" << colFieldName << "'" );
-    }
-  }
-
-  // save field's connectivity type (rowField to colField)
-  m_coupling[rowFieldIndex][colFieldIndex].connector = connectivity;
-
-  if( connectivity == Connector::None && rowFieldIndex == colFieldIndex )
-  {
-    m_coupling[rowFieldIndex][colFieldIndex].connector = static_cast< Connector >( m_fields[rowFieldIndex].location );
-  }
-
-  // Set connectivity with active symmetry flag
-  if( symmetric && colFieldIndex != rowFieldIndex )
-  {
-    m_coupling[colFieldIndex][rowFieldIndex].connector = connectivity;
-    m_coupling[colFieldIndex][rowFieldIndex].regions = regionList;
-  }
-}
-
-void DofManager::addCoupling( string const & fieldName,
-                              FluxApproximationBase const & stencils )
-{
-  localIndex const fieldIndex = getFieldIndex( fieldName );
-  FieldDescription const & field = m_fields[fieldIndex];
-
-  GEOSX_ERROR_IF( field.location != Location::Elem, "Field must be supported on elements in order to use stencil sparsity" );
-
-  CouplingDescription & coupling = m_coupling[fieldIndex][fieldIndex];
-  coupling.connector = Connector::Stencil;
-  coupling.regions = field.regions;
-  coupling.stencils = &stencils;
+                                                                  mask );
 }
 
 void DofManager::reorderByRank()
@@ -1694,11 +1365,10 @@ void DofManager::reorderByRank()
     LocationSwitch( field.location, [&]( auto const loc )
     {
       Location constexpr LOC = decltype(loc)::value;
-      using ArrayHelper = IndexArrayHelper< globalIndex, LOC >;
+      using ArrayHelper = ArrayHelper< globalIndex, LOC >;
+      typename ArrayHelper::Accessor indexArray = ArrayHelper::get( *m_mesh, field.key );
 
-      typename ArrayHelper::Accessor indexArray = ArrayHelper::get( m_mesh, field.key );
-
-      forMeshLocation< LOC, false >( m_mesh, field.regions, [&]( auto const locIdx )
+      forMeshLocation< LOC, false, parallelHostPolicy >( *m_mesh, field.regions, [&]( auto const locIdx )
       {
         ArrayHelper::reference( indexArray, locIdx ) += adjustment;
       } );
@@ -1708,8 +1378,9 @@ void DofManager::reorderByRank()
   }
 
   // synchronize index arrays for all fields across ranks
+  DomainPartition & domain = dynamicCast< DomainPartition & >( m_mesh->getParent().getParent().getParent() );
   CommunicationTools::getInstance().
-    synchronizeFields( fieldToSync, *m_mesh, m_domain->getNeighbors(), false );
+    synchronizeFields( fieldToSync, *m_mesh, domain.getNeighbors(), false );
 
   m_reordered = true;
 }
@@ -1718,29 +1389,49 @@ std::vector< DofManager::SubComponent >
 DofManager::filterDofs( std::vector< SubComponent > const & excluded ) const
 {
   std::vector< DofManager::SubComponent > result;
-  for( std::size_t k = 0; k < m_fields.size(); ++k )
+  for( const auto & field : m_fields )
   {
-    FieldDescription const & field = m_fields[k];
     auto const it = std::find_if( excluded.begin(), excluded.end(),
                                   [&]( SubComponent const & sc ) { return sc.fieldName == field.name; } );
-
-    localIndex loComp = 0;
-    localIndex hiComp = field.numComponents;
-    if( it != excluded.end() )
+    CompMask const includedComp = ( it != excluded.end() ) ? ~it->mask : ~CompMask( field.numComponents );
+    if( !includedComp.empty() )
     {
-      SubComponent const & sc = *it;
-      GEOSX_ASSERT( sc.loComp == 0 || sc.hiComp == field.numComponents );
-      loComp = (sc.loComp == 0) ? sc.hiComp : 0;
-      hiComp = (sc.hiComp == field.numComponents) ? sc.loComp : field.numComponents;
-    }
-    GEOSX_ASSERT_GE( hiComp, loComp );
-    if( hiComp > loComp )
-    {
-      result.push_back( { field.name, loComp, hiComp } );
+      result.push_back( { field.name, includedComp } );
     }
   }
 
   return result;
+}
+
+void DofManager::setupFrom( DofManager const & source,
+                            std::vector< SubComponent > const & selection )
+{
+  clear();
+  for( FieldDescription const & field : source.m_fields )
+  {
+    auto const it = std::find_if( selection.begin(), selection.end(),
+                                  [&]( SubComponent const & sc ) { return sc.fieldName == field.name; } );
+    if( it != selection.end() )
+    {
+      SubComponent const & sc = *it;
+      GEOSX_ASSERT_GE( field.numComponents, sc.mask.size() );
+      array1d< string > regions( field.regions.size() ); // TODO decide on array1d vs vector for interfaces?
+      std::copy( field.regions.begin(), field.regions.end(), regions.begin() );
+      addField( field.name, field.location, sc.mask.size(), regions );
+    }
+  }
+  for( auto const & entry : source.m_coupling )
+  {
+    string const & rowFieldName = source.m_fields[entry.first.first].name;
+    string const & colFieldName = source.m_fields[entry.first.second].name;
+    if( fieldExists( rowFieldName ) && fieldExists( colFieldName ) )
+    {
+      localIndex const rowFieldIndex = getFieldIndex( rowFieldName );
+      localIndex const colFieldIndex = getFieldIndex( colFieldName );
+      m_coupling.insert( { {rowFieldIndex, colFieldIndex}, entry.second } );
+    }
+  }
+  reorderByRank();
 }
 
 template< typename MATRIX >
@@ -1761,12 +1452,8 @@ void DofManager::makeRestrictor( std::vector< SubComponent > const & selection,
     FieldDescription const & fieldOld = m_fields[getFieldIndex( dof.fieldName )];
     FieldDescription & fieldNew = fieldsSelected[k];
 
-    GEOSX_ASSERT_GE( dof.loComp, 0 );
-    GEOSX_ASSERT_GE( fieldOld.numComponents, dof.hiComp );
-    GEOSX_ASSERT_GT( dof.hiComp, dof.loComp );
-
     fieldNew.name = selection[k].fieldName;
-    fieldNew.numComponents = dof.hiComp - dof.loComp;
+    fieldNew.numComponents = dof.mask.size();
     fieldNew.numLocalDof = fieldOld.numLocalDof / fieldOld.numComponents * fieldNew.numComponents;
     fieldNew.numGlobalDof = fieldOld.numGlobalDof / fieldOld.numComponents * fieldNew.numComponents;
     fieldNew.rankOffset = fieldOld.rankOffset / fieldOld.numComponents * fieldNew.numComponents;
@@ -1775,20 +1462,20 @@ void DofManager::makeRestrictor( std::vector< SubComponent > const & selection,
   // 2. Compute remaining offsets (we mostly just need globalOffset, but it depends on others)
 
   globalIndex blockOffset = 0;
-  for( std::size_t k = 0; k < fieldsSelected.size(); ++k )
+  for( auto & field : fieldsSelected )
   {
-    fieldsSelected[k].blockOffset = blockOffset;
-    blockOffset += fieldsSelected[k].numGlobalDof;
+    field.blockOffset = blockOffset;
+    blockOffset += field.numGlobalDof;
   }
 
   globalIndex globalOffset = std::accumulate( fieldsSelected.begin(), fieldsSelected.end(), globalIndex( 0 ),
                                               []( localIndex const n, FieldDescription const & f )
   { return n + f.rankOffset; } );
 
-  for( std::size_t k = 0; k < fieldsSelected.size(); ++k )
+  for( auto & field : fieldsSelected )
   {
-    fieldsSelected[k].globalOffset = globalOffset;
-    globalOffset += fieldsSelected[k].numLocalDof;
+    field.globalOffset = globalOffset;
+    globalOffset += field.numLocalDof;
   }
 
   // 3. Build the restrictor field by field
@@ -1811,17 +1498,18 @@ void DofManager::makeRestrictor( std::vector< SubComponent > const & selection,
     FieldDescription const & fieldRow = transpose ? fieldOld : fieldNew;
     FieldDescription const & fieldCol = transpose ? fieldNew : fieldOld;
 
-    localIndex const compOffsetRow = transpose ? selection[k].loComp : 0;
-    localIndex const compOffsetCol = transpose ? 0 : selection[k].loComp;
-
-    localIndex const numLocalNodes = numLocalSupport( fieldNew.name );
+    CompMask const mask = selection[k].mask;
+    localIndex const numLocalNodes = fieldNew.numLocalDof / fieldNew.numComponents;
 
     for( localIndex i = 0; i < numLocalNodes; ++i )
     {
-      for( localIndex c = 0; c < fieldNew.numComponents; ++c )
+      integer newComp = 0;
+      for( integer const oldComp : mask )
       {
-        restrictor.insert( fieldRow.globalOffset + i * fieldRow.numComponents + compOffsetRow + c,
-                           fieldCol.globalOffset + i * fieldCol.numComponents + compOffsetCol + c, 1.0 );
+        restrictor.insert( fieldRow.globalOffset + i * fieldRow.numComponents + ( transpose ? oldComp : newComp ),
+                           fieldCol.globalOffset + i * fieldCol.numComponents + ( transpose ? newComp : oldComp ),
+                           1.0 );
+        ++newComp;
       }
     }
   }
@@ -1829,12 +1517,11 @@ void DofManager::makeRestrictor( std::vector< SubComponent > const & selection,
   restrictor.close();
 }
 
-// Print the coupling table on screen
 void DofManager::printFieldInfo( std::ostream & os ) const
 {
   if( MpiWrapper::commRank( MPI_COMM_GEOSX ) == 0 )
   {
-    localIndex numFields = m_fields.size();
+    localIndex const numFields = LvArray::integerConversion< localIndex >( m_fields.size() );
 
     os << "Fields:" << std::endl;
     os << " # | " << std::setw( 20 ) << "name" << " | " << "comp" << " | " << "N global DOF" << std::endl;
@@ -1854,40 +1541,46 @@ void DofManager::printFieldInfo( std::ostream & os ) const
     {
       for( localIndex j = 0; j < numFields; ++j )
       {
-        switch( m_coupling[i][j].connector )
+        if( m_coupling.count( {i, j} ) == 0 )
+        {
+          continue;
+        }
+        switch( m_coupling.at( {i, j} ).connector )
         {
           case Connector::Elem:
           {
             os << " E ";
+            break;
           }
-          break;
           case Connector::Face:
           {
             os << " F ";
+            break;
           }
-          break;
           case Connector::Edge:
           {
             os << " G ";
+            break;
           }
-          break;
           case Connector::Node:
           {
             os << " N ";
+            break;
           }
-          break;
           case Connector::None:
           {
             os << "   ";
+            break;
           }
-          break;
           case Connector::Stencil:
           {
             os << " S ";
+            break;
           }
-          break;
           default:
-            GEOSX_ERROR( "Invalid connector type: " << static_cast< int >( m_coupling[i][j].connector ) );
+          {
+            GEOSX_ERROR( "Invalid connector type: " << static_cast< int >( m_coupling.at( {i, j} ).connector ) );
+          }
         }
         if( j < numFields - 1 )
         {
@@ -1909,36 +1602,26 @@ void DofManager::printFieldInfo( std::ostream & os ) const
 }
 
 #define MAKE_DOFMANAGER_METHOD_INST( LAI ) \
-  template void DofManager::setSparsityPattern( LAI::ParallelMatrix &, \
-                                                bool const ) const; \
-  template void DofManager::setSparsityPattern( LAI::ParallelMatrix &, \
-                                                string const &, \
-                                                string const &, \
-                                                bool const ) const; \
   template void DofManager::copyVectorToField( LAI::ParallelVector const &, \
                                                string const &, \
                                                string const &, \
                                                real64 const, \
-                                               localIndex const, \
-                                               localIndex const ) const; \
+                                               CompMask const ) const; \
   template void DofManager::addVectorToField( LAI::ParallelVector const &, \
                                               string const &, \
                                               string const &, \
                                               real64 const, \
-                                              localIndex const, \
-                                              localIndex const ) const; \
+                                              CompMask const ) const; \
   template void DofManager::copyFieldToVector( LAI::ParallelVector &, \
                                                string const &, \
                                                string const &, \
                                                real64 const, \
-                                               localIndex const, \
-                                               localIndex const ) const; \
+                                               CompMask const ) const; \
   template void DofManager::addFieldToVector( LAI::ParallelVector &, \
                                               string const &, \
                                               string const &, \
                                               real64 const, \
-                                              localIndex const, \
-                                              localIndex const ) const; \
+                                              CompMask const ) const; \
   template void DofManager::makeRestrictor( std::vector< SubComponent > const & selection, \
                                             MPI_Comm const & comm, \
                                             bool const transpose, \

--- a/src/coreComponents/linearAlgebra/DofManager.hpp
+++ b/src/coreComponents/linearAlgebra/DofManager.hpp
@@ -19,11 +19,8 @@
 #ifndef GEOSX_LINEARALGEBRA_DOFMANAGER_HPP_
 #define GEOSX_LINEARALGEBRA_DOFMANAGER_HPP_
 
-#include "LvArray/src/SparsityPattern.hpp"
 #include "common/DataTypes.hpp"
-#include "linearAlgebra/interfaces/InterfaceTypes.hpp"
-#include "mesh/ElementRegionManager.hpp"
-#include "mesh/NodeManager.hpp"
+#include "linearAlgebra/utilities/ComponentMask.hpp"
 
 #include <numeric>
 
@@ -44,6 +41,23 @@ class FluxApproximationBase;
 class DofManager
 {
 public:
+
+  /// Maximum number of components in a field
+  static int constexpr MAX_COMP = 32;
+
+  /// Type of component mask used by DofManager
+  using CompMask = ComponentMask< MAX_COMP >;
+
+  /**
+   * @brief Describes a selection of components from a DoF field.
+   *
+   * A half-open range [@p loComp, @p hiComp) is selected.
+   */
+  struct SubComponent
+  {
+    string fieldName;  ///< Name of the DOF field in DofManager
+    CompMask mask;     ///< Mask that defines component selection
+  };
 
   /**
    * @brief Enumeration of geometric objects for support location. Note that this
@@ -74,11 +88,6 @@ public:
   };
 
   /**
-   * Limit on max number of fields
-   */
-  static localIndex constexpr MAX_FIELDS = 10;
-
-  /**
    * @brief Constructor.
    *
    * @param [in] name a unique name for this DoF manager
@@ -102,10 +111,10 @@ public:
   DofManager & operator=( DofManager const & ) = delete;
 
   /**
-   * @brief Deleted move assignment.
+   * @brief Defaulted move assignment.
    * @return
    */
-  DofManager & operator=( DofManager && ) = delete;
+  DofManager & operator=( DofManager && ) = default;
 
   /**
    * @brief Destructor.
@@ -113,130 +122,59 @@ public:
   ~DofManager() = default;
 
   /**
-   * Remove all fields
+   * @brief Remove all fields and couplings and re-enable addition of new fields.
    */
   void clear();
 
   /**
    * @brief Assign a mesh.
-   *
-   * @param [in] domain DomainPartition the input domain.
-   * @param [in] meshLevelIndex Optional localIndex the mesh level.
-   * @param [in] meshBodyIndex Optional localIndex the body level.
+   * @param mesh the target mesh (non-const access required for allocating index arrays)
+   * @note Calling this function unconditionally removes all previously defined fields and couplings.
+   *       The user should only call this when they actually want to replace the mesh with a new one,
+   *       or they think the mesh topology might have changed and so the DOFs need to be re-numbered.
+   *       They must then re-add all fields and couplings, and call reorderByRank() again.
    */
-  void setMesh( DomainPartition & domain,
-                localIndex const meshLevelIndex = 0,
-                localIndex const meshBodyIndex = 0 );
+  void setMesh( MeshLevel & mesh );
 
   /**
-   * @brief Just an interface to allow only three parameters.
+   * @brief Add a new field and enumerate its degrees-of-freedom.
    *
-   * @param [in] fieldName string the name of the field.
-   * @param [in] location Location where it is defined.
+   * @param [in] fieldName the name of the field
+   * @param [in] location type of mesh objects the field is defined on
+   * @param [in] components number of components
+   * @param [in] regions list of region names the field is defined on (if empty, selects all regions)
    */
   void addField( string const & fieldName,
-                 Location const location );
+                 Location location,
+                 integer components,
+                 std::vector< string > const & regions = {} );
 
   /**
-   * @brief Just another interface to allow four parameters (no regions, default is everywhere).
+   * @copydoc addField(string const &, Location, integer, std::vector< string > const &)
    *
-   * @param [in] fieldName string the name of the field.
-   * @param [in] location Location where it is defined.
-   * @param [in] components localIndex number of components (for vector fields).
+   * Overload for arrayView1d<string> input used by physics solvers.
    */
   void addField( string const & fieldName,
-                 Location const location,
-                 localIndex const components );
-
-  /**
-   * @brief Just another interface to allow four parameters (no components, default is 1).
-   *
-   * @param [in] fieldName string the name of the field.
-   * @param [in] location Location where it is defined.
-   * @param [in] regions names of regions where this field is defined.
-   */
-  void addField( string const & fieldName,
-                 Location const location,
+                 Location location,
+                 integer components,
                  arrayView1d< string const > const & regions );
-
-  /**
-   * @brief The user can add a field with a support location, connectivity type, string key, number of scalar
-   * components, and a list of element regions over which the field is active. If the region list is empty,
-   * it is assumed the field exists on all regions.
-   *
-   * The connectivity type is used to infer the sparsity pattern that connects degrees of freedom.
-   * If LC denotes a boolean connectivity graph between support locations L and connectors C, the desired sparsity
-   * pattern will be computed as LC*CL. For example, for a TPFA discretization we have dofs located at cell centers,
-   * and connected through adjacent faces. In this example, LC is the cell-to-face connectivity, and LC*CL is the
-   * desired TPFA sparsity pattern. More generally,
-   *
-   * - Example 1 = ("displacement",NODE,ELEM,3) for a Q1 finite-element interpolation for elasticity
-   * - Example 2 = ("pressure",ELEM,FACE,1) for a scalar TPFA-type approximation
-   * - Example 3 = ("pressure",ELEM,NODE,1) for a scalar MPFA-type approximation
-   * - Example 4 = ("mass",ELEM,NONE,1) for a diagonal-only sparsity pattern (no connectivitys)
-   *
-   * When the number of components is greater than one, we always assume they are tightly coupled to one another
-   * and form a dense block. The sparsity pattern LC*CL is then interpreted as the super-node pattern, containing
-   * dense sub-blocks.
-   *
-   * @param [in] fieldName string the name of the field.
-   * @param [in] location Location where it is defined.
-   * @param [in] components localIndex number of components (for vector fields).
-   * @param [in] regions names of regions where this field is defined.
-   */
-  void addField( string const & fieldName,
-                 Location const location,
-                 localIndex const components,
-                 arrayView1d< string const > const & regions );
-
-  /**
-   * @brief Just an interface to allow only three parameters.
-   *
-   * @param [in] rowFieldName string the name of the row field.
-   * @param [in] colFieldName string the name of the col field.
-   * @param [in] connectivity Connectivity through what they are connected.
-   */
-  void addCoupling( string const & rowFieldName,
-                    string const & colFieldName,
-                    Connector const connectivity );
-
-  /**
-   * @brief Just another interface to allow four parameters (no symmetry, default is true).
-   *
-   * @param [in] rowFieldName string the name of the row field.
-   * @param [in] colFieldName string the name of the col field.
-   * @param [in] connectivity Connectivity through what they are connected.
-   * @param [in] regions names of regions where this coupling is defined.
-   */
-  void addCoupling( string const & rowFieldName,
-                    string const & colFieldName,
-                    Connector const connectivity,
-                    arrayView1d< string const > const & regions );
-
-  /**
-   * @brief Just another interface to allow four parameters (no regions, default is everywhere).
-   *
-   * @param [in] rowFieldName string the name of the row field.
-   * @param [in] colFieldName string the name of the col field.
-   * @param [in] connectivity Connectivity through what they are connected.
-   * @param [in] symmetric bool is it symmetric, i.e., both row-col and col-row?
-   */
-  void addCoupling( string const & rowFieldName,
-                    string const & colFieldName,
-                    Connector const connectivity,
-                    bool const symmetric );
 
   /**
    * @brief Add coupling between two fields.
+   *
    * The connectivity argument defines how the two fields couple. If the first field has support location A,
    * the second field has support location B, and the connecting object is C, the sparsity pattern will be
    * defined as (AC)(CB). The final argument indicates if the coupling is symmetric, in the sense that there
    * is a two-way coupling between the fields. Without this argument, a nonzero block will be added to the
    * system matrix for block AB, but block BA will remain zero (one-way coupling).
    *
-   * - Example 1 = ("node_field","elem_field", ELEM, true) couples all dofs sharing a common element (two-way coupling)
-   * - Example 2 = ("node_field_1","node_field_2", NODE, true) couples all dofs sharing a common node (two-way coupling)
-   * - Example 3 = ("node_field_1","face_field", NODE, false) couples nodal dofs to adjacent faces (one-way coupling)
+   * - Example 1 = ("node_field","elem_field", ELEM, {}, true) couples all dofs sharing a common element (two-way coupling)
+   * - Example 2 = ("node_field","node_field", NODE, {}, true) couples all dofs sharing a common node (two-way coupling)
+   * - Example 3 = ("node_field","face_field", NODE, {}, false) couples nodal dofs to adjacent faces (one-way coupling)
+   *
+   * When the number of components is greater than one, we always assume they are tightly coupled to one another
+   * and form a dense block. The sparsity pattern LC*CL is then interpreted as the super-node pattern, containing
+   * dense sub-blocks.
    *
    * @param [in] rowFieldName string the name of the row field.
    * @param [in] colFieldName string the name of the col field.
@@ -246,9 +184,20 @@ public:
    */
   void addCoupling( string const & rowFieldName,
                     string const & colFieldName,
-                    Connector const connectivity,
+                    Connector connectivity,
+                    std::vector< string > const & regions = {},
+                    bool symmetric = true );
+
+  /**
+   * @copydoc addCoupling(string const &, string const &, Connector, std::vector< string > const &, bool)
+   *
+   * Overload for arrayView1d<string> input used by physics solvers.
+   */
+  void addCoupling( string const & rowFieldName,
+                    string const & colFieldName,
+                    Connector connectivity,
                     arrayView1d< string const > const & regions,
-                    bool const symmetric );
+                    bool symmetric = true );
 
   /**
    * @brief Special interface for self-connectivity through a stencil.
@@ -262,7 +211,7 @@ public:
                     FluxApproximationBase const & stencils );
 
   /**
-   * @brief Finish populating fields and apply appropriate dof renumbering
+   * @brief Finish populating fields and apply appropriate dof renumbering.
    *
    * This function must be called after all field and coupling information has been added.
    * It adjusts DoF index arrays to account for presence of other fields (in a global monolithic fashion).
@@ -279,8 +228,7 @@ public:
   void reorderByRank();
 
   /**
-   * @brief Check if string key is already being used
-   *
+   * @brief Check if string key is already being used.
    * @param name field key to check
    * @return flag true if exists
    */
@@ -288,38 +236,79 @@ public:
 
   /**
    * @brief Return the key used to record the field in the DofManager.
-   *
    * @param [in] fieldName string the name of the field.
    * @return string indicating name of the field.
    */
   string const & getKey( string const & fieldName ) const;
 
   /**
-   * @brief Return global number of dofs across all processors. If field argument is empty, return
-   * monolithic size.
-   *
-   * @param [in] fieldName Optional string the name of the field.
-   * @return     number of global dofs
+   * @brief @return number of global dofs of a given field.
+   * @param fieldName the name of the field
    */
-  globalIndex numGlobalDofs( string const & fieldName = "" ) const;
+  globalIndex numGlobalDofs( string const & fieldName ) const;
 
   /**
-   * @brief Return local number of dofs on this processor. If field argument is empty, return
-   * monolithic size.
-   *
-   * @param [in] fieldName Optional string the name of the field.
-   * @return     number of local dofs
+   * @brief @return total number of dofs across all fields and processors.
    */
-  localIndex numLocalDofs( string const & fieldName = "" ) const;
+  globalIndex numGlobalDofs() const;
 
   /**
-   * @brief Return an array of local number of dofs on this processor
-   * sorted by field registration order.
-   *
-   * @return     array of number of local dofs
+   * @brief @return number of local dofs of a given field.
+   * @param fieldName name of the field
    */
-  array1d< localIndex > numLocalDofsPerField() const;
+  localIndex numLocalDofs( string const & fieldName ) const;
 
+  /**
+   * @brief @return total number of dofs across all fields on current processor.
+   */
+  localIndex numLocalDofs() const;
+
+  /**
+   * @brief @return rank offset of given field, i.e. total number of dofs of this field on previous processors.
+   * @param fieldName name of the field
+   */
+  globalIndex rankOffset( string const & fieldName ) const;
+
+  /**
+   * @brief @return rank offset of current processor, i.e. total number of dofs on previous processors.
+   */
+  globalIndex rankOffset() const;
+
+  /**
+   * @brief @return number of components in a given field.
+   * @param fieldName name of the field
+   */
+  integer numComponents( string const & fieldName = "" ) const;
+
+  /**
+   * @brief @return number of dof components across all fields.
+   */
+  integer numComponents() const;
+
+  /**
+   * @brief Get the support location type of the field.
+   * @param [in] fieldName name of the field
+   * @return support location type
+   */
+  Location location( string const & fieldName ) const;
+
+  /**
+   * @brief @return The list of region names in field's domain.
+   * @param fieldName name of the field
+   */
+  std::vector< string > const & regions( string const & fieldName ) const;
+
+  /**
+   * @brief @return global offset of field's block on current processor in the system matrix.
+   * @param [in] fieldName name of the field.
+   */
+  globalIndex globalOffset( string const & fieldName ) const;
+
+  /**
+   * @brief Return an array of number of components per field, sorted by field registration order.
+   * @return array of number of components
+   */
+  array1d< integer > numComponentsPerField() const;
 
   /**
    * @brief Fill a container with unique dof labels for each local dof.
@@ -338,7 +327,8 @@ public:
     for( FieldDescription const & field : m_fields )
     {
       localIndex const numComp = field.numComponents;
-      for( localIndex i = 0; i < field.numLocalDof / numComp; ++i, it += numComp )
+      localIndex const numSupp = field.numLocalDof / numComp;
+      for( localIndex i = 0; i < numSupp; ++i, it += numComp )
       {
         std::iota( it, it + numComp, labelStart );
       }
@@ -347,120 +337,27 @@ public:
   }
 
   /**
-   * @brief Return the sum of local dofs across all previous processors w.r.t. to the calling one for
-   * the specified field.
-   *
-   * @param [in] fieldName Optional string the name of the field.
-   * @return     the rank offset
-   */
-  globalIndex rankOffset( string const & fieldName = "" ) const;
-
-  /**
-   * @brief Get the number of components in a field. If field argument is empty, return
-   * the total number of components across fields.
-   *
-   * @param [in] fieldName Optional string the name of the field.
-   * @return     the number of dof components
-   */
-  localIndex numComponents( string const & fieldName = "" ) const;
-
-  /**
-   * @brief Return an array of number of components per field, sorted by field
-   * registration order.
-   *
-   * @return     array of number of components
-   */
-  array1d< localIndex > numComponentsPerField() const;
-
-  /**
-   * @brief Get the local number of support points on this processor.
-   * @param [in] fieldName the name of the field
-   * @return number of local support points
-   */
-  localIndex numLocalSupport( string const & fieldName ) const;
-
-  /**
-   * @brief Get the local number of support points across all processors.
-   * @param [in] fieldName name of the field
-   * @return number of global support points
-   */
-  globalIndex numGlobalSupport( string const & fieldName ) const;
-
-  /**
-   * @brief Get the support location type of the field.
-   * @param [in] fieldName name of the field
-   * @return support location type
-   */
-  Location getLocation( string const & fieldName ) const;
-
-  /**
-   * @brief Get global offset of field's block on current processor in the system matrix.
-   * @param [in] fieldName name of the field.
-   * @return global offset of the field
-   */
-  globalIndex globalOffset( string const & fieldName ) const;
-
-  /**
-   * @brief Populate sparsity pattern of the entire system matrix.
-   *
-   * @param [out] matrix the target parallel matrix
-   * @param [in]  closePattern whether to reorderByRank the matrix upon pattern assembly
-   */
-  template< typename MATRIX >
-  void setSparsityPattern( MATRIX & matrix,
-                           bool closePattern = true ) const;
-
-  /**
-   * @brief Populate sparsity pattern for one block of the system matrix.
-   *
-   * @param [out] matrix the target parallel matrix
-   * @param [in]  rowFieldName the name of the row field.
-   * @param [in]  colFieldName the name of the col field.
-   * @param [in]  closePattern whether to reorderByRank the matrix upon pattern assembly
-   */
-  template< typename MATRIX >
-  void setSparsityPattern( MATRIX & matrix,
-                           string const & rowFieldName,
-                           string const & colFieldName,
-                           bool closePattern = true ) const;
-
-  /**
    * @brief Populate sparsity pattern of the entire system matrix.
    * @param [out] pattern the target sparsity pattern
    */
   void setSparsityPattern( SparsityPattern< globalIndex > & pattern ) const;
 
   /**
-   * @brief Populate sparsity pattern for one block of the system matrix.
-   * @param [out] pattern the target sparsity pattern
-   * @param [in]  rowFieldName name of the row field
-   * @param [in]  colFieldName name of the col field
-   */
-  void setSparsityPattern( SparsityPattern< globalIndex > & pattern,
-                           string const & rowFieldName,
-                           string const & colFieldName ) const;
-
-  /**
    * @brief Copy values from LA vectors to simulation data arrays.
    *
-   * @tparam FIELD_OP operation to perform (see FieldSpecificationOps.hpp)
+   * @tparam VECTOR type of LA vector
    * @param vector source LA vector
    * @param srcFieldName name of the source field (as defined in DofManager)
    * @param dstFieldName name of the destination field (view wrapper key on the manager)
    * @param scalingFactor a factor to scale vector values by
-   * @param loCompIndex index of starting DoF component (for partial copy)
-   * @param hiCompIndex index past the ending DoF component (for partial copy)
-   *
-   * @note [@p loCompIndex , @p hiCompIndex) form a half-open interval.
-   *       Negative value of @p hiCompIndex means use full number of field components
+   * @param mask component selection mask
    */
   template< typename VECTOR >
   void copyVectorToField( VECTOR const & vector,
                           string const & srcFieldName,
                           string const & dstFieldName,
-                          real64 const scalingFactor,
-                          localIndex const loCompIndex = 0,
-                          localIndex const hiCompIndex = -1 ) const;
+                          real64 scalingFactor,
+                          CompMask mask = CompMask( MAX_COMP, true ) ) const;
 
   /**
    * @brief Copy values from LA vectors to simulation data arrays.
@@ -469,40 +366,30 @@ public:
    * @param srcFieldName name of the source field (as defined in DofManager)
    * @param dstFieldName name of the destination field (view wrapper key on the manager)
    * @param scalingFactor a factor to scale vector values by
-   * @param loCompIndex index of starting DoF component (for partial copy)
-   * @param hiCompIndex index past the ending DoF component (for partial copy)
-   *
-   * @note [@p loCompIndex , @p hiCompIndex) form a half-open interval.
-   *       Negative value of @p hiCompIndex means use full number of field components
+   * @param mask component selection mask
    */
   void copyVectorToField( arrayView1d< real64 const > const & localVector,
                           string const & srcFieldName,
                           string const & dstFieldName,
-                          real64 const scalingFactor,
-                          localIndex const loCompIndex = 0,
-                          localIndex const hiCompIndex = -1 ) const;
+                          real64 scalingFactor,
+                          CompMask mask = CompMask( MAX_COMP, true ) ) const;
 
   /**
    * @brief Add values from LA vectors to simulation data arrays.
    *
-   * @tparam FIELD_OP operation to perform (see FieldSpecificationOps.hpp)
+   * @tparam VECTOR type of LA vector
    * @param vector source LA vector
    * @param srcFieldName name of the source field (as defined in DofManager)
    * @param dstFieldName name of the destination field (view wrapper key on the manager)
    * @param scalingFactor a factor to scale vector values by
-   * @param loCompIndex index of starting DoF component (for partial copy)
-   * @param hiCompIndex index past the ending DoF component (for partial copy)
-   *
-   * @note [@p loCompIndex , @p hiCompIndex) form a half-open interval.
-   *       Negative value of @p hiCompIndex means use full number of field components
+   * @param mask component selection mask
    */
   template< typename VECTOR >
   void addVectorToField( VECTOR const & vector,
                          string const & srcFieldName,
                          string const & dstFieldName,
-                         real64 const scalingFactor,
-                         localIndex const loCompIndex = 0,
-                         localIndex const hiCompIndex = -1 ) const;
+                         real64 scalingFactor,
+                         CompMask mask = CompMask( MAX_COMP, true ) ) const;
 
   /**
    * @brief Add values from LA vectors to simulation data arrays.
@@ -511,116 +398,77 @@ public:
    * @param srcFieldName name of the source field (as defined in DofManager)
    * @param dstFieldName name of the destination field (view wrapper key on the manager)
    * @param scalingFactor a factor to scale vector values by
-   * @param loCompIndex index of starting DoF component (for partial copy)
-   * @param hiCompIndex index past the ending DoF component (for partial copy)
-   *
-   * @note [@p loCompIndex , @p hiCompIndex) form a half-open interval.
-   *       Negative value of @p hiCompIndex means use full number of field components
+   * @param mask component selection mask
    */
   void addVectorToField( arrayView1d< real64 const > const & localVector,
                          string const & srcFieldName,
                          string const & dstFieldName,
-                         real64 const scalingFactor,
-                         localIndex const loCompIndex = 0,
-                         localIndex const hiCompIndex = -1 ) const;
+                         real64 scalingFactor,
+                         CompMask mask = CompMask( MAX_COMP, true ) ) const;
 
   /**
    * @brief Copy values from nodes to DOFs.
    *
-   * @tparam FIELD_OP operation to perform (see FieldSpecificationOps.hpp)
+   * @tparam VECTOR type of LA vector
    * @param vector target LA vector
    * @param srcFieldName name of the source field (view wrapper key on the manager)
    * @param dstFieldName name of the destination field (as defined in DofManager)
    * @param scalingFactor a factor to scale vector values by
-   * @param loCompIndex index of starting DoF component (for partial copy)
-   * @param hiCompIndex index past the ending DoF component (for partial copy)
-   *
-   * @note [@p loCompIndex , @p hiCompIndex) form a half-open interval.
-   *       Negative value of @p hiCompIndex means use full number of field components
+   * @param mask component selection mask
    */
   template< typename VECTOR >
   void copyFieldToVector( VECTOR & vector,
                           string const & srcFieldName,
                           string const & dstFieldName,
-                          real64 const scalingFactor,
-                          localIndex const loCompIndex = 0,
-                          localIndex const hiCompIndex = -1 ) const;
+                          real64 scalingFactor,
+                          CompMask mask = CompMask( MAX_COMP, true ) ) const;
 
   /**
    * @brief Copy values from simulation data arrays to vectors.
    *
-   * @tparam FIELD_OP operation to perform (see FieldSpecificationOps.hpp)
    * @param localVector target LA vector
    * @param srcFieldName name of the source field (view wrapper key on the manager)
    * @param dstFieldName name of the destination field (as defined in DofManager)
    * @param scalingFactor a factor to scale vector values by
-   * @param loCompIndex index of starting DoF component (for partial copy)
-   * @param hiCompIndex index past the ending DoF component (for partial copy)
-   *
-   * @note [@p loCompIndex , @p hiCompIndex) form a half-open interval.
-   *       Negative value of @p hiCompIndex means use full number of field components
+   * @param mask component selection mask
    */
   void copyFieldToVector( arrayView1d< real64 > const & localVector,
                           string const & srcFieldName,
                           string const & dstFieldName,
-                          real64 const scalingFactor,
-                          localIndex const loCompIndex = 0,
-                          localIndex const hiCompIndex = -1 ) const;
+                          real64 scalingFactor,
+                          CompMask mask = CompMask( MAX_COMP, true ) ) const;
 
   /**
    * @brief Add values from a simulation data array to a DOF vector.
    *
-   * @tparam FIELD_OP operation to perform (see FieldSpecificationOps.hpp)
+   * @tparam VECTOR type of LA vector
    * @param vector target LA vector
    * @param srcFieldName name of the source field (view wrapper key on the manager)
    * @param dstFieldName name of the destination field (as defined in DofManager)
    * @param scalingFactor a factor to scale vector values by
-   * @param loCompIndex index of starting DoF component (for partial copy)
-   * @param hiCompIndex index past the ending DoF component (for partial copy)
-   *
-   * @note [@p loCompIndex , @p hiCompIndex) form a half-open interval.
-   *       Negative value of @p hiCompIndex means use full number of field components
+   * @param mask component selection mask
    */
   template< typename VECTOR >
   void addFieldToVector( VECTOR & vector,
                          string const & srcFieldName,
                          string const & dstFieldName,
-                         real64 const scalingFactor,
-                         localIndex const loCompIndex = 0,
-                         localIndex const hiCompIndex = -1 ) const;
+                         real64 scalingFactor,
+                         CompMask mask = CompMask( MAX_COMP, true ) ) const;
 
   /**
    * @brief Add values from a simulation data array to a DOF vector.
    *
-   * @tparam FIELD_OP operation to perform (see FieldSpecificationOps.hpp)
    * @param localVector target vector
    * @param srcFieldName name of the source field (view wrapper key on the manager)
    * @param dstFieldName name of the destination field (as defined in DofManager)
    * @param scalingFactor a factor to scale vector values by
-   * @param loCompIndex index of starting DoF component (for partial copy)
-   * @param hiCompIndex index past the ending DoF component (for partial copy)
-   *
-   * @note [@p loCompIndex , @p hiCompIndex) form a half-open interval.
-   *       Negative value of @p hiCompIndex means use full number of field components
+   * @param mask component selection mask
    */
   void addFieldToVector( arrayView1d< real64 > const & localVector,
                          string const & srcFieldName,
                          string const & dstFieldName,
-                         real64 const scalingFactor,
-                         localIndex const loCompIndex = 0,
-                         localIndex const hiCompIndex = -1 ) const;
-
-  /**
-   * @brief Describes a selection of components from a DoF field.
-   *
-   * A half-open range [@p loComp, @p hiComp) is selected.
-   */
-  struct SubComponent
-  {
-    string fieldName;  //!< Name of the DOF field in DofManager
-    localIndex loComp; //!< Low component index (included in selection)
-    localIndex hiComp; //!< High component index (excluded from selection)
-  };
+                         real64 scalingFactor,
+                         CompMask mask = CompMask( MAX_COMP, true ) ) const;
 
   /**
    * @brief Create a dof selection by filtering out excluded components
@@ -633,6 +481,15 @@ public:
    */
   std::vector< SubComponent >
   filterDofs( std::vector< SubComponent > const & excluded ) const;
+
+  /**
+   * @brief Populate this manager from another using a sub-selection of fields/components.
+   * @param source source dof manager
+   * @param selection selection of fields/components
+   * @note this will also allocate new dof
+   */
+  void setupFrom( DofManager const & source,
+                  std::vector< SubComponent > const & selection );
 
   /**
    * @brief Create a matrix that restricts vectors and matrices to a subset of DOFs
@@ -666,17 +523,17 @@ private:
    */
   struct FieldDescription
   {
-    string name; //!< field name
-    Location location; //!< support location
-    std::vector< string > regions; //!< list of support region names
-    localIndex numComponents; //!< number of vector components
-    string key; //!< string key for index array
-    string docstring; //!< documentation string
-    localIndex numLocalDof; //!< number of local rows
-    globalIndex numGlobalDof; //!< number of global rows
-    globalIndex blockOffset;  //!< offset of this field's block in a block-wise ordered system
-    globalIndex rankOffset; //!< field's first DoF on current processor (within its block, ignoring other fields)
-    globalIndex globalOffset; //!< global offset of field's DOFs on current processor for multi-field problems
+    string name;                   ///< field name
+    string key;                    ///< string key for index array
+    string docstring;              ///< documentation string
+    std::vector< string > regions; ///< list of support region names
+    Location location;             ///< support location
+    integer numComponents = 1;     ///< number of vector components
+    localIndex numLocalDof = 0;    ///< number of local rows
+    globalIndex numGlobalDof = 0;  ///< number of global rows
+    globalIndex blockOffset = 0;   ///< offset of this field's block in a block-wise ordered system
+    globalIndex rankOffset = 0;    ///< field's first DoF on current processor (within its block, ignoring other fields)
+    globalIndex globalOffset = 0;  ///< global offset of field's DOFs on current processor for multi-field problems
   };
 
   /**
@@ -690,41 +547,27 @@ private:
   };
 
   /**
-   * @brief Initialize data structure for connectivity and sparsity pattern
-   */
-  void initializeDataStructure();
-
-  /**
    * @brief Get field index from string key
    */
   localIndex getFieldIndex( string const & name ) const;
 
   /**
-   * @brief Create index array for the field
+   * @brief Compute and save dof offsets the field
+   * @param fieldIndex index of the field
    */
-  void createIndexArray( FieldDescription & field );
+  void computeFieldDimensions( localIndex fieldIndex );
+
+  /**
+   * @brief Create index array for the field
+   * @param field the field descriptor
+   */
+  void createIndexArray( FieldDescription const & field );
 
   /**
    * @brief Remove an index array for the field
+   * @param field the field descriptor
    */
   void removeIndexArray( FieldDescription const & field );
-
-  /**
-   * @brief Populate the sparsity pattern for a coupling block between given fields.
-   * @param pattern the sparsity to be filled
-   * @param rowFieldIndex index of row field (must be non-negative)
-   * @param colFieldIndex index of col field (must be non-negative)
-   *
-   * This private function is used as a building block by higher-level SetSparsityPattern()
-   */
-  template< typename MATRIX >
-  void setSparsityPatternOneBlock( MATRIX & pattern,
-                                   localIndex const rowFieldIndex,
-                                   localIndex const colFieldIndex ) const;
-
-  template< typename MATRIX >
-  void setSparsityPatternFromStencil( MATRIX & pattern,
-                                      localIndex const fieldIndex ) const;
 
   /**
    * @brief Calculate or estimate the number of nonzero entries in each local row
@@ -733,11 +576,11 @@ private:
    * @param colFieldIndex index of col field (must be non-negative)
    */
   void countRowLengthsOneBlock( arrayView1d< localIndex > const & rowLengths,
-                                localIndex const rowFieldIndex,
-                                localIndex const colFieldIndex ) const;
+                                localIndex rowFieldIndex,
+                                localIndex colFieldIndex ) const;
 
   void countRowLengthsFromStencil( arrayView1d< localIndex > const & rowLengths,
-                                   localIndex const fieldIndex ) const;
+                                   localIndex fieldIndex ) const;
 
   /**
    * @brief Populate the sparsity pattern for a coupling block between given fields.
@@ -747,16 +590,16 @@ private:
    *
    * This private function is used as a building block by higher-level SetSparsityPattern()
    */
-  void setSparsityPatternOneBlock( SparsityPattern< globalIndex > & pattern,
-                                   localIndex const rowFieldIndex,
-                                   localIndex const colFieldIndex ) const;
+  void setSparsityPatternOneBlock( SparsityPatternView< globalIndex > const & pattern,
+                                   localIndex rowFieldIndex,
+                                   localIndex colFieldIndex ) const;
 
-  void setSparsityPatternFromStencil( SparsityPattern< globalIndex > & pattern,
-                                      localIndex const fieldIndex ) const;
+  void setSparsityPatternFromStencil( SparsityPatternView< globalIndex > const & pattern,
+                                      localIndex fieldIndex ) const;
 
   template< int DIMS_PER_DOF >
   void setFiniteElementSparsityPattern( SparsityPattern< globalIndex > & pattern,
-                                        localIndex const fieldIndex ) const;
+                                        localIndex fieldIndex ) const;
 
   /**
    * @brief Generic implementation for @ref copyVectorToField and @ref addVectorToField
@@ -774,12 +617,11 @@ private:
    *       Negative value of @p hiCompIndex means use full number of field components
    */
   template< typename FIELD_OP, typename POLICY, typename LOCAL_VECTOR >
-  void vectorToField( LOCAL_VECTOR const localVector,
+  void vectorToField( LOCAL_VECTOR localVector,
                       string const & srcFieldName,
                       string const & dstFieldName,
-                      real64 const scalingFactor,
-                      localIndex const loCompIndex,
-                      localIndex const hiCompIndex ) const;
+                      real64 scalingFactor,
+                      CompMask mask ) const;
 
   /**
    * @brief Generic implementation for @ref copyFieldToVector and @ref addFieldToVector
@@ -800,15 +642,11 @@ private:
   void fieldToVector( LOCAL_VECTOR localVector,
                       string const & srcFieldName,
                       string const & dstFieldName,
-                      real64 const scalingFactor,
-                      localIndex const loCompIndex,
-                      localIndex const hiCompIndex ) const;
+                      real64 scalingFactor,
+                      CompMask mask ) const;
 
   /// Name of the manager (unique, for unique identification of index array keys)
   string m_name;
-
-  /// Pointer to domain manager
-  DomainPartition * m_domain = nullptr;
 
   /// Pointer to corresponding MeshLevel
   MeshLevel * m_mesh = nullptr;
@@ -817,7 +655,7 @@ private:
   std::vector< FieldDescription > m_fields;
 
   /// Table of connector types within and between fields
-  std::vector< std::vector< CouplingDescription > > m_coupling;
+  std::map< std::pair< localIndex, localIndex >, CouplingDescription > m_coupling;
 
   /// Flag indicating that DOFs have been reordered rank-wise.
   bool m_reordered;

--- a/src/coreComponents/linearAlgebra/DofManagerHelpers.hpp
+++ b/src/coreComponents/linearAlgebra/DofManagerHelpers.hpp
@@ -19,6 +19,8 @@
 #ifndef GEOSX_LINEARALGEBRA_DOFMANAGERHELPERS_HPP
 #define GEOSX_LINEARALGEBRA_DOFMANAGERHELPERS_HPP
 
+#include "mesh/utilities/MeshMapUtilities.hpp"
+
 namespace geosx
 {
 
@@ -31,8 +33,7 @@ namespace
  * @tparam LOC type of mesh location
  */
 template< DofManager::Location LOC >
-struct MeshHelper
-{};
+struct MeshHelper;
 
 template<>
 struct MeshHelper< DofManager::Location::Node >
@@ -97,7 +98,6 @@ struct MeshHelper< DofManager::Location::Elem >
   using MapType = typename MANAGER::ElemMapType;
 };
 
-
 /**
  * @brief Compile-time limits on incidence between mesh objects.
  * @tparam LOC primary mesh object (location) type
@@ -144,202 +144,6 @@ SET_MAX_MESH_INCIDENCE( Elem, Edge, 12 );
 SET_MAX_MESH_INCIDENCE( Elem, Face, 6 );
 
 #undef SET_MAX_MESH_INCIDENCE
-
-template< DofManager::Location LOC, typename MANAGER >
-struct MapTypeHelper
-{
-  using type = typename MeshHelper< LOC >::template MapType< MANAGER >;
-};
-
-// return dummy type if target manager type does not declare a type alias to map to LOC objects
-// this allows all switchyards to compile, but one shouldn't attempt to access a non-existent map
-template< DofManager::Location LOC, typename MANAGER >
-using MapType = typename MapTypeHelper< LOC, MANAGER >::type;
-
-// some helper crust to extract underlying type from InterObjectRelation and the likes
-template< typename T, bool >
-struct BaseTypeHelper
-{
-  using type = T;
-};
-
-template< typename T >
-struct BaseTypeHelper< T, true >
-{
-  using type = typename T::base_type;
-};
-
-HAS_MEMBER_TYPE( base_type );
-
-template< typename MAP >
-using BaseType = typename BaseTypeHelper< MAP, HasMemberType_base_type< MAP > >::type;
-
-/**
- * @brief Helper struct that specializes access to various map types
- * @tparam MAP type of the map
- */
-template< typename MAP >
-struct MapHelperImpl
-{};
-
-template< typename T, typename PERMUTATION >
-struct MapHelperImpl< array2d< T, PERMUTATION > >
-{
-  static localIndex size0( array2d< T, PERMUTATION > const & map )
-  {
-    return map.size( 0 );
-  }
-
-  static localIndex size1( array2d< T, PERMUTATION > const & map, localIndex const GEOSX_UNUSED_PARAM( i0 ) )
-  {
-    return map.size( 1 );
-  }
-
-  static T const & value( array2d< T, PERMUTATION > const & map, localIndex const i0, localIndex const i1 )
-  {
-    return map( i0, i1 );
-  }
-
-  static localIndex size0( arrayView2d<T const, LvArray::typeManipulation::getStrideOneDimension( PERMUTATION {} ) > const & map )
-  {
-    return map.size( 0 );
-  }
-
-  static localIndex size1( arrayView2d<T const, LvArray::typeManipulation::getStrideOneDimension( PERMUTATION {} ) > const & map, localIndex const GEOSX_UNUSED_PARAM( i0 ) )
-  {
-    return map.size( 1 );
-  }
-
-  static T const & value( arrayView2d<T const, LvArray::typeManipulation::getStrideOneDimension( PERMUTATION {} ) > const & map, localIndex const i0, localIndex const i1 )
-  {
-    return map( i0, i1 );
-  }
-
-};
-
-template< typename T >
-struct MapHelperImpl< array1d< array1d< T > > >
-{
-  static localIndex size0( array1d< array1d< T > > const & map )
-  {
-    return map.size();
-  }
-
-  static localIndex size1( array1d< array1d< T > > const & map, localIndex const i0 )
-  {
-    return map[i0].size();
-  }
-
-  static T const & value( array1d< array1d< T > > const & map, localIndex const i0, localIndex const i1 )
-  {
-    return map[i0][i1];
-  }
-
-  static localIndex size0( arrayView1d< arrayView1d< T const > const > const & map )
-  {
-    return map.size();
-  }
-
-  static localIndex size1( arrayView1d< arrayView1d< T const >  const > const & map, localIndex const i0 )
-  {
-    return map[i0].size();
-  }
-
-  static T const & value( arrayView1d< arrayView1d< T const > const > const & map, localIndex const i0, localIndex const i1 )
-  {
-    return map[i0][i1];
-  }
-
-};
-
-template< typename T >
-struct MapHelperImpl< ArrayOfArrays< T > >
-{
-  static localIndex size0( ArrayOfArraysView< T const > const & map )
-  {
-    return map.size();
-  }
-
-  static localIndex size1( ArrayOfArraysView< T const > const & map, localIndex const i0 )
-  {
-    return map.sizeOfArray( i0 );
-  }
-
-  static T const & value( ArrayOfArraysView< T const > const & map, localIndex const i0, localIndex const i1 )
-  {
-    return map( i0, i1 );
-  }
-};
-
-template< typename T >
-struct MapHelperImpl< array1d< SortedArray< T > > >
-{
-  static localIndex size0( array1d< SortedArray< T > > const & map )
-  {
-    return map.size();
-  }
-
-  static localIndex size1( array1d< SortedArray< T > > const & map, localIndex const i0 )
-  {
-    return map[i0].size();
-  }
-
-  static T const & value( array1d< SortedArray< T > > const & map, localIndex const i0, localIndex const i1 )
-  {
-    return map[i0][i1];
-  }
-};
-
-template< typename T >
-struct MapHelperImpl< ArrayOfSets< T > >
-{
-  static localIndex size0( ArrayOfSetsView< T const > const & map )
-  {
-    return map.size();
-  }
-
-  static localIndex size1( ArrayOfSetsView< T const > const & map, localIndex const i0 )
-  {
-    return map.sizeOfSet( i0 );
-  }
-
-  static T const & value( ArrayOfSetsView< T const > const & map, localIndex const i0, localIndex const i1 )
-  {
-    return map( i0, i1 );
-  }
-};
-
-template< typename BASETYPE >
-struct MapHelperImpl< ToElementRelation< BASETYPE > >
-{
-  using BaseHelper = MapHelperImpl< BASETYPE >;
-
-  static localIndex size0( ToElementRelation< BASETYPE > const & map )
-  {
-    return BaseHelper::size0( map.m_toElementIndex );
-  }
-
-  static localIndex size1( ToElementRelation< BASETYPE > const & map, localIndex const i0 )
-  {
-    return BaseHelper::size1( map.m_toElementIndex, i0 );
-  }
-
-  static auto value( ToElementRelation< BASETYPE > const & map, localIndex const i0, localIndex const i1 )
-  {
-    return MeshHelper< DofManager::Location::Elem >::LocalIndexType{ BaseHelper::value( map.m_toElementRegion, i0, i1 ),
-                                                                     BaseHelper::value( map.m_toElementSubRegion, i0, i1 ),
-                                                                     BaseHelper::value( map.m_toElementIndex, i0, i1 ) };
-  }
-};
-
-/**
- * @brief Helper struct that specializes access to various map types
- * @tparam MAP type of the map
- *
- * @note We may need to strip off InterObjectRelation and get the underlying map type, hence the extra layer
- */
-template< typename MAP >
-using MapHelper = MapHelperImpl< BaseType< MAP > >;
 
 /**
  * @brief Switchyard for Location (Node/Edge/Face/Elem)
@@ -397,22 +201,21 @@ bool LocationSwitch( DofManager::Location const loc1,
 }
 
 template< DofManager::Location LOC >
-typename MeshHelper< LOC >::ManagerType const & getObjectManager( MeshLevel const * const mesh )
+typename MeshHelper< LOC >::ManagerType const & getObjectManager( MeshLevel const & mesh )
 {
   using ObjectManager = typename MeshHelper< LOC >::ManagerType;
-  GEOSX_ASSERT( mesh != nullptr );
-  return mesh->getGroup< ObjectManager >( MeshHelper< LOC >::managerGroupName() );
+  return mesh.getGroup< ObjectManager >( MeshHelper< LOC >::managerGroupName() );
 }
 
 template< DofManager::Location LOC >
-typename MeshHelper< LOC >::ManagerType & getObjectManager( MeshLevel * const mesh )
+typename MeshHelper< LOC >::ManagerType & getObjectManager( MeshLevel & mesh )
 {
   using ObjectManager = typename MeshHelper< LOC >::ManagerType;
-  GEOSX_ASSERT( mesh != nullptr );
-  return mesh->getGroup< ObjectManager >( MeshHelper< LOC >::managerGroupName() );
+  return mesh.getGroup< ObjectManager >( MeshHelper< LOC >::managerGroupName() );
 }
 
-ObjectManagerBase const & getObjectManager( DofManager::Location const loc, MeshLevel const * const mesh )
+ObjectManagerBase const & getObjectManager( DofManager::Location const loc,
+                                            MeshLevel const & mesh )
 {
   ObjectManagerBase const * manager = nullptr;
   LocationSwitch( loc, [&]( auto const LOC )
@@ -423,10 +226,18 @@ ObjectManagerBase const & getObjectManager( DofManager::Location const loc, Mesh
   return *manager;
 }
 
-ObjectManagerBase & getObjectManager( DofManager::Location const loc, MeshLevel * const mesh )
+ObjectManagerBase & getObjectManager( DofManager::Location const loc, MeshLevel & mesh )
 {
-  return const_cast< ObjectManagerBase & >( getObjectManager( loc, const_cast< MeshLevel const * >( mesh ) ) );
+  return const_cast< ObjectManagerBase & >( getObjectManager( loc, const_cast< MeshLevel const & >( mesh ) ) );
 }
+
+/**
+ * @brief Helper alias for accessing mesh maps.
+ * @tparam LOC typeof object (location)
+ * @tparam MANAGER type of source object manager
+ */
+template< DofManager::Location LOC, typename MANAGER >
+using MapType = typename MeshHelper< LOC >::template MapType< MANAGER >;
 
 /**
  * @brief A helper struct implementing visitation of mesh objects and connected (adjacent) objects
@@ -436,7 +247,7 @@ ObjectManagerBase & getObjectManager( DofManager::Location const loc, MeshLevel 
  * @tparam VISIT_GHOSTS whether to visit ghosted primary locations
  */
 template< DofManager::Location LOC, DofManager::Location CONN_LOC, bool VISIT_GHOSTS >
-struct MeshLoopHelper;
+struct MeshVisitor;
 
 /**
  * @brief A specialization of MeshLoopHelper used when adjacent objects are NOT needed
@@ -447,12 +258,12 @@ struct MeshLoopHelper;
  * The algorithm will visit objects in order of increasing local index.
  */
 template< DofManager::Location LOC, bool VISIT_GHOSTS >
-struct MeshLoopHelper< LOC, LOC, VISIT_GHOSTS >
+struct MeshVisitor< LOC, LOC, VISIT_GHOSTS >
 {
-  template< typename ... SUBREGIONTYPES, typename LAMBDA >
-  static void visit( MeshLevel * const meshLevel,
+  template< typename POLICY, typename ... SUBREGIONTYPES, typename LAMBDA >
+  static void visit( MeshLevel const & meshLevel,
                      std::vector< string > const & regions,
-                     LAMBDA lambda )
+                     LAMBDA && lambda )
   {
     // derive some useful type aliases
     using ObjectManagerLoc = typename MeshHelper< LOC >::ManagerType;
@@ -462,57 +273,59 @@ struct MeshLoopHelper< LOC, LOC, VISIT_GHOSTS >
     arrayView1d< integer const > const & ghostRank = objectManager.ghostRank();
 
     // create an array to track previously visited locations (to avoid multiple visits)
-    array1d< bool > locationsVisited( objectManager.size() );
-    locationsVisited.setValues< serialPolicy >( false );
+    array1d< integer > visited( objectManager.size() );
 
-    // create (and overallocate) an array to collect indicies to visit
-    array1d< localIndex > locationsToVisit{};
-    locationsToVisit.reserve( objectManager.size() );
-
-    meshLevel->getElemManager().
+    meshLevel.getElemManager().
       forElementSubRegions< SUBREGIONTYPES... >( regions, [&]( localIndex const, auto const & subRegion )
     {
       // derive some more useful, subregion-dependent type aliases
-      using ElementSubRegionType = std::remove_reference_t< decltype( subRegion ) >;
-      using ElemToLocMapType = MapType< LOC, ElementSubRegionType >;
+      using ElemToLocMapType = MapType< LOC, TYPEOFREF( subRegion ) >;
 
       // get access to element-to-location map
       auto const & elemToLocMap =
-        subRegion.template getReference< ElemToLocMapType >( MeshHelper< LOC >::mapViewKey() );
+        subRegion.template getReference< ElemToLocMapType >( MeshHelper< LOC >::mapViewKey() ).toViewConst();
 
       // loop over all elements (including ghosts, which may be necessary to access some locally owned locations)
-      for( localIndex ei = 0; ei < subRegion.size(); ++ei )
+      forAll< parallelHostPolicy >( subRegion.size(), [=, visited = visited.toView()]( localIndex const ei )
       {
-        // loop over all locations incident on an element
-        for( localIndex a = 0; a < MapHelper< ElemToLocMapType >::size1( elemToLocMap, ei ); ++a )
+        // loop over all locations incident on an element and increment visitation counter
+        for( localIndex a = 0; a < meshMapUtilities::size1( elemToLocMap, ei ); ++a )
         {
-          localIndex const locIdx = MapHelper< ElemToLocMapType >::value( elemToLocMap, ei, a );
-
-          // check if we should visit this location
-          if( ( VISIT_GHOSTS || ghostRank[locIdx] < 0) && !std::exchange( locationsVisited[locIdx], true ) )
+          localIndex const locIdx = meshMapUtilities::value( elemToLocMap, ei, a );
+          if( VISIT_GHOSTS || ghostRank[locIdx] < 0 )
           {
-            locationsToVisit.emplace_back( locIdx );
+            RAJA::atomicInc< parallelHostAtomic >( &visited[locIdx] );
           }
         }
-      }
+      } );
     } );
 
-    // optimize for the common case (e.g. all nodes of the mesh)
-    if( locationsToVisit.size() == objectManager.size() )
+    // turn marker array into a list of indices to visit (this is inherently serial, but fast)
+    array1d< localIndex > locations;
+    locations.reserve( objectManager.size() );
+    for( localIndex i = 0; i < visited.size(); ++i )
     {
-      for( localIndex locIdx = 0; locIdx < objectManager.size(); ++locIdx )
+      if( visited[i] > 0 )
+      {
+        locations.emplace_back( i );
+      }
+    }
+
+    // optimize for the common case (e.g. all nodes of the mesh) to avoid extra memory access
+    if( locations.size() == objectManager.size() )
+    {
+      forAll< POLICY >( objectManager.size(), [=]( localIndex const locIdx )
       {
         lambda( locIdx, locIdx, 0 );
-      }
+      } );
     }
     else
     {
-      // I think this is faster than alternatives, but need to profile
-      std::sort( locationsToVisit.begin(), locationsToVisit.end() );
-      for( localIndex const locIdx : locationsToVisit )
+      forAll< POLICY >( locations.size(), [=, locations = locations.toViewConst()]( localIndex const i )
       {
+        localIndex const locIdx = locations[i];
         lambda( locIdx, locIdx, 0 );
-      }
+      } );
     }
   }
 };
@@ -524,12 +337,12 @@ struct MeshLoopHelper< LOC, LOC, VISIT_GHOSTS >
  * @tparam VISIT_GHOSTS whether to visit ghosted primary locations
  */
 template< DofManager::Location LOC, DofManager::Location CONN_LOC, bool VISIT_GHOSTS >
-struct MeshLoopHelper
+struct MeshVisitor
 {
-  template< typename ... SUBREGIONTYPES, typename LAMBDA >
-  static void visit( MeshLevel * const meshLevel,
+  template< typename POLICY, typename ... SUBREGIONTYPES, typename LAMBDA >
+  static void visit( MeshLevel const & meshLevel,
                      std::vector< string > const & regions,
-                     LAMBDA lambda )
+                     LAMBDA && lambda )
   {
     // derive some useful type aliases
     using ObjectManagerLoc = typename MeshHelper< LOC >::ManagerType;
@@ -539,18 +352,19 @@ struct MeshLoopHelper
 
     // get access to location-to-connected map
     auto const & locToConnMap =
-      objectManager.template getReference< LocToConnMapType >( MeshHelper< CONN_LOC >::mapViewKey() );
+      objectManager.template getReference< LocToConnMapType >( MeshHelper< CONN_LOC >::mapViewKey() ).toViewConst();
 
     // call the specialized version first, then add an extra loop over connected objects
-    MeshLoopHelper< LOC, LOC, VISIT_GHOSTS >::template visit< SUBREGIONTYPES... >( meshLevel, regions,
-                                                                                   [&]( localIndex const locIdx,
-                                                                                        localIndex const,
-                                                                                        localIndex const )
+    MeshVisitor< LOC, LOC, VISIT_GHOSTS >::
+    template visit< POLICY, SUBREGIONTYPES... >( meshLevel, regions,
+                                                 [=]( localIndex const locIdx,
+                                                      localIndex const,
+                                                      localIndex const )
     {
       // loop over all connected locations
-      for( localIndex b = 0; b < MapHelper< LocToConnMapType >::size1( locToConnMap, locIdx ); ++b )
+      for( localIndex b = 0; b < meshMapUtilities::size1( locToConnMap, locIdx ); ++b )
       {
-        auto const connIdx = MapHelper< LocToConnMapType >::value( locToConnMap, locIdx, b );
+        auto const connIdx = meshMapUtilities::value( locToConnMap, locIdx, b );
         lambda( locIdx, connIdx, b );
       }
     } );
@@ -566,40 +380,41 @@ struct MeshLoopHelper
  *       map types in that they are stored in data repository as three separate arrays.
  */
 template< DofManager::Location LOC, bool VISIT_GHOSTS >
-struct MeshLoopHelper< LOC, DofManager::Location::Elem, VISIT_GHOSTS >
+struct MeshVisitor< LOC, DofManager::Location::Elem, VISIT_GHOSTS >
 {
-  template< typename ... SUBREGIONTYPES, typename LAMBDA >
-  static void visit( MeshLevel * const meshLevel,
+  template< typename POLICY, typename ... SUBREGIONTYPES, typename LAMBDA >
+  static void visit( MeshLevel const & meshLevel,
                      std::vector< string > const & regions,
-                     LAMBDA lambda )
+                     LAMBDA && lambda )
   {
     // derive some useful type aliases
     using ObjectManagerLoc = typename MeshHelper< LOC >::ManagerType;
-    using ToElemMapType = BaseType< MapType< DofManager::Location::Elem, ObjectManagerLoc > >;
+    using ToElemMapType = typename MapType< DofManager::Location::Elem, ObjectManagerLoc >::base_type;
 
     // get mesh object manager for LOC to access maps
     ObjectManagerLoc const & objectManager = getObjectManager< LOC >( meshLevel );
 
     // access to location-to-element map
     auto const & elemRegionList =
-      objectManager.template getReference< ToElemMapType >( ObjectManagerLoc::viewKeyStruct::elementRegionListString() );
+      objectManager.template getReference< ToElemMapType >( ObjectManagerLoc::viewKeyStruct::elementRegionListString() ).toViewConst();
     auto const & elemSubRegionList =
-      objectManager.template getReference< ToElemMapType >( ObjectManagerLoc::viewKeyStruct::elementSubRegionListString() );
+      objectManager.template getReference< ToElemMapType >( ObjectManagerLoc::viewKeyStruct::elementSubRegionListString() ).toViewConst();
     auto const & elemIndexList =
-      objectManager.template getReference< ToElemMapType >( ObjectManagerLoc::viewKeyStruct::elementListString() );
+      objectManager.template getReference< ToElemMapType >( ObjectManagerLoc::viewKeyStruct::elementListString() ).toViewConst();
 
     // call the specialized version first, then add an extra loop over connected elements
-    MeshLoopHelper< LOC, LOC, VISIT_GHOSTS >::template visit< SUBREGIONTYPES... >( meshLevel, regions,
-                                                                                   [&]( localIndex const locIdx,
-                                                                                        localIndex const,
-                                                                                        localIndex const )
+    MeshVisitor< LOC, LOC, VISIT_GHOSTS >::
+    template visit< POLICY, SUBREGIONTYPES... >( meshLevel, regions,
+                                                 [=]( localIndex const locIdx,
+                                                      localIndex const,
+                                                      localIndex const )
     {
       // loop over all connected locations
-      for( localIndex b = 0; b < MapHelper< ToElemMapType >::size1( elemIndexList, locIdx ); ++b )
+      for( localIndex b = 0; b < meshMapUtilities::size1( elemIndexList, locIdx ); ++b )
       {
-        localIndex const er  = MapHelper< ToElemMapType >::value( elemRegionList, locIdx, b );
-        localIndex const esr = MapHelper< ToElemMapType >::value( elemSubRegionList, locIdx, b );
-        localIndex const ei  = MapHelper< ToElemMapType >::value( elemIndexList, locIdx, b );
+        localIndex const er  = meshMapUtilities::value( elemRegionList, locIdx, b );
+        localIndex const esr = meshMapUtilities::value( elemSubRegionList, locIdx, b );
+        localIndex const ei  = meshMapUtilities::value( elemIndexList, locIdx, b );
 
         if( er >= 0 && esr >= 0 && ei >= 0 )
         {
@@ -619,14 +434,14 @@ struct MeshLoopHelper< LOC, DofManager::Location::Elem, VISIT_GHOSTS >
  *       map types, so the correct map type must be derived within the subregion loop
  */
 template< DofManager::Location CONN_LOC, bool VISIT_GHOSTS >
-struct MeshLoopHelper< DofManager::Location::Elem, CONN_LOC, VISIT_GHOSTS >
+struct MeshVisitor< DofManager::Location::Elem, CONN_LOC, VISIT_GHOSTS >
 {
-  template< typename ... SUBREGIONTYPES, typename LAMBDA >
-  static void visit( MeshLevel * const meshLevel,
+  template< typename POLICY, typename ... SUBREGIONTYPES, typename LAMBDA >
+  static void visit( MeshLevel const & meshLevel,
                      std::vector< string > const & regions,
-                     LAMBDA lambda )
+                     LAMBDA && lambda )
   {
-    meshLevel->getElemManager().
+    meshLevel.getElemManager().
       forElementSubRegionsComplete< SUBREGIONTYPES... >( regions, [&]( localIndex const,
                                                                        localIndex const er,
                                                                        localIndex const esr,
@@ -638,23 +453,23 @@ struct MeshLoopHelper< DofManager::Location::Elem, CONN_LOC, VISIT_GHOSTS >
 
       // get access to element-to-location map
       auto const & elemToConnMap =
-        subRegion.template getReference< ElemToConnMapType >( MeshHelper< CONN_LOC >::mapViewKey() );
+        subRegion.template getReference< ElemToConnMapType >( MeshHelper< CONN_LOC >::mapViewKey() ).toViewConst();
 
-      arrayView1d< integer const > const & elemGhostRank = subRegion.ghostRank();
+      arrayView1d< integer const > const & ghostRank = subRegion.ghostRank();
 
-      for( localIndex ei = 0; ei < subRegion.size(); ++ei )
+      forAll< POLICY >( subRegion.size(), [=]( localIndex const ei )
       {
-        if( VISIT_GHOSTS || elemGhostRank[ei] < 0 )
+        if( VISIT_GHOSTS || ghostRank[ei] < 0 )
         {
           auto const elemIdx = MeshHelper< DofManager::Location::Elem >::LocalIndexType{ er, esr, ei };
 
-          for( localIndex a = 0; a < MapHelper< ElemToConnMapType >::size1( elemToConnMap, ei ); ++a )
+          for( localIndex a = 0; a < meshMapUtilities::size1( elemToConnMap, ei ); ++a )
           {
-            localIndex const locIdx = MapHelper< ElemToConnMapType >::value( elemToConnMap, ei, a );
+            localIndex const locIdx = meshMapUtilities::value( elemToConnMap, ei, a );
             lambda( elemIdx, locIdx, a );
           }
         }
-      }
+      } );
     } );
   }
 };
@@ -664,31 +479,30 @@ struct MeshLoopHelper< DofManager::Location::Elem, CONN_LOC, VISIT_GHOSTS >
  * @tparam VISIT_GHOSTS whether to visit ghosted elements
  */
 template< bool VISIT_GHOSTS >
-struct MeshLoopHelper< DofManager::Location::Elem, DofManager::Location::Elem, VISIT_GHOSTS >
+struct MeshVisitor< DofManager::Location::Elem, DofManager::Location::Elem, VISIT_GHOSTS >
 {
-  template< typename ... SUBREGIONTYPES, typename LAMBDA >
-  static void visit( MeshLevel * const meshLevel,
+  template< typename POLICY, typename ... SUBREGIONTYPES, typename LAMBDA >
+  static void visit( MeshLevel const & meshLevel,
                      std::vector< string > const & regions,
                      LAMBDA && lambda )
   {
-    meshLevel->getElemManager().
+    meshLevel.getElemManager().
       forElementSubRegionsComplete< SUBREGIONTYPES... >( regions, [&]( localIndex const,
                                                                        localIndex const er,
                                                                        localIndex const esr,
                                                                        ElementRegionBase const &,
                                                                        ElementSubRegionBase const & subRegion )
     {
-      arrayView1d< integer const > const & elemGhostRank = subRegion.ghostRank();
-      localIndex const numElems = subRegion.size();
+      arrayView1d< integer const > const & ghostRank = subRegion.ghostRank();
 
-      for( localIndex ei = 0; ei < numElems; ++ei )
+      forAll< POLICY >( subRegion.size(), [=]( localIndex const ei )
       {
-        if( VISIT_GHOSTS || elemGhostRank[ei] < 0 )
+        if( VISIT_GHOSTS || ghostRank[ei] < 0 )
         {
           auto const elemIdx = MeshHelper< DofManager::Location::Elem >::LocalIndexType{ er, esr, ei };
           lambda( elemIdx, elemIdx, 0 );
         }
-      }
+      } );
     } );
   }
 };
@@ -716,30 +530,29 @@ struct MeshLoopHelper< DofManager::Location::Elem, DofManager::Location::Elem, V
  *       Similarly, while primary loop is limited to @p regions, adjacent locations may not belong.
  */
 template< DofManager::Location LOC, DofManager::Location CONN_LOC, bool VISIT_GHOSTS,
-          typename ... SUBREGIONTYPES, typename LAMBDA >
-void forMeshLocation( MeshLevel * const mesh,
+          typename POLICY, typename ... SUBREGIONTYPES, typename LAMBDA >
+void forMeshLocation( MeshLevel const & mesh,
                       std::vector< string > const & regions,
                       LAMBDA && lambda )
 {
-  MeshLoopHelper< LOC, CONN_LOC, VISIT_GHOSTS >::template visit< SUBREGIONTYPES... >( mesh,
-                                                                                      regions,
-                                                                                      std::forward< LAMBDA >( lambda ) );
+  MeshVisitor< LOC, CONN_LOC, VISIT_GHOSTS >::
+  template visit< POLICY, SUBREGIONTYPES... >( mesh,
+                                               regions,
+                                               std::forward< LAMBDA >( lambda ) );
 }
 
 /**
  * @brief A shortcut for forMeshLocation with CONN_LOC == LOC
  */
 template< DofManager::Location LOC, bool VISIT_GHOSTS,
-          typename ... SUBREGIONTYPES, typename LAMBDA >
-void forMeshLocation( MeshLevel * const mesh,
+          typename POLICY, typename ... SUBREGIONTYPES, typename LAMBDA >
+void forMeshLocation( MeshLevel const & mesh,
                       std::vector< string > const & regions,
                       LAMBDA && lambda )
 {
-  forMeshLocation< LOC, LOC, VISIT_GHOSTS, SUBREGIONTYPES... >( mesh,
-                                                                regions,
-                                                                [&]( auto const locIdx,
-                                                                     auto const,
-                                                                     auto const )
+  forMeshLocation< LOC, LOC, VISIT_GHOSTS, POLICY, SUBREGIONTYPES... >( mesh,
+                                                                        regions,
+                                                                        [=]( auto const locIdx, auto, auto )
   {
     lambda( locIdx );
   } );
@@ -752,38 +565,61 @@ void forMeshLocation( MeshLevel * const mesh,
  * @tparam SUBREGIONTYPES types of subregions to include in counting
  * @param mesh the mesh level to use
  * @param regions a list of region names (assumed to be unique)
- * @return
+ * @return number of mesh objects adjacent to given regions
  */
 template< DofManager::Location LOC, bool VISIT_GHOSTS, typename ... SUBREGIONTYPES >
-localIndex countMeshObjects( MeshLevel * const mesh,
+localIndex countMeshObjects( MeshLevel const & mesh,
+                             std::vector< string > const & regions )
+{
+  using countPolicy = parallelHostPolicy;
+  RAJA::ReduceSum< ReducePolicy< countPolicy >, localIndex > count( 0 );
+  forMeshLocation< LOC, VISIT_GHOSTS, countPolicy, SUBREGIONTYPES... >( mesh, regions, [=]( auto )
+  {
+    count += 1;
+  } );
+  return count.get();
+}
+
+/**
+ * @brief Count objects of given type within a set of regions
+ * @tparam VISIT_GHOSTS whether ghosted objects should be counted
+ * @tparam SUBREGIONTYPES types of subregions to include in counting
+ * @param mesh the mesh level to use
+ * @param regions a list of region names (assumed to be unique)
+ * @param loc type of mesh objects (locations)
+ * @return number of mesh objects adjacent to given regions
+ */
+template< bool VISIT_GHOSTS, typename ... SUBREGIONTYPES >
+localIndex countMeshObjects( DofManager::Location const location,
+                             MeshLevel const & mesh,
                              std::vector< string > const & regions )
 {
   localIndex count = 0;
-  forMeshLocation< LOC, VISIT_GHOSTS, SUBREGIONTYPES... >( mesh, regions,
-                                                           [&]( auto const GEOSX_UNUSED_PARAM( connIdx ) )
+  bool const success = LocationSwitch( location, [&]( auto const loc )
   {
-    ++count;
+    DofManager::Location constexpr LOC = decltype(loc)::value;
+    count = countMeshObjects< LOC, VISIT_GHOSTS, SUBREGIONTYPES... >( mesh, regions );
   } );
+  GEOSX_ERROR_IF( !success, "Invalid location type: " << static_cast< int >( location ) );
   return count;
 }
 
 /**
  * @brief This template abstracts some differences between index arrays that live
  *        on elements vs other mesh objects: (de)registration, value access, etc.
+ * @tparam T type of index value
  * @tparam LOC target location
  */
-template< typename INDEX, DofManager::Location LOC >
-struct IndexArrayHelper
+template< typename T, DofManager::Location LOC >
+struct ArrayHelper
 {
-  using IndexType = localIndex;
-  using ArrayType = array1d< std::remove_const_t< INDEX > >;
-  using ViewType = arrayView1d< INDEX >;
-  using Accessor = ViewType const;
-  using Mesh = add_const_if_t< MeshLevel, std::is_const< INDEX >::value >;
+  using ArrayType = array1d< std::remove_const_t< T > >;
+  using ViewType = arrayView1d< T >;
+  using Accessor = ViewType;
 
   template< typename ... SUBREGIONTYPES >
   static void
-  create( Mesh * const mesh,
+  create( MeshLevel & mesh,
           string const & key,
           string const & description,
           std::vector< string > const & GEOSX_UNUSED_PARAM( regions ) )
@@ -796,24 +632,24 @@ struct IndexArrayHelper
       setDescription( description );
   }
 
-  static Accessor get( Mesh * const mesh, string const & key )
+  static Accessor get( add_const_if_t< MeshLevel, std::is_const< T >::value > & mesh, string const & key )
   {
     return getObjectManager< LOC >( mesh ).template getReference< ArrayType >( key );
   }
 
-  static inline INDEX value( Accessor & indexArray, typename MeshHelper< LOC >::LocalIndexType const i )
+  static inline T value( Accessor const & indexArray, typename MeshHelper< LOC >::LocalIndexType const i )
   {
     return indexArray[i];
   }
 
-  static inline INDEX & reference( Accessor & indexArray, typename MeshHelper< LOC >::LocalIndexType const i )
+  static inline T & reference( Accessor const & indexArray, typename MeshHelper< LOC >::LocalIndexType const i )
   {
     return indexArray[i];
   }
 
   template< typename ... SUBREGIONTYPES >
   static void
-  remove( Mesh * const mesh,
+  remove( MeshLevel & mesh,
           string const & key,
           std::vector< string > const & GEOSX_UNUSED_PARAM( regions ) )
   {
@@ -822,29 +658,27 @@ struct IndexArrayHelper
 };
 
 /**
- * @brief Specialized version of IndexArrayHelper for elements.
+ * @brief Specialized version of ArrayHelper for element-based arrays.
+ * @tparam T type of index value
  */
-template< typename INDEX >
-struct IndexArrayHelper< INDEX, DofManager::Location::Elem >
+template< typename T >
+struct ArrayHelper< T, DofManager::Location::Elem >
 {
-  using IndexType = INDEX;
-  using ArrayType = array1d< std::remove_const_t< INDEX > >;
-  using ViewType = arrayView1d< INDEX >;
-  using Accessor = ElementRegionManager::ElementViewAccessor< ViewType > const;
-  using Mesh = add_const_if_t< MeshLevel, std::is_const< INDEX >::value >;
+  using ArrayType = array1d< std::remove_const_t< T > >;
+  using ViewType = arrayView1d< T >;
+  using Accessor = ElementRegionManager::ElementViewAccessor< ViewType >;
 
   template< typename ... SUBREGIONTYPES >
   static void
-  create( Mesh * const mesh,
+  create( MeshLevel & mesh,
           string const & key,
           string const & description,
           std::vector< string > const & regions )
   {
-    mesh->getElemManager().template forElementSubRegions< SUBREGIONTYPES... >( regions,
-                                                                               [&]( localIndex const,
-                                                                                    auto & subRegion )
+    mesh.getElemManager().template forElementSubRegions< SUBREGIONTYPES... >( regions,
+                                                                              [&]( localIndex const, ElementSubRegionBase & subRegion )
     {
-      subRegion.template registerWrapper< ArrayType >( key ).
+      subRegion.registerWrapper< ArrayType >( key ).
         setApplyDefaultValue( -1 ).
         setPlotLevel( dataRepository::PlotLevel::LEVEL_1 ).
         setRestartFlags( dataRepository::RestartFlags::NO_WRITE ).
@@ -852,13 +686,13 @@ struct IndexArrayHelper< INDEX, DofManager::Location::Elem >
     } );
   }
 
-  static Accessor get( Mesh * const mesh, string const & key )
+  static Accessor get( add_const_if_t< MeshLevel, std::is_const< T >::value > & mesh, string const & key )
   {
-    return mesh->getElemManager().template constructViewAccessor< ArrayType, ViewType >( key );
+    return mesh.getElemManager().template constructViewAccessor< ArrayType, ViewType >( key );
   }
 
-  static inline INDEX value( Accessor & indexArray,
-                             MeshHelper< DofManager::Location::Elem >::LocalIndexType const & e )
+  static inline T value( Accessor const & indexArray,
+                         MeshHelper< DofManager::Location::Elem >::LocalIndexType const & e )
   {
     if( indexArray[std::get< 0 >( e )].empty() || indexArray[std::get< 0 >( e )][std::get< 1 >( e )].empty() )
     {
@@ -867,21 +701,20 @@ struct IndexArrayHelper< INDEX, DofManager::Location::Elem >
     return indexArray[std::get< 0 >( e )][std::get< 1 >( e )][std::get< 2 >( e )];
   }
 
-  static inline INDEX & reference( Accessor & indexArray,
-                                   MeshHelper< DofManager::Location::Elem >::LocalIndexType const & e )
+  static inline T & reference( Accessor const & indexArray,
+                               MeshHelper< DofManager::Location::Elem >::LocalIndexType const & e )
   {
     return indexArray[std::get< 0 >( e )][std::get< 1 >( e )][std::get< 2 >( e )];
   }
 
   template< typename ... SUBREGIONTYPES >
   static void
-  remove( Mesh * const mesh,
+  remove( MeshLevel & mesh,
           string const & key,
           std::vector< string > const & regions )
   {
-    mesh->getElemManager().template forElementSubRegions< SUBREGIONTYPES... >( regions,
-                                                                               [&]( localIndex const,
-                                                                                    ElementSubRegionBase & subRegion )
+    mesh.getElemManager().template forElementSubRegions< SUBREGIONTYPES... >( regions,
+                                                                              [&]( localIndex const, ElementSubRegionBase & subRegion )
     {
       subRegion.deregisterWrapper( key );
     } );

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreMGRStrategies.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreMGRStrategies.hpp
@@ -52,7 +52,7 @@ namespace mgr
  */
 template< typename STRATEGY >
 void setStrategy( LinearSolverParameters::MGR const & params,
-                  arrayView1d< localIndex const > const & numComponentsPerField,
+                  arrayView1d< integer const > const & numComponentsPerField,
                   HyprePrecWrapper & precond,
                   HypreMGRData & mgrData )
 {
@@ -136,7 +136,7 @@ public:
   /**
    * @brief Constructor.
    */
-  explicit SinglePhasePoroelastic( arrayView1d< localIndex const > const & )
+  explicit SinglePhasePoroelastic( arrayView1d< integer const > const & )
     : MGRStrategyBase( 4 )
   {
     m_labels[0].push_back( 3 );
@@ -213,7 +213,7 @@ public:
    * @brief Constructor.
    * @param numComponentsPerField array with number of components for each field
    */
-  explicit CompositionalMultiphaseFVM( arrayView1d< localIndex const > const & numComponentsPerField )
+  explicit CompositionalMultiphaseFVM( arrayView1d< integer const > const & numComponentsPerField )
     : MGRStrategyBase( LvArray::integerConversion< HYPRE_Int >( numComponentsPerField[0] ) )
   {
     // Level 0: eliminate last density which corresponds to the volume constraint equation
@@ -293,7 +293,7 @@ public:
    * @brief Constructor.
    * @param numComponentsPerField array with number of components for each field
    */
-  explicit CompositionalMultiphaseReservoir( arrayView1d< localIndex const > const & numComponentsPerField )
+  explicit CompositionalMultiphaseReservoir( arrayView1d< integer const > const & numComponentsPerField )
     : MGRStrategyBase( LvArray::integerConversion< HYPRE_Int >( numComponentsPerField[0] + numComponentsPerField[1] ) )
   {
     HYPRE_Int const numResLabels = LvArray::integerConversion< HYPRE_Int >( numComponentsPerField[0] );
@@ -381,7 +381,7 @@ public:
    * @brief Constructor.
    * @param numComponentsPerField array with number of components for each field
    */
-  explicit CompositionalMultiphaseHybridFVM( arrayView1d< localIndex const > const & numComponentsPerField )
+  explicit CompositionalMultiphaseHybridFVM( arrayView1d< integer const > const & numComponentsPerField )
     : MGRStrategyBase( LvArray::integerConversion< HYPRE_Int >( numComponentsPerField[0] + numComponentsPerField[1] ) )
   {
     // Level 0: eliminate the last density of the cell-centered block
@@ -469,7 +469,7 @@ public:
   /**
    * @brief Constructor.
    */
-  explicit LagrangianContactMechanics( arrayView1d< localIndex const > const & )
+  explicit LagrangianContactMechanics( arrayView1d< integer const > const & )
     : MGRStrategyBase( 2 )
   {
     // Level 0: all three displacements kept

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HyprePreconditioner.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HyprePreconditioner.cpp
@@ -359,7 +359,7 @@ void createMGR( LinearSolverParameters const & params,
   GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetMaxIter( precond.ptr, 1 ) );
   GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetPrintLevel( precond.ptr, LvArray::integerConversion< HYPRE_Int >( params.logLevel ) ) );
 
-  array1d< localIndex > const numComponentsPerField = dofManager->numComponentsPerField();
+  array1d< integer > const numComponentsPerField = dofManager->numComponentsPerField();
   dofManager->getLocalDofComponentLabels( mgrData.pointMarkers );
 
   if( params.logLevel >= 1 )
@@ -513,7 +513,7 @@ HypreMatrix const & HyprePreconditioner::setupPreconditioningMatrix( HypreMatrix
     GEOSX_LAI_ASSERT_MSG( mat.dofManager() != nullptr, "MGR preconditioner requires a DofManager instance" );
     HypreMatrix Pu;
     HypreMatrix Auu;
-    mat.dofManager()->makeRestrictor( { { m_params.mgr.displacementFieldName, 0, 3 } }, mat.getComm(), true, Pu );
+    mat.dofManager()->makeRestrictor( { { m_params.mgr.displacementFieldName, { 3, true } } }, mat.getComm(), true, Pu );
     mat.multiplyPtAP( Pu, Auu );
     LAIHelperFunctions::separateComponentFilter( Auu, m_precondMatrix, m_params.dofsPerNode );
   }

--- a/src/coreComponents/linearAlgebra/utilities/ComponentMask.hpp
+++ b/src/coreComponents/linearAlgebra/utilities/ComponentMask.hpp
@@ -336,7 +336,7 @@ private:
   bool operator[]( int const i ) const
   {
     GEOSX_ASSERT_GT( m_numComp, i );
-    return m_mask & (mask_t(1) << i);
+    return m_mask & (mask_t( 1 ) << i);
   }
 
   ///@}
@@ -366,7 +366,7 @@ private:
     GEOSX_ASSERT_GE( MAX_COMP, numComp );
     if( numComp < m_numComp )
     {
-      m_mask &= (mask_t(1) << numComp) - 1;
+      m_mask &= (mask_t( 1 ) << numComp) - 1;
     }
     m_numComp = numComp;
   }
@@ -380,7 +380,7 @@ private:
   {
     GEOSX_ASSERT_GE( i, 0 );
     GEOSX_ASSERT_GT( m_numComp, i );
-    m_mask |= mask_t(1) << i;
+    m_mask |= mask_t( 1 ) << i;
   }
 
   /**
@@ -392,7 +392,7 @@ private:
   {
     GEOSX_ASSERT_GE( i, 0 );
     GEOSX_ASSERT_GT( m_numComp, i );
-    m_mask &= ~(mask_t(1) << i);
+    m_mask &= ~(mask_t( 1 ) << i);
   }
 
   /**
@@ -427,7 +427,7 @@ private:
   ComponentMask operator~() const
   {
     ComponentMask mask( m_numComp );
-    mask.m_mask = ~m_mask & ((mask_t(1) << m_numComp) - 1);
+    mask.m_mask = ~m_mask & ((mask_t( 1 ) << m_numComp) - 1);
     return mask;
   }
 

--- a/src/coreComponents/linearAlgebra/utilities/ComponentMask.hpp
+++ b/src/coreComponents/linearAlgebra/utilities/ComponentMask.hpp
@@ -1,0 +1,499 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 Total, S.A
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file ComponentMask.hpp
+ */
+
+#ifndef GEOSX_LINEARALGEBRA_UTILITIES_COMPONENTMASK_HPP_
+#define GEOSX_LINEARALGEBRA_UTILITIES_COMPONENTMASK_HPP_
+
+#include "common/GeosxMacros.hpp"
+#include "common/Logger.hpp"
+
+#include <cstdint>
+
+namespace geosx
+{
+
+namespace internal
+{
+
+/// Helps make static_assert's condition dependent on a non-type template parameter.
+template< typename T >
+constexpr bool always_false( T )
+{
+  return false;
+}
+
+template< int N >
+struct ComponentMaskTypeImpl
+{
+  static_assert( always_false( N ), "Unsupported template parameter N for ComponentMask. Use a value between 8 and 64." );
+};
+
+/**
+ * @brief Macro for declaring a specialization of ComponentMaskTypeImpl template.
+ */
+#define GEOSX_LAI_COMPONENTMASK_DECL( N ) \
+  template<> \
+  struct ComponentMaskTypeImpl< N > \
+  { \
+    using type = std::uint ## N ## _t; \
+  }
+
+GEOSX_LAI_COMPONENTMASK_DECL( 8 );
+GEOSX_LAI_COMPONENTMASK_DECL( 16 );
+GEOSX_LAI_COMPONENTMASK_DECL( 32 );
+GEOSX_LAI_COMPONENTMASK_DECL( 64 );
+
+#undef GEOSX_LAI_COMPONENTMASK_DECL
+
+constexpr std::uint32_t roundToNextPowerOfTwo( std::uint32_t v )
+{
+  if( v <= 8 ) return 8;
+  v--;
+  v |= v >> 1;
+  v |= v >> 2;
+  v |= v >> 4;
+  v |= v >> 8;
+  v |= v >> 16;
+  v++;
+  return v;
+}
+
+template< int N >
+using ComponentMaskType = typename ComponentMaskTypeImpl< roundToNextPowerOfTwo( N ) >::type;
+
+}
+
+/**
+ * @brief Utility class that represents a mask for included/excluded component of a mask.
+ * @tparam MAX_COMP maximum number of components
+ *
+ * The main advantage over std::bitset<N> is being CUDA-friendly. In addition, it provides
+ * convenience constructors and iteration over set bits.
+ *
+ * Class intended to be used by DofManager to specify component mappings when constructing
+ * restriction/prolongation operators and during field-vector data copying.
+ */
+template< int MAX_COMP >
+class ComponentMask
+{
+private:
+
+  /// Type used to represent the bit mask
+  using mask_t = internal::ComponentMaskType< MAX_COMP >;
+
+public:
+
+  /**
+   * @name Constructors.
+   */
+  ///@{
+
+  /**
+   * @brief Constructor.
+   * @param numComp total number of components
+   * @param includeAll if @p true, initializes the mask to include rather than exclude all components
+   */
+  GEOSX_HOST_DEVICE
+  ComponentMask( int const numComp, bool const includeAll )
+    : m_mask( includeAll ? -1 : 0 ),
+    m_numComp( numComp )
+  {
+    GEOSX_ASSERT_GE( m_numComp, 0 );
+    GEOSX_ASSERT_GE( MAX_COMP, m_numComp );
+  }
+
+  /**
+   * @brief Constructor.
+   * @param numComp total number of components
+   */
+  GEOSX_HOST_DEVICE
+  explicit ComponentMask( int const numComp )
+    : ComponentMask( numComp, false )
+  {}
+
+  /**
+   * @brief Range constructor, includes contiguous range of components
+   * @param numComp total number of components
+   * @param lo first component number to include
+   * @param hi one-past last component number to include
+   * @note [lo,hi) form a half-open range, indexing is zero-based.
+   */
+  GEOSX_HOST_DEVICE
+  ComponentMask( int const numComp, int const lo, int const hi )
+    : ComponentMask( numComp )
+  {
+    for( int i = lo; i < hi; ++i )
+    {
+      set( i );
+    }
+  }
+
+  /**
+   * @brief Converting constructor from another mask with fewer max components.
+   * @tparam M number of components in source mask
+   * @param other source mask
+   */
+  template< int N, typename = std::enable_if_t< ( N < MAX_COMP ) > >
+  GEOSX_HOST_DEVICE
+  ComponentMask( ComponentMask< N > const & other )
+    : m_mask( other.m_mask ),
+    m_numComp( other.m_numComp )
+  {}
+
+  ///@}
+
+  /**
+   * @name Inspection methods.
+   */
+  ///@{
+
+  /**
+   * @brief Forward const iterator over the set components (bits).
+   * @note Iterator is invalidated by any mutating operation on the ComponentMask object.
+   */
+  class Iterator
+  {
+public:
+
+    using difference_type = int;                         ///< difference type
+    using value_type = int;                              ///< value type
+    using pointer = void;                                ///< pointer type (meaningless but makes it iterator_traits compatible)
+    using reference_type = int;                          ///< reference type (no real references since this is a const iterator)
+    using iterator_category = std::forward_iterator_tag; ///< iterator category
+
+    /**
+     * @brief Dereference operator.
+     * @return index of currently pointed-to component
+     */
+    GEOSX_HOST_DEVICE
+    GEOSX_FORCE_INLINE
+    reference_type operator*() const
+    {
+      return m_index;
+    }
+
+    /**
+     * @brief Prefix increment operator.
+     * @return reference to @p this
+     */
+    GEOSX_HOST_DEVICE
+    GEOSX_FORCE_INLINE
+    Iterator & operator++()
+    {
+      GEOSX_ASSERT_NE( m_mask, 0 );
+      skipOne();
+      findNextBit();
+      return *this;
+    }
+
+    /**
+     * @brief Postfix increment operator.
+     * @return copy of @p this prior to increment
+     */
+    GEOSX_HOST_DEVICE
+    GEOSX_FORCE_INLINE
+    Iterator operator++( int ) &
+    {
+      Iterator old = *this;
+      ++*this;
+      return old;
+    }
+
+    /**
+     * @brief Comparison operator.
+     * @param other the iterator to compare to
+     * @return @p true if iterators are equal (as determined by remaining mask)
+     */
+    GEOSX_HOST_DEVICE
+    GEOSX_FORCE_INLINE
+    bool operator==( Iterator const & other ) const
+    {
+      return m_mask == other.m_mask;
+    }
+
+    /**
+     * @brief Comparison operator.
+     * @param other the iterator to compare to
+     * @return @p true if iterators are not equal
+     */
+    GEOSX_HOST_DEVICE
+    GEOSX_FORCE_INLINE
+    bool operator!=( Iterator const & other ) const
+    {
+      return !(*this == other);
+    }
+
+private:
+
+    GEOSX_HOST_DEVICE
+    GEOSX_FORCE_INLINE
+    void skipOne()
+    {
+      m_mask >>= 1;
+      ++m_index;
+    }
+
+    GEOSX_HOST_DEVICE
+    GEOSX_FORCE_INLINE
+    void findNextBit()
+    {
+      if( m_mask )
+      {
+        // TODO: use hardware intrinsics (ffs/ctz) where possible
+        while( !( m_mask & 1 ) )
+        {
+          skipOne();
+        }
+      }
+    }
+
+    GEOSX_HOST_DEVICE
+    Iterator( mask_t const mask, int const index )
+      : m_mask( mask ),
+      m_index( index )
+    {
+      findNextBit();
+    }
+
+    friend class ComponentMask;
+
+    mask_t m_mask;
+    int m_index;
+  };
+
+  /**
+   * @brief @return iterator to the start of the component index range
+   */
+  GEOSX_HOST_DEVICE
+  Iterator begin() const
+  {
+    return Iterator( m_mask, 0 );
+  }
+
+  /**
+   * @brief @return iterator past the end of the component index range
+   */
+  GEOSX_HOST_DEVICE
+  Iterator end() const
+  {
+    return Iterator( 0, -1 );
+  }
+
+  /**
+   * @brief @return the number of set components.
+   */
+  GEOSX_HOST_DEVICE
+  int size() const
+  {
+    mask_t mask = m_mask;
+    int c = 0;
+    for(; mask != 0; ++c )
+    {
+      mask &= mask - 1;
+    }
+    return c;
+  }
+
+  /**
+   * @brief @return number of components
+   */
+  GEOSX_HOST_DEVICE
+  int numComp() const
+  {
+    return m_numComp;
+  }
+
+  /**
+   * @brief @return @p true if mask is empty (no components selected), @p false otherwise.
+   */
+  GEOSX_HOST_DEVICE
+  bool empty() const
+  {
+    return m_mask == 0;
+  }
+
+  /**
+   * @brief Check if a particular component is selected.
+   * @param i component index
+   * @return @p true if i-th component is selected, @p false otherwise
+   */
+  GEOSX_HOST_DEVICE
+  bool operator[]( int const i ) const
+  {
+    GEOSX_ASSERT_GT( m_numComp, i );
+    return m_mask & (mask_t(1) << i);
+  }
+
+  ///@}
+
+  /**
+   * @name Modification methods/operators.
+   */
+  ///@{
+
+  /**
+   * @brief Clear the mask, removing selected components.
+   */
+  GEOSX_HOST_DEVICE
+  void clear()
+  {
+    m_mask = 0;
+  }
+
+  /**
+   * @brief Set new component limit and truncate all components above.
+   * @param numComp new max components value
+   */
+  GEOSX_HOST_DEVICE
+  void setNumComp( int numComp )
+  {
+    GEOSX_ASSERT_GE( numComp, 0 );
+    GEOSX_ASSERT_GE( MAX_COMP, numComp );
+    if( numComp < m_numComp )
+    {
+      m_mask &= (mask_t(1) << numComp) - 1;
+    }
+    m_numComp = numComp;
+  }
+
+  /**
+   * @brief Add a component.
+   * @param i component index
+   */
+  GEOSX_HOST_DEVICE
+  void set( int const i )
+  {
+    GEOSX_ASSERT_GE( i, 0 );
+    GEOSX_ASSERT_GT( m_numComp, i );
+    m_mask |= mask_t(1) << i;
+  }
+
+  /**
+   * @brief Remove a component.
+   * @param i component index
+   */
+  GEOSX_HOST_DEVICE
+  void unset( int const i )
+  {
+    GEOSX_ASSERT_GE( i, 0 );
+    GEOSX_ASSERT_GT( m_numComp, i );
+    m_mask &= ~(mask_t(1) << i);
+  }
+
+  /**
+   * @brief Add a component.
+   * @param i component index
+   * @return reference to this object
+   */
+  GEOSX_HOST_DEVICE
+  ComponentMask & operator+=( int const i )
+  {
+    set( i );
+    return *this;
+  }
+
+  /**
+   * @brief Remove a component.
+   * @param i component index
+   * @return reference to this object
+   */
+  GEOSX_HOST_DEVICE
+  ComponentMask & operator-=( int const i )
+  {
+    unset( i );
+    return *this;
+  }
+
+  /**
+   * @brief Negation operator (inverts component selection).
+   * @return new mask that is the inversion of this object
+   */
+  GEOSX_HOST_DEVICE
+  ComponentMask operator~() const
+  {
+    ComponentMask mask( m_numComp );
+    mask.m_mask = ~m_mask & ((mask_t(1) << m_numComp) - 1);
+    return mask;
+  }
+
+  /**
+   * @brief Make a new mask by adding a component.
+   * @param mask the mask to append to
+   * @param i component index
+   * @return new component mask
+   */
+  GEOSX_HOST_DEVICE
+  friend ComponentMask operator+( ComponentMask const & mask, int const i )
+  {
+    ComponentMask new_mask = mask;
+    new_mask += i;
+    return new_mask;
+  }
+
+  /**
+   * @brief Make a new mask by adding a component.
+   * @param i component index
+   * @param mask the mask to append to
+   * @return new component mask
+   */
+  GEOSX_HOST_DEVICE
+  friend ComponentMask operator+( int const i, ComponentMask const & mask )
+  {
+    return mask + i;
+  }
+
+  /**
+   * @brief Make a new mask by removing a component.
+   * @param mask the mask to remove from
+   * @param i component index
+   * @return new component mask
+   */
+  GEOSX_HOST_DEVICE
+  friend ComponentMask operator-( ComponentMask const & mask, int const i )
+  {
+    ComponentMask new_mask = mask;
+    new_mask -= i;
+    return new_mask;
+  }
+
+  /**
+   * @brief Make a new mask by removing a component.
+   * @param i component index
+   * @param mask the mask to remove from
+   * @return new component mask
+   */
+  GEOSX_HOST_DEVICE
+  friend ComponentMask operator-( int const i, ComponentMask const & mask )
+  {
+    return mask - i;
+  }
+
+  ///@}
+
+private:
+
+  /// Bit representation of the component mask
+  mask_t m_mask = 0;
+
+  /// Runtime number of components (included or excluded) represented by this mask
+  int m_numComp = 0;
+};
+
+}
+
+#endif //GEOSX_LINEARALGEBRA_UTILITIES_COMPONENTMASK_HPP_

--- a/src/coreComponents/linearAlgebra/utilities/LAIHelperFunctions.hpp
+++ b/src/coreComponents/linearAlgebra/utilities/LAIHelperFunctions.hpp
@@ -247,7 +247,7 @@ void computeRigidBodyModes( MeshLevel const & mesh,
   array1d< globalIndex > globalNodeList;
   for( localIndex k = 0; k < LvArray::integerConversion< localIndex >( selection.size() ); ++k )
   {
-    if( dofManager.getLocation( selection[k] ) == DofManager::Location::Node )
+    if( dofManager.location( selection[k] ) == DofManager::Location::Node )
     {
       string const & dispDofKey = dofManager.getKey( selection[k] );
       arrayView1d< globalIndex const > const & dofNumber = nodeManager.getReference< globalIndex_array >( dispDofKey );

--- a/src/coreComponents/mesh/CMakeLists.txt
+++ b/src/coreComponents/mesh/CMakeLists.txt
@@ -46,6 +46,7 @@ set( mesh_headers
      simpleGeometricObjects/ThickPlane.hpp
      simpleGeometricObjects/BoundedPlane.hpp
      utilities/ComputationalGeometry.hpp
+     utilities/MeshMapUtilities.hpp
      utilities/MeshUtilities.hpp
      utilities/StructuredGridUtilities.hpp
   )

--- a/src/coreComponents/mesh/utilities/MeshMapUtilities.hpp
+++ b/src/coreComponents/mesh/utilities/MeshMapUtilities.hpp
@@ -1,0 +1,216 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2019 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2019 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2019 Total, S.A
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All right reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file MeshMapUtilities.hpp
+ */
+#ifndef GEOSX_MESH_UTILITIES_MESHMAPUTILITIES_HPP
+#define GEOSX_MESH_UTILITIES_MESHMAPUTILITIES_HPP
+
+#include "common/DataTypes.hpp"
+
+namespace geosx
+{
+
+/**
+ * @brief This namespace contains helper functions that facilitate access
+ *        into the assortment of maps used by GEOSX mesh object managers
+ *        (e.g. array2d/array1d(array1d)/ArrayOfArrays/ArrayOfSets, etc.)
+ */
+namespace meshMapUtilities
+{
+
+//////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @brief @return the size of the map along first dimension
+ * @tparam T type of map element
+ * @param map reference to the map
+ */
+template< typename T >
+inline localIndex size0( arrayView1d< arrayView1d< T const > const > const & map )
+{
+  return map.size();
+}
+
+/**
+ * @copydoc size0(arrayView1d< arrayView1d< T const > const > const &)
+ * @tparam USD unit-stride dimension of the map
+ */
+template< typename T, int USD >
+inline localIndex size0( arrayView2d< T, USD > const & map )
+{
+  return map.size( 0 );
+}
+
+/**
+ * @copydoc size0(arrayView1d< arrayView1d< T const > const > const &)
+ */
+template< typename T >
+inline localIndex size0( ArrayOfArraysView< T const > const & map )
+{
+  return map.size();
+}
+
+/**
+ * @copydoc size0(arrayView1d< arrayView1d< T const > const > const &)
+ */
+template< typename T >
+inline localIndex size0( ArrayOfSetsView< T const > const & map )
+{
+  return map.size();
+}
+
+//////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @brief @return the size of the map along second dimension
+ * @tparam T type of map element
+ * @param map reference to the map
+ * @param i0 first-dimension index into the map
+ */
+template< typename T >
+inline localIndex size1( arrayView1d< arrayView1d< T const > const > const & map, localIndex const i0 )
+{
+  return map[i0].size();
+}
+
+/**
+ * @copydoc size1(arrayView1d< arrayView1d< T const > const > const &, localIndex const)
+ * @tparam USD unit-stride dimension of the map
+ */
+template< typename T, int USD >
+inline localIndex size1( arrayView2d< T, USD > const & map, localIndex const i0 )
+{
+  GEOSX_UNUSED_VAR( i0 )
+  return map.size( 1 );
+}
+
+/**
+ * @copydoc size1(arrayView1d< arrayView1d< T const > const > const &, localIndex const)
+ */
+template< typename T >
+inline localIndex size1( ArrayOfArraysView< T const > const & map, localIndex const i0 )
+{
+  return map.sizeOfArray( i0 );
+}
+
+/**
+ * @copydoc size1(arrayView1d< arrayView1d< T const > const > const &, localIndex const)
+ */
+template< typename T >
+inline localIndex size1( ArrayOfSetsView< T const > const & map, localIndex const i0 )
+{
+  return map.sizeOfSet( i0 );
+}
+
+//////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @brief @return the value of the map
+ * @tparam T type of map element
+ * @param map reference to the map
+ * @param i0 first-dimension index into the map
+ * @param i1 second-dimension index into the map
+ */
+template< typename T >
+inline T const & value( arrayView1d< arrayView1d< T const > const > const & map, localIndex const i0, localIndex const i1 )
+{
+  return map[i0][i1];
+}
+
+/**
+ * @copydoc value(arrayView1d< arrayView1d< T const > const > const &, localIndex const, localIndex const)
+ * @tparam USD unit-stride dimension of the map
+ */
+template< typename T, int USD >
+inline T const & value( arrayView2d< T, USD > const & map, localIndex const i0, localIndex const i1 )
+{
+  return map( i0, i1 );
+}
+
+/**
+ * @copydoc value(arrayView1d< arrayView1d< T const > const > const &, localIndex const, localIndex const)
+ */
+template< typename T >
+inline T const & value( ArrayOfArraysView< T const > const & map, localIndex const i0, localIndex const i1 )
+{
+  return map( i0, i1 );
+}
+
+/**
+ * @copydoc value(arrayView1d< arrayView1d< T const > const > const &, localIndex const, localIndex const)
+ */
+template< typename T >
+inline T const & value( ArrayOfSetsView< T const > const & map, localIndex const i0, localIndex const i1 )
+{
+  return map( i0, i1 );
+}
+
+//////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @brief @return the total number of elements in the map
+ * @tparam T type of map element
+ * @param map reference to the map
+ */
+template< typename T >
+inline localIndex numElements( arrayView1d< arrayView1d< T const > const > const & map )
+{
+  return map.size();
+}
+
+/**
+ * @copydoc numElements(arrayView1d< arrayView1d< T const > const > const &)
+ * @tparam USD unit-stride dimension of the map
+ */
+template< typename T, int USD >
+inline localIndex numElements( arrayView2d< T, USD > const & map )
+{
+  return map.size();
+}
+
+/**
+ * @copydoc numElements(arrayView1d< arrayView1d< T const > const > const &)
+ */
+template< typename T >
+inline localIndex numElements( ArrayOfArraysView< T const > const & map )
+{
+  localIndex size = 0;
+  for( localIndex i = 0; i < map.size(); ++i )
+  {
+    size += map.sizeOfArray( i );
+  }
+  return size;
+}
+
+/**
+ * @copydoc numElements(arrayView1d< arrayView1d< T const > const > const &)
+ */
+template< typename T >
+inline localIndex numElements( ArrayOfSetsView< T const > const & map )
+{
+  localIndex size = 0;
+  for( localIndex i = 0; i < map.size(); ++i )
+  {
+    size += map.sizeOfSet( i );
+  }
+  return size;
+}
+
+} // namespace meshMapUtilities
+
+} // namespace geosx
+
+#endif //GEOSX_MESH_UTILITIES_MESHMAPUTILITIES_HPP

--- a/src/coreComponents/physicsSolvers/SolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/SolverBase.cpp
@@ -664,7 +664,7 @@ void SolverBase::setupSystem( DomainPartition & domain,
 {
   GEOSX_MARK_FUNCTION;
 
-  dofManager.setMesh( domain, 0, 0 );
+  dofManager.setMesh( domain.getMeshBody( 0 ).getMeshLevel( 0 ) );
 
   setupDofs( domain, dofManager );
   dofManager.reorderByRank();

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFVM.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFVM.cpp
@@ -341,17 +341,19 @@ void CompositionalMultiphaseFVM::applySystemSolution( DofManager const & dofMana
                                                       DomainPartition & domain )
 {
   MeshLevel & mesh = domain.getMeshBody( 0 ).getMeshLevel( 0 );
+  DofManager::CompMask pressureMask( m_numDofPerCell, 0, 1 );
+
   dofManager.addVectorToField( localSolution,
                                viewKeyStruct::elemDofFieldString(),
                                viewKeyStruct::deltaPressureString(),
                                scalingFactor,
-                               0, 1 );
+                               pressureMask );
 
   dofManager.addVectorToField( localSolution,
                                viewKeyStruct::elemDofFieldString(),
                                viewKeyStruct::deltaGlobalCompDensityString(),
                                scalingFactor,
-                               1, m_numDofPerCell );
+                               ~pressureMask );
 
   // if component density chopping is allowed, some component densities may be negative after the update
   // these negative component densities are set to zero in this function

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseHybridFVM.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseHybridFVM.cpp
@@ -296,8 +296,7 @@ void CompositionalMultiphaseHybridFVM::setupDofs( DomainPartition const & GEOSX_
   // setup coupling between pressure and face pressure
   dofManager.addCoupling( viewKeyStruct::faceDofFieldString(),
                           viewKeyStruct::elemDofFieldString(),
-                          DofManager::Connector::Elem,
-                          true );
+                          DofManager::Connector::Elem );
 
 }
 
@@ -783,18 +782,19 @@ void CompositionalMultiphaseHybridFVM::applySystemSolution( DofManager const & d
   MeshLevel & mesh = domain.getMeshBody( 0 ).getMeshLevel( 0 );
 
   // 1. apply the elem-based update
+  DofManager::CompMask pressureMask( m_numDofPerCell, 0, 1 );
 
   dofManager.addVectorToField( localSolution,
                                viewKeyStruct::elemDofFieldString(),
                                viewKeyStruct::deltaPressureString(),
                                scalingFactor,
-                               0, 1 );
+                               pressureMask );
 
   dofManager.addVectorToField( localSolution,
                                viewKeyStruct::elemDofFieldString(),
                                viewKeyStruct::deltaGlobalCompDensityString(),
                                scalingFactor,
-                               1, m_numDofPerCell );
+                               ~pressureMask );
 
   // if component density chopping is allowed, some component densities may be negative after the update
   // these negative component densities are set to zero in this function

--- a/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBase.hpp
@@ -161,7 +161,7 @@ protected:
   integer m_coupledWellsFlag;
 
   /// the number of Degrees of Freedom per cell
-  localIndex m_numDofPerCell;
+  integer m_numDofPerCell;
 
   std::unique_ptr< CRSMatrix< real64, localIndex > > m_derivativeFluxResidual_dAperture;
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/ProppantTransport.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/ProppantTransport.cpp
@@ -965,7 +965,7 @@ void ProppantTransport::applySystemSolution( DofManager const & dofManager,
                                viewKeyStruct::proppantConcentrationString(),
                                viewKeyStruct::deltaProppantConcentrationString(),
                                scalingFactor,
-                               0, 1 );
+                               { m_numDofPerCell, 0, 1 } );
 
 
   if( m_numDofPerCell > 1 )
@@ -974,7 +974,7 @@ void ProppantTransport::applySystemSolution( DofManager const & dofManager,
                                  viewKeyStruct::proppantConcentrationString(),
                                  viewKeyStruct::deltaComponentConcentrationString(),
                                  scalingFactor,
-                                 1, m_numDofPerCell );
+                                 { m_numDofPerCell, 1, m_numDofPerCell } );
   }
 
   std::map< string, string_array > fieldNames;

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseFVM.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseFVM.cpp
@@ -70,6 +70,7 @@ void SinglePhaseFVM< BASE >::setupDofs( DomainPartition const & domain,
 {
   dofManager.addField( BASE::viewKeyStruct::pressureString(),
                        DofManager::Location::Elem,
+                       1,
                        targetRegionNames() );
 
   NumericalMethodsManager const & numericalMethodManager = domain.getNumericalMethodManager();

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseHybridFVM.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseHybridFVM.cpp
@@ -173,6 +173,7 @@ void SinglePhaseHybridFVM::setupDofs( DomainPartition const & GEOSX_UNUSED_PARAM
   // in AssembleOneSidedMassFluxes
   dofManager.addField( viewKeyStruct::pressureString(),
                        DofManager::Location::Elem,
+                       1,
                        targetRegionNames() );
 
   dofManager.addCoupling( viewKeyStruct::pressureString(),
@@ -182,6 +183,7 @@ void SinglePhaseHybridFVM::setupDofs( DomainPartition const & GEOSX_UNUSED_PARAM
   // setup the connectivity of face fields
   dofManager.addField( viewKeyStruct::facePressureString(),
                        DofManager::Location::Face,
+                       1,
                        targetRegionNames() );
 
   dofManager.addCoupling( viewKeyStruct::facePressureString(),
@@ -191,8 +193,7 @@ void SinglePhaseHybridFVM::setupDofs( DomainPartition const & GEOSX_UNUSED_PARAM
   // setup coupling between pressure and face pressure
   dofManager.addCoupling( viewKeyStruct::facePressureString(),
                           viewKeyStruct::pressureString(),
-                          DofManager::Connector::Elem,
-                          true );
+                          DofManager::Connector::Elem );
 }
 
 void SinglePhaseHybridFVM::assembleFluxTerms( real64 const GEOSX_UNUSED_PARAM( time_n ),

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
@@ -1286,19 +1286,19 @@ CompositionalMultiphaseWell::applySystemSolution( DofManager const & dofManager,
                                wellElementDofName(),
                                viewKeyStruct::deltaPressureString(),
                                scalingFactor,
-                               0, 1 );
+                               { m_numDofPerWellElement, 0, 1 } );
 
   dofManager.addVectorToField( localSolution,
                                wellElementDofName(),
                                viewKeyStruct::deltaGlobalCompDensityString(),
                                scalingFactor,
-                               1, m_numDofPerWellElement - 1 );
+                               { m_numDofPerWellElement, 1, m_numDofPerWellElement - 1 } );
 
   dofManager.addVectorToField( localSolution,
                                wellElementDofName(),
                                viewKeyStruct::deltaMixtureConnRateString(),
                                scalingFactor,
-                               m_numDofPerWellElement - 1, m_numDofPerWellElement );
+                               { m_numDofPerWellElement, m_numDofPerWellElement - 1, m_numDofPerWellElement } );
 
   // if component density chopping is allowed, some component densities may be negative after the update
   // these negative component densities are set to zero in this function

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/SinglePhaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/SinglePhaseWell.cpp
@@ -647,13 +647,13 @@ SinglePhaseWell::applySystemSolution( DofManager const & dofManager,
                                wellElementDofName(),
                                viewKeyStruct::deltaPressureString(),
                                scalingFactor,
-                               0, 1 );
+                               { m_numDofPerWellElement, 0, 1 } );
 
   dofManager.addVectorToField( localSolution,
                                wellElementDofName(),
                                viewKeyStruct::deltaConnRateString(),
                                scalingFactor,
-                               1, m_numDofPerWellElement );
+                               { m_numDofPerWellElement, 1, m_numDofPerWellElement } );
 
   std::map< string, string_array > fieldNames;
   fieldNames["elems"].emplace_back( string( viewKeyStruct::deltaPressureString() ) );

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/WellSolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/WellSolverBase.hpp
@@ -294,10 +294,10 @@ protected:
   array1d< string > m_fluidModelNames;
 
   /// the number of Degrees of Freedom per well element
-  localIndex m_numDofPerWellElement;
+  integer m_numDofPerWellElement;
 
   /// the number of Degrees of Freedom per reservoir element
-  localIndex m_numDofPerResElement;
+  integer m_numDofPerResElement;
 
   /// copy of the time step size saved in this class for residual normalization
   real64 m_currentDt;

--- a/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.cpp
@@ -495,7 +495,7 @@ void HydrofractureSolver::setupSystem( DomainPartition & domain,
   MeshLevel & mesh = domain.getMeshBody( 0 ).getMeshLevel( 0 );
   m_flowSolver->resetViews( mesh );
 
-  dofManager.setMesh( domain, 0, 0 );
+  dofManager.setMesh( mesh );
 
   setupDofs( domain, dofManager );
   dofManager.reorderByRank();

--- a/src/coreComponents/physicsSolvers/multiphysics/LagrangianContactSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/LagrangianContactSolver.cpp
@@ -1160,7 +1160,7 @@ void LagrangianContactSolver::createPreconditioner( DomainPartition const & doma
 
     // Preconditioner for the leading block: tracPrecond
     precond->setupBlock( 0,
-                         { { viewKeyStruct::tractionString(), 0, 3 } },
+                         { { viewKeyStruct::tractionString(), { 3, true } } },
                          std::move( tracPrecond ) );
 
     if( mechParams.amg.nullSpaceType == LinearSolverParameters::AMG::NullSpaceType::rigidBodyModes )
@@ -1178,7 +1178,7 @@ void LagrangianContactSolver::createPreconditioner( DomainPartition const & doma
     // Preconditioner for the Schur complement: mechPrecond
     std::unique_ptr< PreconditionerBase< LAInterface > > mechPrecond = LAInterface::createPreconditioner( mechParams, m_solidSolver->getRigidBodyModes() );
     precond->setupBlock( 1,
-                         { { keys::TotalDisplacement, 0, 3 } },
+                         { { keys::TotalDisplacement, { 3, true } } },
                          std::move( mechPrecond ) );
 
     m_precond = std::move( precond );

--- a/src/coreComponents/physicsSolvers/multiphysics/PoroelasticSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/PoroelasticSolver.cpp
@@ -547,12 +547,12 @@ void PoroelasticSolver::createPreconditioner()
 
     auto mechPrecond = LAInterface::createPreconditioner( m_solidSolver->getLinearSolverParameters() );
     precond->setupBlock( 0,
-                         { { keys::TotalDisplacement, 0, 3 } },
+                         { { keys::TotalDisplacement, { 3, true } } },
                          std::make_unique< SeparateComponentPreconditioner< LAInterface > >( 3, std::move( mechPrecond ) ) );
 
     auto flowPrecond = LAInterface::createPreconditioner( m_flowSolver->getLinearSolverParameters() );
     precond->setupBlock( 1,
-                         { { SinglePhaseBase::viewKeyStruct::pressureString(), 0, 1 } },
+                         { { SinglePhaseBase::viewKeyStruct::pressureString(), { 1, true } } },
                          std::move( flowPrecond ) );
 
     m_precond = std::move( precond );

--- a/src/coreComponents/physicsSolvers/multiphysics/PoroelasticSolverEmbeddedFractures.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/PoroelasticSolverEmbeddedFractures.cpp
@@ -134,7 +134,7 @@ void PoroelasticSolverEmbeddedFractures::setupSystem( DomainPartition & domain,
 
   GEOSX_UNUSED_VAR( setSparsity );
 
-  dofManager.setMesh( domain, 0, 0 );
+  dofManager.setMesh( domain.getMeshBody( 0 ).getMeshLevel( 0 ) );
   setupDofs( domain, dofManager );
   dofManager.reorderByRank();
 

--- a/src/coreComponents/physicsSolvers/multiphysics/ReservoirSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/ReservoirSolverBase.cpp
@@ -205,7 +205,7 @@ void ReservoirSolverBase::setupSystem( DomainPartition & domain,
 {
   GEOSX_MARK_FUNCTION;
 
-  dofManager.setMesh( domain, 0, 0 );
+  dofManager.setMesh( domain.getMeshBody( 0 ).getMeshLevel( 0 ) );
 
   setupDofs( domain, dofManager );
   dofManager.reorderByRank();

--- a/src/coreComponents/physicsSolvers/simplePDE/LaplaceBaseH1.cpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/LaplaceBaseH1.cpp
@@ -123,7 +123,9 @@ void LaplaceBaseH1::setupDofs( DomainPartition const & GEOSX_UNUSED_PARAM( domai
                                DofManager & dofManager ) const
 {
   dofManager.addField( m_fieldName,
-                       DofManager::Location::Node );
+                       DofManager::Location::Node,
+                       1,
+                       targetRegionNames() );
 
   dofManager.addCoupling( m_fieldName,
                           m_fieldName,

--- a/src/coreComponents/physicsSolvers/simplePDE/LaplaceVEM.cpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/LaplaceVEM.cpp
@@ -100,7 +100,7 @@ void LaplaceVEM::setupSystem( DomainPartition & domain,
   //       m_localMatrix.assimilate< parallelDevicePolicy<> >( std::move( pattern ) );
   //       and that creates problems (integratedTests failures) on Lassen for CPU-only implicit simulations
 
-  dofManager.setMesh( domain, 0, 0 );
+  dofManager.setMesh( domain.getMeshBody( 0 ).getMeshLevel( 0 ) );
 
   setupDofs( domain, dofManager );
   dofManager.reorderByRank();

--- a/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEM.cpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEM.cpp
@@ -191,18 +191,19 @@ void PhaseFieldDamageFEM::setupSystem( DomainPartition & domain,
   SolverBase::setupSystem( domain, dofManager, localMatrix, localRhs, localSolution, setSparsity );
 }
 
-void PhaseFieldDamageFEM::implicitStepComplete(
-  real64 const & GEOSX_UNUSED_PARAM( time_n ),
-  real64 const & GEOSX_UNUSED_PARAM( dt ),
-  DomainPartition & GEOSX_UNUSED_PARAM( domain ) )
+void PhaseFieldDamageFEM::implicitStepComplete( real64 const & GEOSX_UNUSED_PARAM( time_n ),
+                                                real64 const & GEOSX_UNUSED_PARAM( dt ),
+                                                DomainPartition & GEOSX_UNUSED_PARAM( domain ) )
 {}
 
-void PhaseFieldDamageFEM::setupDofs(
-  DomainPartition const & GEOSX_UNUSED_PARAM( domain ),
-  DofManager & dofManager ) const
+void PhaseFieldDamageFEM::setupDofs( DomainPartition const & GEOSX_UNUSED_PARAM( domain ),
+                                     DofManager & dofManager ) const
 {
   GEOSX_MARK_FUNCTION;
-  dofManager.addField( m_fieldName, DofManager::Location::Node );
+  dofManager.addField( m_fieldName,
+                       DofManager::Location::Node,
+                       1,
+                       targetRegionNames() );
 
   dofManager.addCoupling( m_fieldName,
                           m_fieldName,

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsEmbeddedFractures.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsEmbeddedFractures.cpp
@@ -197,7 +197,7 @@ void SolidMechanicsEmbeddedFractures::setupSystem( DomainPartition & domain,
 
   GEOSX_UNUSED_VAR( setSparsity );
 
-  dofManager.setMesh( domain, 0, 0 );
+  dofManager.setMesh( domain.getMeshBody( 0 ).getMeshLevel( 0 ) );
   setupDofs( domain, dofManager );
   dofManager.reorderByRank();
 

--- a/src/coreComponents/unitTests/linearAlgebraTests/testLAIHelperFunctions.cpp
+++ b/src/coreComponents/unitTests/linearAlgebraTests/testLAIHelperFunctions.cpp
@@ -85,7 +85,7 @@ TYPED_TEST_P( LAIHelperFunctionsTest, nodalVectorPermutation )
   arrayView1d< globalIndex const > const nodeLocalToGlobal = nodeManager.localToGlobalMap();
 
   DofManager dofManager( "test" );
-  dofManager.setMesh( domain, 0, 0 );
+  dofManager.setMesh( meshLevel );
 
   string_array regions;
   regions.emplace_back( "region1" );
@@ -144,12 +144,12 @@ TYPED_TEST_P( LAIHelperFunctionsTest, cellCenteredVectorPermutation )
   ElementRegionManager const & elemManager = meshLevel.getElemManager();
 
   DofManager dofManager( "test" );
-  dofManager.setMesh( domain, 0, 0 );
+  dofManager.setMesh( meshLevel );
 
   string_array regions;
   regions.emplace_back( "region1" );
 
-  dofManager.addField( "cellCentered", DofManager::Location::Elem, regions );
+  dofManager.addField( "cellCentered", DofManager::Location::Elem, 1, regions );
   dofManager.addCoupling( "cellCentered", "cellCentered", DofManager::Connector::Face );
   dofManager.reorderByRank();
 

--- a/src/docs/doxygen/GeosxConfig.hpp
+++ b/src/docs/doxygen/GeosxConfig.hpp
@@ -72,11 +72,11 @@
 #define GEOSX_USE_PETSC
 
 /// Choice of global linear algebra interface (CMake option GEOSX_LA_INTERFACE)
-#define GEOSX_LA_INTERFACE Trilinos
+#define GEOSX_LA_INTERFACE Hypre
 /// Macro defined when Trilinos interface is selected
-#define GEOSX_LA_INTERFACE_TRILINOS
+/* #undef GEOSX_LA_INTERFACE_TRILINOS */
 /// Macro defined when Hypre interface is selected
-/* #undef GEOSX_LA_INTERFACE_HYPRE */
+#define GEOSX_LA_INTERFACE_HYPRE
 /// Macro defined when PETSc interface is selected
 /* #undef GEOSX_LA_INTERFACE_PETSC */
 


### PR DESCRIPTION
* Reduce the number of memory accesses when populating dof index arrays by slightly tweaking the numbering logic
* Replace mesh visitor raw loops with RAJA loops and use parallel host policy where appropriate (e.g. when counting)
* Remove concatenated region names from dof index wrapper name - it is no longer useful when each DofManager instance has its own unique name prefix.
* Add `ComponentMask` abstraction that replaces the `[loComp; hiComp)` pairs in methods that do component sub-setting (all vector-to-field and field-to-vector methods, as well as `makeRestrictor`), which allows for more flexible specification of component mapping (previously only a contiguous range). It acts like a simple dynamic-size bitset of fixed capacity (up to 64, so that it fits into a single unsigned 64-bit int), but is host-device marked so it can be used in device kernels.
* Remove a bunch of methods related to sparsity pattern generation on LAI matrices - we don't use that capability anymore outside of unit tests but it contained a lot of duplicate code.
* Remove the artificial limit on number of fields in DofManager by changing the storage for coupling data from array2d to map.
* Removed multiple overloads of `addField` and `addCoupling` methods (seems easy enough to just provide all parameters at all call sites)
* Miscellaneous minor code cleanups

No change in functionality otherwise, but rebaseline required to a slight naming scheme change for dof index arrays - even though dof index array have a `NO_WRITE` flag, the wrapper name still appears (without data) in the restart file. 