### PR TITLE
CMake build cleanup

### DIFF
--- a/scripts/circular_dependencies.sh
+++ b/scripts/circular_dependencies.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+# Writes to a dependency_matrix.txt file in the current directory.
+# Each row has the component followed by a "yes" or "no" if the component
+# has a header/dependency to the other component named at the top of the 
+# column.
+# Tab delimited, can be exported to Excel (Data --> From Test/CSV)
+
+declare -ar coreComponents=(
+ common
+ codingUtilities
+ dataRepository
+ schema
+ functions
+ constitutive
+ mesh
+ linearAlgebra
+ fieldSpecification
+ finiteElement
+ finiteVolume
+ virtualElement
+ discretizationMethods
+ fileIO
+ physicsSolvers
+ events
+ mainInterface
+)
+
+declare -a depMatrix
+
+length=${#coreComponents[@]}
+
+printf -v header '%s\t' "${coreComponents[@]}"
+echo -e " x\t" "${header}" > dependency_matrix.txt
+
+
+# For each component
+for (( i=0; i<$length; i++))
+do
+  # Name of component, followed by dependency
+  declare -a name_dependencies=( ${coreComponents[$i]} )
+  echo "Checking dependencies derived from headers for component $name_dependencies..."
+
+  # Check if header appears in component's files
+  for (( j=0; j<$length; j++))
+  do
+    if grep -nr "#include" src/coreComponents/${coreComponents[$i]} | 
+       grep -v "//#include" | 
+       grep -v "<" | 
+       grep -v "unitTests" |
+       grep -q "${coreComponents[$j]}"; then
+
+    	name_dependencies+=( yes )
+    	depMatrix[($i * $length) + $j]=yes
+    else 
+    	name_dependencies+=( no )
+    	depMatrix[($i * $length) + $j]=no
+    fi
+  done
+
+  printf -v row '%s\t' "${name_dependencies[@]}"
+  echo "${row}" >> dependency_matrix.txt
+done
+
+echo -e "\n\nFinish checking dependencies! Dependency matrix written to dependency_matrix.txt"
+echo -e "\nNow checking for circular dependencies...\n\n"
+
+# Check for circular dependencies
+> circular_dependencies.txt
+for (( x=0; x<$length; x++))
+do
+  # Check half of the matrix
+  for (( y=($x + 1); y < $length; y++))
+  do
+    declare -i a=$x*$length+$y
+    declare -i b=$y*$length+$x
+  	if [ "${depMatrix[$a]}" == yes ] && [ "${depMatrix[$b]}" == yes ]; then
+      echo -e "${coreComponents[$x]} & ${coreComponents[$y]} have a circular dependency" | tee -a circular_dependencies.txt
+      
+      echo -e "\n${coreComponents[$x]} ---> ${coreComponents[$y]}" >> circular_dependencies.txt
+      grep -nr "#include" src/coreComponents/${coreComponents[$x]} | 
+       grep -v "//#include" | 
+       grep -v "<" | 
+       grep -v "unitTests" |
+       grep "${coreComponents[$y]}" >> circular_dependencies.txt
+
+      echo -e "\n${coreComponents[$y]} ---> ${coreComponents[$x]}" >> circular_dependencies.txt
+      grep -nr "#include" src/coreComponents/${coreComponents[$y]} | 
+       grep -v "//#include" | 
+       grep -v "<" | 
+       grep -v "unitTests" |
+       grep "${coreComponents[$x]}" >> circular_dependencies.txt
+
+      echo -e "\n\n" >> circular_dependencies.txt
+  	fi
+  done
+done
+
+echo -e "\nFinished checking for circular dependecies! Any circular dependencies are written to circular_dependencies.txt"

--- a/scripts/find_cycles.py
+++ b/scripts/find_cycles.py
@@ -1,0 +1,168 @@
+import argparse
+from dataclasses import dataclass
+import json
+import logging
+import multiprocessing
+import os
+import subprocess
+import sys
+from typing import List, Dict, Tuple
+
+import networkx as nx
+
+
+@dataclass(frozen=True, eq=True)
+class Compile(object):
+    """
+    Data class that wraps the json Ninja output.
+    """
+    directory: str
+    command: str
+    file: str
+
+    @property
+    def include_command(self) -> List[str]:
+        """
+        Returns the gcc command that will output the include hierarchy.
+        :return: List of strings ready to be used in a subprocess.call.
+        """
+        tmp = self.command.split()
+        tmp.insert(1, "-E")  # gcc postprocessing option to stop after preprocessing.
+        tmp.insert(1, "-H")  # gcc postprocessing option to get the included headers
+        return tmp
+
+
+def get_compile_commands(ninja_compile_command: str) -> Tuple[Compile]:
+    """
+    Converts Ninja's json into a list of Compile instances.
+    :param ninja_compile_command: absolute path the the ninja `compile_commands.json` file
+    :return: The tuple of compilation.
+    """
+    with open(ninja_compile_command, "r") as f:
+        raw = json.load(f)
+    return tuple(map(
+        lambda j: Compile(j["directory"], j["command"], j["file"]),
+        raw
+    ))
+
+
+def recursive_populate(edges: Tuple[str, str], root_indent: int, root_path: str, sub_graph_info: Tuple[int, str]) -> None:
+    """
+    Constructs the edges and populate the list.
+    :param edges: List the will contain the pairs of string.
+    :param root_indent: The gcc log indents more deep graph nodes.
+    :param root_path: One node/file/root includes other nodes/files/children.
+    :param sub_graph_info: List of (child indent, child path), respecting the gcc log.
+    :return: None
+    """
+    for index, (indent, path) in enumerate(sub_graph_info):
+        if indent == (root_indent + 1):
+            edges.append((root_path, path))
+            recursive_populate(edges, indent, path, sub_graph_info[index + 1:])
+        if indent <= root_indent:  # This is not our graph branch anymore
+            return
+
+
+def find_cycles(outputs: Dict[Compile, str], exclude_dirs: List[str]) -> int:
+    """
+    Builds the graph of include dependencies and search for cycles.
+    Cycles are printed on screen.
+    :param exclude_dirs: List of directories we do not want to consider for the cycle analysis.
+    :param outputs: For each Compile instance, the gcc log with the include graph (to be parsed).
+    :return: The number of cycles
+    """
+    edges = []
+    for cc, stderr in outputs.items():
+        # For each compilation log, contains the depth and name for each included file.
+        sub_graph_info = []
+        logging.info("Populating include graph for %s." % cc.file)
+        for line in filter(None, stderr.split('\n')):
+            if line.startswith('.'):
+                indent, path = line.split()
+                # Making all the paths absolute
+                if not os.path.isabs(path):
+                    path = os.path.normpath(os.path.join(cc.directory, path))
+                sub_graph_info.append((len(indent), path))
+            else:
+                break  # graph lines are on top, we stop at first non graph line.
+        recursive_populate(edges, 0, cc.file, sub_graph_info)
+
+    # Using dedicated graph lib to find cycles.
+    def edge_predicate(edge: Tuple[str, str]) -> bool:
+        for node in edge:
+            for e in exclude_dirs:
+                if node.startswith(e):
+                    return False
+        return True
+
+    graph = nx.DiGraph()
+    graph.add_edges_from(filter(edge_predicate, edges))
+    cycles = tuple(nx.simple_cycles(graph))
+    logging.info("%s cycle(s) found" % len(cycles))
+    for cycle in cycles:
+        print(cycle)
+    return len(cycles)
+
+
+def get_gcc_output(cc: Compile) -> str:
+    """
+    Gets the log that will be parsed into dependency graph.
+    :param cc: The Compile command instance
+    :return: The stderr
+
+    sys.exit(-1) in case of error.
+    """
+    try:
+        logging.info("Extracting include information for " + cc.file)
+        process = subprocess.run(cc.include_command, capture_output=True, cwd=cc.directory, check=True)
+        return process.stderr.decode('utf-8')  # output is on stderr.
+    except subprocess.CalledProcessError as e:
+        logging.error("Could not run " + " ".join(cc.include_command), exc_info=e)
+        sys.exit(-1)
+
+
+def get_gcc_outputs(ninja_compile_command: str) -> Dict[Compile, str]:
+    """
+    Given the list of compile commands from Ninja, gets the logs containing the included files information.
+    :param ninja_compile_command: absolute path the the ninja `compile_commands.json` file
+    :return: A Compile to log dictionary.
+    """
+    compile_commands = get_compile_commands(ninja_compile_command)
+    # multiprocessing.cpu_count does not consider some limitations, si I use os.sched_getaffinity
+    with multiprocessing.Pool(len(os.sched_getaffinity(0))) as pool:
+        # get_gcc_output write to stdout in parallel using the logging module
+        # I did not see any any interweaving so...
+        logs = pool.map(get_gcc_output, compile_commands)
+    return {cc: log for cc, log in zip(compile_commands, logs)}
+
+
+def parse(cli_args: List[str]):
+    """
+    Parse the command line arguments and return the corresponding structure.
+    :param cli_args: The list of arguments (as strings)
+    :return: The struct
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--compile-command', help="Ninja's compile_command.json file.",
+                        type=str, dest="ninja_compile_command")
+    parser.add_argument('-e', '--exclude-dir', default=[], action='append', dest="exclude_dirs",
+                        help="Exclude a directory for cycle analysis. Can be used multiple times.")
+    args = parser.parse_args(cli_args)
+    return args
+
+
+def main():
+    """
+    Exits on -1 in case of internal error. Otherwise exits on number of cycles found.
+    No cycle found will therefore exit on 0.
+    :return: None
+    """
+    logging.basicConfig(format='[%(asctime)s][%(levelname)s] %(message)s', level=logging.INFO)
+    args = parse(sys.argv[1:])
+    logging.info("Starting cycle detection process.")
+    outputs = get_gcc_outputs(args.ninja_compile_command)
+    sys.exit(find_cycles(outputs, args.exclude_dirs))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cmake/thirdparty/SetupGeosxThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupGeosxThirdParty.cmake
@@ -259,7 +259,10 @@ if(DEFINED ADIAK_DIR)
 
     set_property(TARGET adiak
                  APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
-                 ${adiak_INCLUDE_DIRS} )
+                 ${adiak_INCLUDE_DIR} )
+    set_property(TARGET adiak
+                 APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                 ${adiak_INCLUDE_DIR} )
 
     set(ENABLE_ADIAK ON CACHE BOOL "")
     set(thirdPartyLibs ${thirdPartyLibs} adiak)
@@ -286,9 +289,9 @@ if(DEFINED CALIPER_DIR)
                  APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
                  ${caliper_INCLUDE_PATH} )
 
-    get_target_property( includeDirs 
-                         caliper
-                         INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
+    set_property(TARGET caliper
+                 APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                 ${caliper_INCLUDE_PATH} )
 
     set(ENABLE_CALIPER ON CACHE BOOL "")
     set(thirdPartyLibs ${thirdPartyLibs} caliper)

--- a/src/coreComponents/CMakeLists.txt
+++ b/src/coreComponents/CMakeLists.txt
@@ -5,7 +5,6 @@ set( subdirs
      dataRepository
      schema
      functions
-     events
      constitutive
      mesh
      linearAlgebra
@@ -16,6 +15,7 @@ set( subdirs
      discretizationMethods
      fileIO
      physicsSolvers
+     events
      mainInterface
      python
      )
@@ -30,7 +30,6 @@ if ( GEOSX_BUILD_OBJ_LIBS )
   set( LVARRAY_BUILD_OBJ_LIBS TRUE CACHE BOOL "" FORCE)
 endif()
 
-list( APPEND coreLibs lvarray)
 add_subdirectory(LvArray)
 
 if( ENABLE_PYGEOSX )

--- a/src/coreComponents/codingUtilities/tests/CMakeLists.txt
+++ b/src/coreComponents/codingUtilities/tests/CMakeLists.txt
@@ -6,16 +6,11 @@ set(testSources
     testGeosxTraits.cpp
    )
 
-set(dependencyList gtest codingUtilities RAJA)
-
-if ( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
-endif()
+set(dependencyList gtest codingUtilities )
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )
 endif()
-
 
 #
 # Add gtest C++ based tests

--- a/src/coreComponents/constitutive/CMakeLists.txt
+++ b/src/coreComponents/constitutive/CMakeLists.txt
@@ -134,10 +134,6 @@ if( ENABLE_PVTPackage )
 
 endif()
 
-if ( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
-endif()
-
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )
 endif()

--- a/src/coreComponents/constitutive/unitTests/CMakeLists.txt
+++ b/src/coreComponents/constitutive/unitTests/CMakeLists.txt
@@ -3,7 +3,6 @@
 #
 
 set( gtest_geosx_tests
-     testDamage.cpp
      testDamageUtilities.cpp
      testDruckerPrager.cpp
      testElasticIsotropic.cpp

--- a/src/coreComponents/constitutive/unitTests/CMakeLists.txt
+++ b/src/coreComponents/constitutive/unitTests/CMakeLists.txt
@@ -9,21 +9,11 @@ set( gtest_geosx_tests
      testPropertyConversions.cpp
    )
 
-
-set( dependencyList gtest constitutive conduit )
-
-if( ENABLE_MPI )
-    set( dependencyList ${dependencyList} mpi )
-endif()
-
-if( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
-endif()
+set( dependencyList gtest constitutive )
 
 if( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )
 endif()
-
 
 #
 # Add gtest C++ based tests

--- a/src/coreComponents/dataRepository/CMakeLists.txt
+++ b/src/coreComponents/dataRepository/CMakeLists.txt
@@ -34,30 +34,14 @@ set(dataRepository_sources
     xmlWrapper.cpp
     )
 
-set( extraComponentsLinkList "")
-
-if( ENABLE_MPI )
-  set( extraComponentsLinkList ${extraComponentsLinkList} mpi )
-endif()
-
-set (dependencyList codingUtilities pugixml )
-
-if ( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
-endif()
+set (dependencyList codingUtilities )
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )
 endif()
 
-set( dependencyList ${dependencyList} common conduit )
-
 if( ENABLE_PYGEOSX )
   set( dependencyList ${dependencyList} pylvarray )
-endif()
-
-if( ENABLE_CALIPER )
-  set( dependencyList ${dependencyList} caliper adiak )
 endif()
 
 blt_add_library( NAME                  dataRepository

--- a/src/coreComponents/dataRepository/unitTests/CMakeLists.txt
+++ b/src/coreComponents/dataRepository/unitTests/CMakeLists.txt
@@ -9,18 +9,10 @@ set( dataRepository_tests
      testBufferOps.cpp
    )
 
-set( dependencyList gtest dataRepository conduit RAJA )
-
-if ( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
-endif()
+set( dependencyList gtest dataRepository )
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )
-endif()
-
-if ( ENABLE_CALIPER )
-  set( dependencyList ${dependencyList} caliper adiak )
 endif()
 
 #

--- a/src/coreComponents/discretizationMethods/CMakeLists.txt
+++ b/src/coreComponents/discretizationMethods/CMakeLists.txt
@@ -7,21 +7,9 @@ set(mainInterface_headers
 
 set( dependencyList finiteElement finiteVolume virtualElement )
 
-if( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
-endif( )
-
 if( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )
 endif( )
-
-if( ENABLE_MPI )
-  set( dependencyList ${dependencyList} mpi )
-endif()
-
-if( ENABLE_CALIPER )
-  set( dependencyList ${dependencyList} caliper )
-endif()
 
 #
 # Specify all sources

--- a/src/coreComponents/events/CMakeLists.txt
+++ b/src/coreComponents/events/CMakeLists.txt
@@ -26,7 +26,7 @@ set(events_sources
     tasks/TasksManager.cpp
    )
 
-set( dependencyList common RAJA )
+set( dependencyList fileIO )
 
 if( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )

--- a/src/coreComponents/fieldSpecification/CMakeLists.txt
+++ b/src/coreComponents/fieldSpecification/CMakeLists.txt
@@ -22,24 +22,10 @@ set(fieldSpecification_sources
     TractionBoundaryCondition.cpp
    )
 
-
-
-set( dependencyList functions RAJA linearAlgebra conduit )
-
-if ( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
-endif()
+set( dependencyList functions linearAlgebra )
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )
-endif()
-
-if ( ENABLE_CALIPER )
-  set( dependencyList ${dependencyList} caliper adiak )
-endif()
-
-if ( ENABLE_MKL )
-  set( dependencyList ${dependencyList} mkl )
 endif()
 
 blt_add_library( NAME                  fieldSpecification

--- a/src/coreComponents/fieldSpecification/FieldSpecificationManager.hpp
+++ b/src/coreComponents/fieldSpecification/FieldSpecificationManager.hpp
@@ -19,8 +19,6 @@
 #ifndef GEOSX_FIELDSPECIFICATION_FIELDSPECIFICATIONMANAGER_HPP_
 #define GEOSX_FIELDSPECIFICATION_FIELDSPECIFICATIONMANAGER_HPP_
 
-#include "FieldSpecificationManager.hpp"
-
 #include "FieldSpecificationBase.hpp"
 
 #include "codingUtilities/StringUtilities.hpp"

--- a/src/coreComponents/fileIO/CMakeLists.txt
+++ b/src/coreComponents/fileIO/CMakeLists.txt
@@ -63,19 +63,9 @@ if( ENABLE_VTK )
   list( APPEND dependencyList VTK::CommonCore VTK::CommonSystem VTK::CommonMisc VTK::IOCore VTK::IOXML VTK::expat VTK::doubleconversion VTK::lz4 VTK::lzma VTK::zlib VTK::loguru )
 endif()
 
-if( ENABLE_OPENMP )
-  list( APPEND dependencyList openmp )
-endif()
-
 if ( ENABLE_CUDA )
   list( APPEND dependencyList  cuda )
 endif()
-
-if( ENABLE_CALIPER )
-  list( APPEND dependencyList  caliper adiak )
-endif()
-
-
 
 blt_add_library( NAME                  fileIO
                  SOURCES               ${fileIO_sources}

--- a/src/coreComponents/finiteElement/CMakeLists.txt
+++ b/src/coreComponents/finiteElement/CMakeLists.txt
@@ -28,11 +28,7 @@ set( finiteElement_sources
      FiniteElementDiscretizationManager.cpp
    )
 
-set( dependencyList dataRepository codingUtilities)
-
-if( ENABLE_OPENMP )
-    set( dependencyList ${dependencyList} openmp )
-endif()
+set( dependencyList dataRepository )
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )

--- a/src/coreComponents/finiteElement/unitTests/CMakeLists.txt
+++ b/src/coreComponents/finiteElement/unitTests/CMakeLists.txt
@@ -14,14 +14,6 @@ set(testSources
 
 set( dependencyList gtest finiteElement)
 
-if ( ENABLE_MPI )
-  set ( dependencyList ${dependencyList} mpi )
-endif()
-
-if ( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
-endif()
-
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )
 endif()

--- a/src/coreComponents/finiteVolume/CMakeLists.txt
+++ b/src/coreComponents/finiteVolume/CMakeLists.txt
@@ -36,10 +36,6 @@ set( finiteVolume_sources
 
 set( dependencyList mesh codingUtilities fieldSpecification )
 
-if ( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
-endif()
-
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )
 endif()

--- a/src/coreComponents/functions/CMakeLists.txt
+++ b/src/coreComponents/functions/CMakeLists.txt
@@ -28,24 +28,15 @@ if( ENABLE_MATHPRESSO )
 endif()
 
 
-set( dependencyList codingUtilities dataRepository )
+set( dependencyList dataRepository )
 
 if( ENABLE_MATHPRESSO )
    set( dependencyList ${dependencyList} mathpresso )
 endif()
 
-if ( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
-endif()
-
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )
 endif()
-
-if ( ENABLE_CALIPER )
-  set( dependencyList ${dependencyList} caliper adiak )
-endif()
-
 
 blt_add_library( NAME                  functions
                  SOURCES               ${functions_sources}

--- a/src/coreComponents/linearAlgebra/CMakeLists.txt
+++ b/src/coreComponents/linearAlgebra/CMakeLists.txt
@@ -52,7 +52,7 @@ set( linearAlgebra_sources
      solvers/SeparateComponentPreconditioner.cpp
      DofManager.cpp )
 
-set( dependencyList mesh blas lapack RAJA)
+set( dependencyList mesh blas lapack )
 
 
 list( APPEND linearAlgebra_headers
@@ -148,23 +148,9 @@ if( ENABLE_PETSC )
 
 endif()
 
-if( ENABLE_OPENMP )
-    list( APPEND dependencyList openmp )
-endif()
-
 if ( ENABLE_CUDA )
     list( APPEND dependencyList cuda )
 endif()
-
-if ( ENABLE_MKL )
-    list( APPEND dependencyList mkl )
-endif()
-
-if( ENABLE_MPI )
-    list( APPEND dependencyList mpi )
-endif()
-
-
 
 blt_add_library( NAME                  linearAlgebra
                  SOURCES               ${linearAlgebra_sources}

--- a/src/coreComponents/linearAlgebra/unitTests/CMakeLists.txt
+++ b/src/coreComponents/linearAlgebra/unitTests/CMakeLists.txt
@@ -12,10 +12,6 @@ set( nranks 2 )
 
 set( dependencyList gtest linearAlgebra )
 
-if ( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
-endif()
-
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )
 endif()

--- a/src/coreComponents/mainInterface/CMakeLists.txt
+++ b/src/coreComponents/mainInterface/CMakeLists.txt
@@ -18,7 +18,7 @@ set(mainInterface_sources
     GeosxState.cpp
    )
 
-set( dependencyList events fileIO optionparser RAJA conduit)
+set( dependencyList physicsSolvers discretizationMethods fieldSpecification linearAlgebra events fileIO optionparser RAJA conduit)
 
 
 if( ENABLE_MATHPRESSO )

--- a/src/coreComponents/mainInterface/CMakeLists.txt
+++ b/src/coreComponents/mainInterface/CMakeLists.txt
@@ -18,27 +18,10 @@ set(mainInterface_sources
     GeosxState.cpp
    )
 
-set( dependencyList physicsSolvers discretizationMethods fieldSpecification linearAlgebra events fileIO optionparser RAJA conduit)
-
-
-if( ENABLE_MATHPRESSO )
-   set( dependencyList ${dependencyList} mathpresso )
-endif()
-
-if ( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
-endif()
+set( dependencyList physicsSolvers discretizationMethods fieldSpecification linearAlgebra events fileIO optionparser )
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )
-endif()
-
-if ( ENABLE_CALIPER )
-  set( dependencyList ${dependencyList} caliper adiak )
-endif()
-
-if ( ENABLE_MKL )
-  set( dependencyList ${dependencyList} mkl )
 endif()
 
 blt_add_library( NAME                  mainInterface

--- a/src/coreComponents/mesh/CMakeLists.txt
+++ b/src/coreComponents/mesh/CMakeLists.txt
@@ -102,11 +102,6 @@ set(mesh_sources
 
 set(dependencyList schema dataRepository constitutive metis)
 
-
-if( ENABLE_OPENMP )
-    set( dependencyList ${dependencyList} openmp )
-endif()
-
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )
 endif()

--- a/src/coreComponents/physicsSolvers/CMakeLists.txt
+++ b/src/coreComponents/physicsSolvers/CMakeLists.txt
@@ -122,10 +122,6 @@ if( ENABLE_GEOSX_PTP )
   list( APPEND externalComponentDeps GEOSX_PTP )
 endif()
 
-if ( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
-endif()
-
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )
 endif()

--- a/src/coreComponents/schema/CMakeLists.txt
+++ b/src/coreComponents/schema/CMakeLists.txt
@@ -16,10 +16,6 @@ set( schema_sources
 
 set( dependencyList dataRepository )
 
-if ( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
-endif()
-
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )
 endif()

--- a/src/coreComponents/unitTests/constitutiveTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/constitutiveTests/CMakeLists.txt
@@ -3,6 +3,7 @@
 #
 
 set( gtest_geosx_tests
+     testDamage.cpp
      testRelPerm.cpp
      testCapillaryPressure.cpp
    )
@@ -12,7 +13,13 @@ set( gtest_triaxial_xmls
      testTriaxial_druckerPragerExtended.xml
    )
 
-set( dependencyList gtest geosx_core conduit )
+set( dependencyList gtest )
+
+if ( GEOSX_BUILD_SHARED_LIBS )
+  set (dependencyList ${dependencyList} geosx_core )
+else()
+  set (dependencyList ${dependencyList} ${geosx_core_libs} conduit)
+endif()
 
 if( ENABLE_MPI )
     set( dependencyList ${dependencyList} mpi )

--- a/src/coreComponents/unitTests/constitutiveTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/constitutiveTests/CMakeLists.txt
@@ -18,11 +18,7 @@ set( dependencyList gtest )
 if ( GEOSX_BUILD_SHARED_LIBS )
   set (dependencyList ${dependencyList} geosx_core )
 else()
-  set (dependencyList ${dependencyList} ${geosx_core_libs} conduit)
-endif()
-
-if( ENABLE_MPI )
-    set( dependencyList ${dependencyList} mpi )
+  set (dependencyList ${dependencyList} ${geosx_core_libs} )
 endif()
 
 if( ENABLE_PVTPackage )
@@ -31,10 +27,6 @@ if( ENABLE_PVTPackage )
           testCO2BrinePVTModels.cpp )
 
     set( dependencyList ${dependencyList} PVTPackage )
-endif()
-
-if( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
 endif()
 
 if( ENABLE_CUDA )

--- a/src/coreComponents/unitTests/constitutiveTests/testDamage.cpp
+++ b/src/coreComponents/unitTests/constitutiveTests/testDamage.cpp
@@ -12,7 +12,7 @@
  * ------------------------------------------------------------------------------------------------------------
  */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "constitutive/ConstitutiveManager.hpp"
 #include "constitutive/solid/ElasticIsotropic.hpp"

--- a/src/coreComponents/unitTests/dataRepositoryTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/dataRepositoryTests/CMakeLists.txt
@@ -10,18 +10,16 @@ set( dataRepository_tests
      testWrapperHelpers.cpp
    )
 
-set( dependencyList gtest geosx_core RAJA )
+set( dependencyList gtest )
 
-if ( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
+if ( GEOSX_BUILD_SHARED_LIBS )
+  set (dependencyList ${dependencyList} geosx_core )
+else()
+  set (dependencyList ${dependencyList} ${geosx_core_libs} )
 endif()
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )
-endif()
-
-if ( ENABLE_CALIPER )
-  set( dependencyList ${dependencyList} caliper adiak )
 endif()
 
 #

--- a/src/coreComponents/unitTests/fieldSpecificationTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/fieldSpecificationTests/CMakeLists.txt
@@ -7,7 +7,7 @@ set( gtest_geosx_tests
    )
 
 
-set( dependencyList gtest fieldSpecification )
+set( dependencyList gtest )
 
 if ( GEOSX_BUILD_SHARED_LIBS )
   set (dependencyList ${dependencyList} geosx_core conduit)

--- a/src/coreComponents/unitTests/fieldSpecificationTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/fieldSpecificationTests/CMakeLists.txt
@@ -10,17 +10,9 @@ set( gtest_geosx_tests
 set( dependencyList gtest )
 
 if ( GEOSX_BUILD_SHARED_LIBS )
-  set (dependencyList ${dependencyList} geosx_core conduit)
+  set (dependencyList ${dependencyList} geosx_core )
 else()
-  set (dependencyList ${dependencyList} ${geosx_core_libs} conduit)
-endif()
-
-if ( ENABLE_MPI )
-  set ( dependencyList ${dependencyList} mpi )
-endif()
-
-if ( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
+  set (dependencyList ${dependencyList} ${geosx_core_libs} )
 endif()
 
 if ( ENABLE_CUDA )

--- a/src/coreComponents/unitTests/fileIOTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/fileIOTests/CMakeLists.txt
@@ -6,14 +6,12 @@ set(geosx_fileio_tests
    testHDFFile.cpp
    )
 
-set( dependencyList gtest geosx_core )
+set( dependencyList gtest )
 
-if ( ENABLE_MPI )
-  set ( dependencyList ${dependencyList} mpi )
-endif()
-
-if( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
+if ( GEOSX_BUILD_SHARED_LIBS )
+  set (dependencyList ${dependencyList} geosx_core )
+else()
+  set (dependencyList ${dependencyList} ${geosx_core_libs} )
 endif()
 
 if ( ENABLE_CUDA )

--- a/src/coreComponents/unitTests/finiteVolumeTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/finiteVolumeTests/CMakeLists.txt
@@ -6,10 +6,12 @@ set( gtest_geosx_tests
      testMimeticInnerProducts.cpp
    )
 
-set( dependencyList gtest geosx_core)
+set( dependencyList gtest )
 
-if( ENABLE_OPENMP )
-    set( dependencyList ${dependencyList} openmp )
+if ( GEOSX_BUILD_SHARED_LIBS )
+  set (dependencyList ${dependencyList} geosx_core )
+else()
+  set (dependencyList ${dependencyList} ${geosx_core_libs} )
 endif()
 
 if ( ENABLE_CUDA )

--- a/src/coreComponents/unitTests/fluidFlowTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/fluidFlowTests/CMakeLists.txt
@@ -8,7 +8,13 @@ set( gtest_geosx_tests
      testSinglePhaseHybridFVMKernels.cpp
    )
 
-set( dependencyList geosx_core gtest )
+set( dependencyList gtest )
+
+if ( GEOSX_BUILD_SHARED_LIBS )
+  set (dependencyList ${dependencyList} geosx_core conduit)
+else()
+  set (dependencyList ${dependencyList} ${geosx_core_libs} conduit)
+endif()
 
 if ( ENABLE_MPI )
   set ( dependencyList ${dependencyList} mpi )

--- a/src/coreComponents/unitTests/fluidFlowTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/fluidFlowTests/CMakeLists.txt
@@ -11,17 +11,9 @@ set( gtest_geosx_tests
 set( dependencyList gtest )
 
 if ( GEOSX_BUILD_SHARED_LIBS )
-  set (dependencyList ${dependencyList} geosx_core conduit)
+  set (dependencyList ${dependencyList} geosx_core )
 else()
-  set (dependencyList ${dependencyList} ${geosx_core_libs} conduit)
-endif()
-
-if ( ENABLE_MPI )
-  set ( dependencyList ${dependencyList} mpi )
-endif()
-
-if( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
+  set (dependencyList ${dependencyList} ${geosx_core_libs} )
 endif()
 
 if ( ENABLE_CUDA )

--- a/src/coreComponents/unitTests/functionsTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/functionsTests/CMakeLists.txt
@@ -7,7 +7,7 @@ set( gtest_geosx_tests
    )
 
 
-set( dependencyList gtest functions)
+set( dependencyList gtest )
 
 if ( GEOSX_BUILD_SHARED_LIBS )
   set (dependencyList ${dependencyList} geosx_core conduit)

--- a/src/coreComponents/unitTests/functionsTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/functionsTests/CMakeLists.txt
@@ -10,17 +10,9 @@ set( gtest_geosx_tests
 set( dependencyList gtest )
 
 if ( GEOSX_BUILD_SHARED_LIBS )
-  set (dependencyList ${dependencyList} geosx_core conduit)
+  set (dependencyList ${dependencyList} geosx_core )
 else()
-  set (dependencyList ${dependencyList} ${geosx_core_libs} conduit)
-endif()
-
-if ( ENABLE_MPI )
-  set ( dependencyList ${dependencyList} mpi )
-endif()
-
-if ( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
+  set (dependencyList ${dependencyList} ${geosx_core_libs} )
 endif()
 
 if ( ENABLE_CUDA )

--- a/src/coreComponents/unitTests/linearAlgebraTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/linearAlgebraTests/CMakeLists.txt
@@ -16,15 +16,7 @@ set( dependencyList gtest )
 if ( GEOSX_BUILD_SHARED_LIBS )
   set (dependencyList ${dependencyList} geosx_core )
 else()
-  set (dependencyList ${dependencyList} ${geosx_core_libs} conduit)
-endif()
-
-if ( ENABLE_MPI )
-  set ( dependencyList ${dependencyList} mpi )
-endif()
-
-if( ENABLE_OPENMP )
-    set( dependencyList ${dependencyList} openmp )
+  set (dependencyList ${dependencyList} ${geosx_core_libs} )
 endif()
 
 if ( ENABLE_CUDA )

--- a/src/coreComponents/unitTests/linearAlgebraTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/linearAlgebraTests/CMakeLists.txt
@@ -11,7 +11,7 @@ set( nranks 2 )
 #
 # Add gtest C++ based tests
 #
-set( dependencyList gtest geosx_core)
+set( dependencyList gtest )
 
 if ( GEOSX_BUILD_SHARED_LIBS )
   set (dependencyList ${dependencyList} geosx_core )

--- a/src/coreComponents/unitTests/meshTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/meshTests/CMakeLists.txt
@@ -18,7 +18,13 @@ if(ENABLE_PAMELA)
     configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/meshFileNames.hpp.in ${CMAKE_BINARY_DIR}/include/tests/meshFileNames.hpp )
 endif(ENABLE_PAMELA)
 
-set( dependencyList geosx_core gtest )
+set( dependencyList gtest )
+
+if ( GEOSX_BUILD_SHARED_LIBS )
+  set (dependencyList ${dependencyList} geosx_core )
+else()
+  set (dependencyList ${dependencyList} ${geosx_core_libs} conduit)
+endif()
 
 if ( ENABLE_MPI )
   set ( dependencyList ${dependencyList} mpi )

--- a/src/coreComponents/unitTests/meshTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/meshTests/CMakeLists.txt
@@ -23,15 +23,7 @@ set( dependencyList gtest )
 if ( GEOSX_BUILD_SHARED_LIBS )
   set (dependencyList ${dependencyList} geosx_core )
 else()
-  set (dependencyList ${dependencyList} ${geosx_core_libs} conduit)
-endif()
-
-if ( ENABLE_MPI )
-  set ( dependencyList ${dependencyList} mpi )
-endif()
-
-if( ENABLE_OPENMP )
-    set( dependencyList ${dependencyList} openmp )
+  set (dependencyList ${dependencyList} ${geosx_core_libs} )
 endif()
 
 if ( ENABLE_CUDA )

--- a/src/coreComponents/unitTests/virtualElementTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/virtualElementTests/CMakeLists.txt
@@ -14,14 +14,6 @@ else()
   set (dependencyList ${dependencyList} ${geosx_core_libs} )
 endif()
 
-if ( ENABLE_MPI )
-  set ( dependencyList ${dependencyList} mpi )
-endif()
-
-if ( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
-endif()
-
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )
 endif()

--- a/src/coreComponents/unitTests/wellsTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/wellsTests/CMakeLists.txt
@@ -11,15 +11,7 @@ set( dependencyList gtest )
 if ( GEOSX_BUILD_SHARED_LIBS )
   set (dependencyList ${dependencyList} geosx_core )
 else()
-  set (dependencyList ${dependencyList} ${geosx_core_libs} conduit)
-endif()
-
-if ( ENABLE_MPI )
-  set ( dependencyList ${dependencyList} mpi )
-endif()
-
-if( ENABLE_OPENMP )
-  set( dependencyList ${dependencyList} openmp )
+  set (dependencyList ${dependencyList} ${geosx_core_libs} )
 endif()
 
 if ( ENABLE_CUDA )

--- a/src/coreComponents/unitTests/wellsTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/wellsTests/CMakeLists.txt
@@ -6,7 +6,13 @@ set( gtest_geosx_tests
      testReservoirSinglePhaseMSWells.cpp
    )
 
-set( dependencyList gtest geosx_core )
+set( dependencyList gtest )
+
+if ( GEOSX_BUILD_SHARED_LIBS )
+  set (dependencyList ${dependencyList} geosx_core )
+else()
+  set (dependencyList ${dependencyList} ${geosx_core_libs} conduit)
+endif()
 
 if ( ENABLE_MPI )
   set ( dependencyList ${dependencyList} mpi )

--- a/src/coreComponents/unitTests/xmlTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/xmlTests/CMakeLists.txt
@@ -17,14 +17,6 @@ else()
   set (dependencyList ${dependencyList} ${geosx_core_libs} )
 endif()
 
-if ( ENABLE_MPI )
-  set ( dependencyList ${dependencyList} mpi )
-endif()
-
-if( ENABLE_OPENMP )
-    set( dependencyList ${dependencyList} openmp )
-endif()
-
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )
 endif()


### PR DESCRIPTION
This PR:
- Fixes compilation when building with GEOSX_BUILD__OBJ_LIBS=OFF (Relates to #1421)
- Removes repetitive mpi, openmp, etc. dependencies from higher level components (Relates to #1389)
  - cuda dependency could not be removed, related issue posted at llnl/blt#490
- Added a script `circular_dependencies.sh` that outputs:
  -  a matrix of coreComponents and if they depend on another coreComponent (dependency_matrix.txt)
  - any circular dependencies and the header includes between the two circular coreComponents (circular_dependencies.txt)