### PR TITLE
Fixed bug in compositional residual norm calculation with multiple regions

### DIFF
--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBaseKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBaseKernels.hpp
@@ -387,8 +387,6 @@ struct ResidualNormKernel
                       arrayView1d< real64 const > const & totalDensOld,
                       real64 & localResidualNorm )
   {
-    localResidualNorm = 0.0;
-
     RAJA::ReduceSum< REDUCE_POLICY, real64 > localSum( 0.0 );
 
     forAll< POLICY >( dofNumber.size(), [=] GEOSX_HOST_DEVICE ( localIndex const ei )

--- a/src/coreComponents/physicsSolvers/fluidFlow/benchmarks/Egg/dead_oil_egg.xml
+++ b/src/coreComponents/physicsSolvers/fluidFlow/benchmarks/Egg/dead_oil_egg.xml
@@ -744,7 +744,7 @@
       setNames="{ all }"
       objectPath="ElementRegions/reservoir/DEFAULT_HEX"
       fieldName="globalCompFraction"
-      component="2"
+      component="1"
       scale="0.1"/>
   </FieldSpecifications>
   <!-- SPHINX_TUT_DEAD_OIL_EGG_FIELD_SPECS_END -->


### PR DESCRIPTION
This PR fixes a bug in the residual norm of the compositional solver (that I introduced I think, sorry). The `localResidualNorm` needs to be incremented for each subregion, but it was reset to zero for each subregion.

This PR requires the rebaseline of the staircase examples of the compositional solver because the change results in a small change in the number of nonlinear iterations.

Related to https://github.com/GEOSX/integratedTests/pull/135