### PR TITLE
Consistify temperature units for CO2-brine input

### DIFF
--- a/src/coreComponents/constitutive/docs/CO2Brine.rst
+++ b/src/coreComponents/constitutive/docs/CO2Brine.rst
@@ -40,8 +40,8 @@ The user can parameterize the construction of the table by specifying the salini
 | FlashModel | CO2Solubility | :math:`p_{min}` | :math:`p_{max}` | :math:`\Delta p` | :math:`T_{min}` | :math:`T_{max}` | :math:`\Delta T` | Salinity | 
 +------------+---------------+-----------------+-----------------+------------------+-----------------+-----------------+------------------+----------+
 
-Note that the pressures are in Pascal, and the temperatures are in degree Celsius.
-The temperature must be between 10 and 350 degrees Celsius.
+Note that the pressures are in Pascal, and the temperatures are in Kelvin.
+The temperature must be between 283.15 and 623.15 Kelvin.
 The table is populated using the model of Duan and Sun (2003).
 Specifically, we solve the following nonlinear CO2 equation of state (equation (A1) in Duan and Sun, 2003) for each pair :math:`(p,T)` to obtain the reduced volume, :math:`V_r`.
 
@@ -86,13 +86,13 @@ CO2 phase density and viscosity
 -------------------------------
 
 In GEOSX, the computation of the CO2 phase density and viscosity  is entirely based on look-up in precomputed tables.
-The user defines the pressure (in Pascal) and temperature (in degrees Celsius) axis of the density table in the form:
+The user defines the pressure (in Pascal) and temperature (in Kelvin) axis of the density table in the form:
 
 +------------+----------------------+-----------------+-----------------+------------------+-----------------+-----------------+------------------+
 | DensityFun | SpanWagnerCO2Density | :math:`p_{min}` | :math:`p_{max}` | :math:`\Delta p` | :math:`T_{min}` | :math:`T_{max}` | :math:`\Delta T` |
 +------------+----------------------+-----------------+-----------------+------------------+-----------------+-----------------+------------------+
 
-This correlation is valid for pressures less than :math:`8 \times 10^8` Pascal and temperatures less than 800 degrees Celsius.  
+This correlation is valid for pressures less than :math:`8 \times 10^8` Pascal and temperatures less than 1073.15 Kelvin.  
 Using these parameters, GEOSX internally constructs a two-dimensional table storing the values of density as a function of pressure and temperature.
 This table is populated as explained in the work of Span and Wagner (1996) by solving the following nonlinear Helmholtz energy equation for each pair :math:`(p,T)` to obtain the value of density, :math:`\rho_{g}`:
 
@@ -110,7 +110,7 @@ The pressure and temperature axis of the viscosity table can be parameterized in
 | ViscosityFun | FenghourCO2Viscosity | :math:`p_{min}` | :math:`p_{max}` | :math:`\Delta p` | :math:`T_{min}` | :math:`T_{max}` | :math:`\Delta T` |
 +--------------+----------------------+-----------------+-----------------+------------------+-----------------+-----------------+------------------+
 
-This correlation is valid for pressures less than :math:`3 \times 10^8` Pascal and temperatures less than 1220 degrees Celsius.  
+This correlation is valid for pressures less than :math:`3 \times 10^8` Pascal and temperatures less than 1493.15 Kelvin.  
 This table is populated as explained in the work of Fenghour and Wakeham (1998) by computing the CO2 phase viscosity, :math:`\mu_g`, as follows:
 
 .. math::
@@ -134,7 +134,7 @@ The user specifies the (constant) salinity and defines the pressure and temperat
 +------------+----------------------+-----------------+-----------------+------------------+-----------------+-----------------+------------------+----------+
 
 The pressure must be in Pascal and must be less than :math:`5 \times 10^7` Pascal.
-The temperature must be in degree Celsius and must be between 10 and 350 degrees Celsius.
+The temperature must be in Kelvin and must be between 283.15 and 623.15 Kelvin.
 Using these parameters, GEOSX performs a preprocessing step to construct a two-dimensional table storing the brine density, :math:`\rho_{\ell,table}` for the specified salinity as a function of pressure and temperature using the expression:
 
 .. math::

--- a/src/coreComponents/constitutive/fluid/PVTFunctions/PVTFunctionHelpers.hpp
+++ b/src/coreComponents/constitutive/fluid/PVTFunctions/PVTFunctionHelpers.hpp
@@ -99,16 +99,22 @@ struct PVTFunctionHelpers
       real64 const PEnd = stod( inputParameters[3] );
       real64 const dP = stod( inputParameters[4] );
 
+      GEOSX_THROW_IF( PStart >= PEnd, "PStart must be strictly smaller than PEnd",
+                      InputError );
+
       constexpr real64 T_K = 273.15;
 
       real64 const TStart = stod( inputParameters[5] ) - T_K;
       real64 const TEnd = stod( inputParameters[6] ) - T_K;
       real64 const dT = stod( inputParameters[7] );
 
-      GEOSX_THROW_IF( TStart < 0, "Temperature must be in Kelvin and must be positive",
+      GEOSX_THROW_IF( TStart < 10, "Temperature must be in Kelvin and must be larger than 283.15 K",
                       InputError );
-      GEOSX_THROW_IF( TEnd < 0, "Temperature must be in Kelvin and must be positive",
+      GEOSX_THROW_IF( TEnd > 350, "Temperature must be in Kelvin and must be smaller than 623.15 K",
                       InputError );
+      GEOSX_THROW_IF( TStart >= TEnd, "TStart must be strictly smaller than TEnd",
+                      InputError );
+
 
       for( real64 P = PStart; P <= PEnd; P += dP )
       {

--- a/src/coreComponents/constitutive/fluid/PVTFunctions/PVTFunctionHelpers.hpp
+++ b/src/coreComponents/constitutive/fluid/PVTFunctions/PVTFunctionHelpers.hpp
@@ -99,9 +99,16 @@ struct PVTFunctionHelpers
       real64 const PEnd = stod( inputParameters[3] );
       real64 const dP = stod( inputParameters[4] );
 
-      real64 const TStart = stod( inputParameters[5] );
-      real64 const TEnd = stod( inputParameters[6] );
+      constexpr real64 T_K = 273.15;
+
+      real64 const TStart = stod( inputParameters[5] ) - T_K;
+      real64 const TEnd = stod( inputParameters[6] ) - T_K;
       real64 const dT = stod( inputParameters[7] );
+
+      GEOSX_THROW_IF( TStart < 0, "Temperature must be in Kelvin and must be positive",
+                      InputError );
+      GEOSX_THROW_IF( TEnd < 0, "Temperature must be in Kelvin and must be positive",
+                      InputError );
 
       for( real64 P = PStart; P <= PEnd; P += dP )
       {

--- a/src/coreComponents/physicsSolvers/fluidFlow/integratedTests/compositionalMultiphaseFlow/co2flash.txt
+++ b/src/coreComponents/physicsSolvers/fluidFlow/integratedTests/compositionalMultiphaseFlow/co2flash.txt
@@ -1,1 +1,1 @@
-FlashModel CO2Solubility  1e6 1.5e7 5e4 94 96 1 0
+FlashModel CO2Solubility  1e6 1.5e7 5e4 367.15 369.15 1 0

--- a/src/coreComponents/physicsSolvers/fluidFlow/integratedTests/compositionalMultiphaseFlow/pvtgas.txt
+++ b/src/coreComponents/physicsSolvers/fluidFlow/integratedTests/compositionalMultiphaseFlow/pvtgas.txt
@@ -1,2 +1,2 @@
-DensityFun SpanWagnerCO2Density 1e6 1.5e7 5e4 94 96 1
-ViscosityFun FenghourCO2Viscosity 1e6 1.5e7 5e4 94 96 1
+DensityFun SpanWagnerCO2Density 1e6 1.5e7 5e4 367.15 369.15 1
+ViscosityFun FenghourCO2Viscosity 1e6 1.5e7 5e4 367.15 369.15 1

--- a/src/coreComponents/physicsSolvers/fluidFlow/integratedTests/compositionalMultiphaseFlow/pvtliquid.txt
+++ b/src/coreComponents/physicsSolvers/fluidFlow/integratedTests/compositionalMultiphaseFlow/pvtliquid.txt
@@ -1,2 +1,2 @@
-DensityFun BrineCO2Density 1e6 1.5e7 5e4 94 96 1 0
+DensityFun BrineCO2Density 1e6 1.5e7 5e4 367.15 369.15 1 0
 ViscosityFun BrineViscosity 0

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/integratedTests/compositionalMultiphaseWell/co2flash.txt
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/integratedTests/compositionalMultiphaseWell/co2flash.txt
@@ -1,1 +1,1 @@
-FlashModel CO2Solubility  1e6 1.5e7 5e4 94 96 1 0
+FlashModel CO2Solubility  1e6 1.5e7 5e4 367.15 369.15 1 0

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/integratedTests/compositionalMultiphaseWell/pvtgas.txt
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/integratedTests/compositionalMultiphaseWell/pvtgas.txt
@@ -1,2 +1,2 @@
-DensityFun SpanWagnerCO2Density 1e6 1.5e7 5e4 94 96 1
-ViscosityFun FenghourCO2Viscosity 1e6 1.5e7 5e4 94 96 1
+DensityFun SpanWagnerCO2Density 1e6 1.5e7 5e4 367.15 369.15 1
+ViscosityFun FenghourCO2Viscosity 1e6 1.5e7 5e4 367.15 369.15 1

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/integratedTests/compositionalMultiphaseWell/pvtliquid.txt
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/integratedTests/compositionalMultiphaseWell/pvtliquid.txt
@@ -1,2 +1,2 @@
-DensityFun BrineCO2Density 1e6 1.5e7 5e4 94 96 1 0
+DensityFun BrineCO2Density 1e6 1.5e7 5e4 367.15 369.15 1 0
 ViscosityFun BrineViscosity 0

--- a/src/coreComponents/physicsSolvers/multiphysics/integratedTests/pvt_tables/co2flash.txt
+++ b/src/coreComponents/physicsSolvers/multiphysics/integratedTests/pvt_tables/co2flash.txt
@@ -1,1 +1,1 @@
-FlashModel CO2Solubility  1e6 1.5e7 5e4 94 96 1 0
+FlashModel CO2Solubility  1e6 1.5e7 5e4 367.15 369.15 1 0

--- a/src/coreComponents/physicsSolvers/multiphysics/integratedTests/pvt_tables/pvtgas.txt
+++ b/src/coreComponents/physicsSolvers/multiphysics/integratedTests/pvt_tables/pvtgas.txt
@@ -1,2 +1,2 @@
-DensityFun SpanWagnerCO2Density 1e6 1.5e7 5e4 94 96 1
-ViscosityFun FenghourCO2Viscosity 1e6 1.5e7 5e4 94 96 1
+DensityFun SpanWagnerCO2Density 1e6 1.5e7 5e4 367.15 369.15 1
+ViscosityFun FenghourCO2Viscosity 1e6 1.5e7 5e4 367.15 369.15 1

--- a/src/coreComponents/physicsSolvers/multiphysics/integratedTests/pvt_tables/pvtliquid.txt
+++ b/src/coreComponents/physicsSolvers/multiphysics/integratedTests/pvt_tables/pvtliquid.txt
@@ -1,2 +1,2 @@
-DensityFun BrineCO2Density 1e6 1.5e7 5e4 94 96 1 0
+DensityFun BrineCO2Density 1e6 1.5e7 5e4 367.15 369.15 1 0
 ViscosityFun BrineViscosity 0

--- a/src/coreComponents/unitTests/constitutiveTests/testCO2BrinePVTModels.cpp
+++ b/src/coreComponents/unitTests/constitutiveTests/testCO2BrinePVTModels.cpp
@@ -37,13 +37,13 @@ using namespace geosx::constitutive::PVTProps;
 
 /// Input tables written into temporary files during testing
 
-static const char * pvtLiquidTableContent = "DensityFun BrineCO2Density 1e6 1.5e7 5e4 94 96 1 0.2\n"
+static const char * pvtLiquidTableContent = "DensityFun BrineCO2Density 1e6 1.5e7 5e4 367.15 369.15 1 0.2\n"
                                             "ViscosityFun BrineViscosity 0.1";
 
-static const char * pvtGasTableContent = "DensityFun SpanWagnerCO2Density 1e6 1.5e7 5e4 94 96 1\n"
-                                         "ViscosityFun FenghourCO2Viscosity 1e6 1.5e7 5e4 94 96 1";
+static const char * pvtGasTableContent = "DensityFun SpanWagnerCO2Density 1e6 1.5e7 5e4 367.15 369.15 1\n"
+                                         "ViscosityFun FenghourCO2Viscosity 1e6 1.5e7 5e4 367.15 369.15 1";
 
-static const char * co2FlashTableContent = "FlashModel CO2Solubility 1e6 1.5e7 5e4 94 96 1 0.15";
+static const char * co2FlashTableContent = "FlashModel CO2Solubility 1e6 1.5e7 5e4 367.15 369.15 1 0.15";
 
 void testValuesAgainstPreviousImplementation( PVTFunctionBaseUpdate const & pvtFunctionWrapper,
                                               real64 const pressure,

--- a/src/coreComponents/unitTests/constitutiveTests/testMultiFluid.cpp
+++ b/src/coreComponents/unitTests/constitutiveTests/testMultiFluid.cpp
@@ -112,13 +112,13 @@ static const char * pvdwTableContent = "# Pref[bar] Bw[m3/sm3] Cp[1/bar]     Vis
 
 // CO2-brine model
 
-static const char * pvtLiquidTableContent = "DensityFun BrineCO2Density 1e6 1.5e7 5e4 94 96 1 0.2\n"
+static const char * pvtLiquidTableContent = "DensityFun BrineCO2Density 1e6 1.5e7 5e4 367.15 369.15 1 0.2\n"
                                             "ViscosityFun BrineViscosity 0.1";
 
-static const char * pvtGasTableContent = "DensityFun SpanWagnerCO2Density 1e6 1.5e7 5e4 94 96 1\n"
-                                         "ViscosityFun FenghourCO2Viscosity 1e6 1.5e7 5e4 94 96 1";
+static const char * pvtGasTableContent = "DensityFun SpanWagnerCO2Density 1e6 1.5e7 5e4 367.15 369.15 1\n"
+                                         "ViscosityFun FenghourCO2Viscosity 1e6 1.5e7 5e4 367.15 369.15 1";
 
-static const char * co2FlashTableContent = "FlashModel CO2Solubility 1e6 1.5e7 5e4 94 96 1 0.15";
+static const char * co2FlashTableContent = "FlashModel CO2Solubility 1e6 1.5e7 5e4 367.15 369.15 1 0.15";
 
 void testNumericalDerivatives( MultiFluidBase & fluid,
                                Group & parent,


### PR DESCRIPTION
Until now, the CO2-brine model was expecting a temperature in degrees Celsius, while the solver takes a temperature in Kelvin. This PR changes the CO2-brine model input to Kelvin for consistency. The implementation of the CO2-brine remains the same.

The PR also updates the documentation of the CO2-brine model to reflect the change.

Does not require a rebaseline of the integrated tests.