### PR TITLE
Fixed the bug related to underscores in PAMELA region/surface names

### DIFF
--- a/src/coreComponents/mesh/generators/PAMELAMeshGenerator.hpp
+++ b/src/coreComponents/mesh/generators/PAMELAMeshGenerator.hpp
@@ -152,14 +152,12 @@ public:
       // But we only want to keep Ovbd1_Ovbd2
       // So we find the word GROUP, and then we keep what is after, except the last piece
 
-      using std::begin;
-      using std::end;
-      auto it = std::find( begin( splitLabel ), end( splitLabel ), "GROUP" );
+      auto it = std::find( std::begin( splitLabel ), std::end( splitLabel ), "GROUP" );
 
-      GEOSX_THROW_IF( it == end( splitLabel ),
+      GEOSX_THROW_IF( it == std::end( splitLabel ),
                       "GEOSX assumes that PAMELA places the word GROUP before the region/surface name", InputError );
 
-      localIndex const id = std::distance( begin( splitLabel ), it );
+      localIndex const id = std::distance( std::begin( splitLabel ), it );
       string name = "";
       for( localIndex i = id+1; i < splitLabel.size()-1; ++i )
       {

--- a/src/coreComponents/mesh/generators/PAMELAMeshGenerator.hpp
+++ b/src/coreComponents/mesh/generators/PAMELAMeshGenerator.hpp
@@ -147,7 +147,29 @@ public:
     static string retrieveSurfaceOrRegionName( string const & pamelaLabel )
     {
       string_array const splitLabel = stringutilities::tokenize( pamelaLabel, m_separator );
-      return splitLabel[splitLabel.size() -2 ];
+
+      // The PAMELA label looks like: PART00002_POLYGON_POLYGON_GROUP_Ovbd1_Ovbd2_14
+      // But we only want to keep Ovbd1_Ovbd2
+      // So we find the word GROUP, and then we keep what is after, except the last piece
+
+      using std::begin;
+      using std::end;
+      auto it = std::find( begin( splitLabel ), end( splitLabel ), "GROUP" );
+
+      GEOSX_THROW_IF( it == end( splitLabel ),
+                      "GEOSX assumes that PAMELA places the word GROUP before the region/surface name", InputError );
+
+      localIndex const id = std::distance( begin( splitLabel ), it );
+      string name = "";
+      for( localIndex i = id+1; i < splitLabel.size()-1; ++i )
+      {
+        name += ( i == id+1 ) ? splitLabel[i] : "_"+splitLabel[i];
+      }
+
+      GEOSX_THROW_IF( name == "",
+                      "Something unexpected happened when converting the PAMELA label into a GEOSX label", InputError );
+
+      return name;
     }
 private:
     static string const m_separator;


### PR DESCRIPTION
Until now, it was not easy to figure out how the `PAMELAMeshGenerator` was setting the names of the physical entities in the mesh. For instance, a surface called `Ovbd1_Ovbd2` in the msh file was becoming just `Ovbd2` in GEOSX without notification. 

This PR makes sure that the name used in GEOSX is the same as the name used in the msh file: `Ovbd1_Ovbd2` in the msh file is still `Ovbd1_Ovbd2` in GEOSX.

This PR does not require a rebaseline.

Fixes #1425 