### PR TITLE
Improved well error/warning messages 

### DIFF
--- a/src/coreComponents/mesh/Perforation.hpp
+++ b/src/coreComponents/mesh/Perforation.hpp
@@ -24,15 +24,6 @@
 namespace geosx
 {
 
-namespace dataRepository
-{
-namespace keys
-{
-static constexpr auto perforation = "Perforation";
-}
-}
-
-
 /**
  * @class Perforation
  *

--- a/src/coreComponents/mesh/PerforationData.cpp
+++ b/src/coreComponents/mesh/PerforationData.cpp
@@ -126,8 +126,12 @@ void PerforationData::computeWellTransmissibility( MeshLevel const & mesh,
 
     // if the well transmissibility has been read from the XML
     // then skip the computation of the well transmissibility carried out below
-    if( m_wellTransmissibility[iperf] > 0 )
+    if( m_wellTransmissibility[iperf] >= 0 )
     {
+      GEOSX_LOG_RANK_IF( isZero( m_wellTransmissibility[iperf] ),
+                         "\n \nWarning! A perforation is defined with a zero transmissibility! \n"
+                         << "The simulation is going to proceed with this zero transmissibility,\n"
+                         << "but a better strategy to shut down a perforation is to remove the <Perforation> block from the XML\n \n" );
       continue;
     }
 

--- a/src/coreComponents/mesh/PerforationData.cpp
+++ b/src/coreComponents/mesh/PerforationData.cpp
@@ -128,10 +128,11 @@ void PerforationData::computeWellTransmissibility( MeshLevel const & mesh,
     // then skip the computation of the well transmissibility carried out below
     if( m_wellTransmissibility[iperf] >= 0 )
     {
+      WellElementRegion const & wellRegion = dynamicCast< WellElementRegion const & >( wellElemSubRegion.getParent().getParent() );
       GEOSX_LOG_RANK_IF( isZero( m_wellTransmissibility[iperf] ),
-                         "\n \nWarning! A perforation is defined with a zero transmissibility! \n"
-                         << "The simulation is going to proceed with this zero transmissibility,\n"
-                         << "but a better strategy to shut down a perforation is to remove the <Perforation> block from the XML\n \n" );
+                         "\n \nWarning! A perforation is defined with a zero transmissibility in " << wellRegion.getWellGeneratorName() << "! \n"
+                                                                                                   << "The simulation is going to proceed with this zero transmissibility,\n"
+                                                                                                   << "but a better strategy to shut down a perforation is to remove the <Perforation> block from the XML\n \n" );
       continue;
     }
 
@@ -147,6 +148,13 @@ void PerforationData::computeWellTransmissibility( MeshLevel const & mesh,
     // get an approximate dx, dy, dz for the reservoir element
     // this is done by computing a bounding box
     getReservoirElementDimensions( mesh, er, esr, ei, dx, dy, dz );
+
+    if( dx <= 0 || dy <= 0 || dz <= 0 )
+    {
+      WellElementRegion const & wellRegion = dynamicCast< WellElementRegion const & >( wellElemSubRegion.getParent().getParent() );
+      GEOSX_THROW( "The reservoir element dimensions (dx, dy, and dz) should be positive in " << wellRegion.getWellGeneratorName(),
+                   InputError );
+    }
 
     real64 d1 = 0;
     real64 d2 = 0;
@@ -191,16 +199,24 @@ void PerforationData::computeWellTransmissibility( MeshLevel const & mesh,
     arrayView1d< real64 const > const & wellElemRadius =
       wellElemSubRegion.getReference< array1d< real64 > >( WellElementSubRegion::viewKeyStruct::radiusString() );
 
-    GEOSX_ERROR_IF( rEq < wellElemRadius[wellElemIndex],
-                    "The equivalent radius r_eq = " << rEq <<
-                    " is smaller than the well radius (r = " << wellElemRadius[wellElemIndex] <<
-                    ") in " << getName() );
+    if( rEq < wellElemRadius[wellElemIndex] )
+    {
+      WellElementRegion const & wellRegion = dynamicCast< WellElementRegion const & >( wellElemSubRegion.getParent().getParent() );
+      GEOSX_THROW( "The equivalent radius r_eq = " << rEq <<
+                   " is smaller than the well radius (r = " << wellElemRadius[wellElemIndex] <<
+                   ") in " << wellRegion.getWellGeneratorName(),
+                   InputError );
+    }
 
     // compute the well Peaceman index
     m_wellTransmissibility[iperf] = 2 * M_PI * kh / std::log( rEq / wellElemRadius[wellElemIndex] );
 
-    GEOSX_ERROR_IF( m_wellTransmissibility[iperf] <= 0,
-                    "The well index is negative or equal to zero in " << getName() );
+    if( m_wellTransmissibility[iperf] <= 0 )
+    {
+      WellElementRegion const & wellRegion = dynamicCast< WellElementRegion const & >( wellElemSubRegion.getParent().getParent() );
+      GEOSX_THROW( "The well index is negative or equal to zero in " << wellRegion.getWellGeneratorName(),
+                   InputError );
+    }
   }
 }
 
@@ -216,7 +232,7 @@ void PerforationData::getReservoirElementDimensions( MeshLevel const & mesh,
 
   // compute the bounding box of the element
   real64 boxDims[ 3 ];
-  computationalGeometry::GetBoundingBox( ei,
+  computationalGeometry::getBoundingBox( ei,
                                          subRegion.nodeList(),
                                          nodeManager.referencePosition(),
                                          boxDims );
@@ -228,10 +244,6 @@ void PerforationData::getReservoirElementDimensions( MeshLevel const & mesh,
   // dz is computed as vol / (dx * dy)
   dz  = subRegion.getElementVolume()[ei];
   dz /= dx * dy;
-
-  GEOSX_ERROR_IF( dx <= 0 || dy <= 0 || dz <= 0,
-                  "The reservoir element dimensions (dx, dy, and dz) should be positive in " << getName() );
-
 }
 
 void PerforationData::connectToWellElements( InternalWellGenerator const & wellGeometry,

--- a/src/coreComponents/mesh/WellElementRegion.cpp
+++ b/src/coreComponents/mesh/WellElementRegion.cpp
@@ -64,11 +64,12 @@ void WellElementRegion::generateWell( MeshLevel & mesh,
   subRegion.connectPerforationsToMeshElements( mesh, wellGeometry );
 
   globalIndex const matchedPerforations = MpiWrapper::sum( perforationData->size() );
-  GEOSX_ERROR_IF( matchedPerforations != numPerforationsGlobal,
-                  "Invalid mapping perforation-to-element in well " << this->getName() << "." <<
+  GEOSX_THROW_IF( matchedPerforations != numPerforationsGlobal,
+                  "Invalid mapping perforation-to-element in well " << wellGeometry.getName() << "." <<
                   " This happens when GEOSX cannot match a perforation with a reservoir element." <<
                   " The most common reason for this error is that a perforation is on a section of " <<
-                  " the well polyline located outside the domain." );
+                  " the well polyline located outside the domain.",
+                  InputError );
 
 
   // 2) classify well elements based on connectivity to local mesh partition

--- a/src/coreComponents/mesh/WellElementSubRegion.cpp
+++ b/src/coreComponents/mesh/WellElementSubRegion.cpp
@@ -383,8 +383,9 @@ void WellElementSubRegion::generate( MeshLevel & mesh,
   // this is enforced in the InternalWellGenerator that currently merges two perforations
   // if they belong to the same well element. This is a temporary solution.
   // TODO: split the well elements that contain multiple perforations, so that no element is shared
-  GEOSX_ERROR_IF( sharedElems.size() > 0,
-                  "Well " << getName() << " contains shared well elements" );
+  GEOSX_THROW_IF( sharedElems.size() > 0,
+                  "Well " << wellGeometry.getName() << " contains shared well elements",
+                  InputError );
 
 
   // In Steps 1 and 2 we determine the local objects on this rank (elems and nodes)
@@ -532,11 +533,12 @@ void WellElementSubRegion::checkPartitioningValidity( InternalWellGenerator cons
       globalIndex const numBranches = prevElemIdsGlobal[iwelemGlobal].size();
       globalIndex const prevGlobal  = prevElemIdsGlobal[iwelemGlobal][numBranches-1];
 
-      GEOSX_ERROR_IF( prevGlobal <= iwelemGlobal || prevGlobal < 0,
-                      "The structure of well " << getName() << " is invalid. " <<
+      GEOSX_THROW_IF( prevGlobal <= iwelemGlobal || prevGlobal < 0,
+                      "The structure of well " << wellGeometry.getName() << " is invalid. " <<
                       " The main reason for this error is that there may be no perforation" <<
                       " in the bottom well element of the well, which is required to have" <<
-                      " a well-posed problem." );
+                      " a well-posed problem.",
+                      InputError );
 
       if( elemStatusGlobal[prevGlobal] == WellElemStatus::LOCAL )
       {

--- a/src/coreComponents/mesh/generators/InternalWellGenerator.cpp
+++ b/src/coreComponents/mesh/generators/InternalWellGenerator.cpp
@@ -486,11 +486,15 @@ void InternalWellGenerator::mergePerforations()
           continue;
         }
 
-        GEOSX_LOG_RANK_0( "Moving perforation #" << elemToPerfMap[iwelem][ip]
-                                                 << " of well " << getName()
-                                                 << " from " << m_perfCoords[elemToPerfMap[iwelem][ip]]
-                                                 << " to " << m_perfCoords[iperfMaxTransmissibility] <<
-                          " to make sure that no well element is shared between two MPI ranks" );
+        GEOSX_LOG_RANK_0( "\n \nThe GEOSX wells currently have the following limitation in parallel: \n"
+                          << "We cannot allow an element of the well mesh to have two or more perforations associated with it. \n"
+                          << "So, in the present simulation, perforation #" << elemToPerfMap[iwelem][ip]
+                          << " of well " << getName()
+                          << " is moved from " << m_perfCoords[elemToPerfMap[iwelem][ip]]
+                          << " to " << m_perfCoords[iperfMaxTransmissibility]
+                          << " to make sure that no element of the well mesh has two perforations associated with it. \n"
+                          << "To circumvent this issue, please increase the value of \"numElementsPerSegment\" that controls the number of (uniformly distributed) well mesh elements per segment of the well polyline. \n"
+                          << "Our recommendation is to choose \"numElementsPerSegment\" such that each well mesh element has at most one perforation. \n \n" );
         LvArray::tensorOps::copy< 3 >( m_perfCoords[elemToPerfMap[iwelem][ip]], m_perfCoords[iperfMaxTransmissibility] );
       }
     }

--- a/src/coreComponents/mesh/generators/InternalWellGenerator.hpp
+++ b/src/coreComponents/mesh/generators/InternalWellGenerator.hpp
@@ -25,20 +25,6 @@
 namespace geosx
 {
 
-namespace dataRepository
-{
-namespace keys
-{
-string const nodeCoords       = "polylineNodeCoords";
-string const segmentConn      = "polylineSegmentConn";
-string const nElems           = "numElementsPerSegment";
-string const radius           = "radius";
-string const wellRegionName   = "wellRegionName";
-string const wellControlsName = "wellControlsName";
-string const meshBodyName     = "meshName";
-}
-}
-
 /**
  * @class InternalWellGenerator
  *
@@ -211,6 +197,20 @@ public:
 
   ///@}
 
+  ///@cond DO_NOT_DOCUMENT
+  struct viewKeyStruct
+  {
+    constexpr static char const * polylineNodeCoordsString() { return "polylineNodeCoords"; }
+    constexpr static char const * polylineSegmentConnString() { return "polylineSegmentConn"; }
+    constexpr static char const * numElementsPerSegmentString() { return "numElementsPerSegment"; }
+    constexpr static char const * radiusString() { return "radius"; }
+    constexpr static char const * wellRegionNameString() { return "wellRegionName"; }
+    constexpr static char const * wellControlsNameString() { return "wellControlsName"; }
+    constexpr static char const * meshNameString() { return "meshName"; }
+    constexpr static char const * perforationString() { return "Perforation"; }
+  };
+  /// @endcond
+
 protected:
 
   /**
@@ -247,9 +247,16 @@ private:
   void connectPerforationsToWellElements();
 
   /**
+   * @brief Make sure that the perforation locations are valid:
+   *   - for partitioning purposes
+   *   - to have a well-posed problem
+   */
+  void checkPerforationLocationsValidity();
+
+  /**
    * @brief Merge perforations on the elements with multiple perforations.
    */
-  void mergePerforations();
+  void mergePerforations( array1d< array1d< localIndex > > const & elemToPerfMap );
 
   /**
    * @brief At a given node, find the next segment going in the direction of the bottom of the well.

--- a/src/coreComponents/mesh/utilities/ComputationalGeometry.hpp
+++ b/src/coreComponents/mesh/utilities/ComputationalGeometry.hpp
@@ -399,7 +399,7 @@ bool IsPointInsidePolyhedron( arrayView2d< real64 const, nodes::REFERENCE_POSITI
  */
 template< typename VEC_TYPE >
 GEOSX_HOST_DEVICE
-void GetBoundingBox( localIndex const elemIndex,
+void getBoundingBox( localIndex const elemIndex,
                      arrayView2d< localIndex const, cells::NODE_MAP_USD > const & pointIndices,
                      arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const & pointCoordinates,
                      VEC_TYPE && boxDims )


### PR DESCRIPTION
Fixes #1469 

This PR clarifies the warning that is output when a user tries to define a well with multiple perforations in the same well element message. The current message is a little bit cryptic, so I propose the following one:
```
The GEOSX wells currently have the following limitation in parallel:                                                                                                                                            
We cannot allow an element of the well mesh to have two or more perforations associated with it.                                                                                                                
So, in the present simulation, perforation #2 of well wellInjector1 is moved from { 5025, 4624, 28.82 } to { 5025, 5024, 28.82 } to make sure that no element of the well mesh has two perforations associated \
with it.                                                                                                                                                                                                        
To circumvent this issue, please increase the value of "numElementsPerSegment" that controls the number of (uniformly distributed) well mesh elements per segment of the well polyline.                         
Our recommendation is to choose "numElementsPerSegment" such that each well mesh element has at most one perforation.
```
The reason for not allowing two perforations in the same well mesh element is that these two perforations could be connected to two reservoir cells on different MPI partitions, which would break the logic of the well mesh partitioning.

This PR also clarifies the behavior of the well generator when the user provides a well transmissibility equal to zero (which we do not encourage). Currently, if a user sets the transmissibility to zero, GEOSX is silently recomputing the transmissibility using the Peaceman formula. With this PR, GEOSX will output the following warning:
```
Warning! A perforation is defined with a zero transmissibility!                                                                                                                                                
The simulation is going to proceed with this zero transmissibility,                                                                                                                                             
but a better strategy to shut down a perforation is to remove to <Perforation> block from the XML
```
and proceed with the simulation.