### PR TITLE
Force google's gsutil to use python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ geosx_pangea_build: &geosx_pangea_build
   - openssl aes-256-cbc -K $encrypted_5ac030ea614b_key -iv $encrypted_5ac030ea614b_iv
     -in ${TRAVIS_BUILD_DIR}/geosx-key.json.enc -out ${GEOSX_GCLOUD_KEY} -d
   - gcloud auth activate-service-account --key-file=${GEOSX_GCLOUD_KEY}
-  - gsutil cp -a public-read ${GEOSX_BUNDLE} gs://geosx/Pangea2/
+  - CLOUDSDK_PYTHON=python3 gsutil cp -a public-read ${GEOSX_BUNDLE} gs://geosx/Pangea2/
 
 draft_script: &draft_script
   script:


### PR DESCRIPTION
The python 2 support for gsutil is deprecated.