### PR TITLE
Moved resizeFields to registerDataOnMesh in compositional solvers

### DIFF
--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.cpp
@@ -107,71 +107,100 @@ void CompositionalMultiphaseBase::registerDataOnMesh( Group & meshBodies )
 {
   FlowSolverBase::registerDataOnMesh( meshBodies );
 
+  DomainPartition const & domain = this->getGroupByPath< DomainPartition >( "/Problem/domain" );
+  ConstitutiveManager const & cm = domain.getConstitutiveManager();
+
+  // 1. Set key dimensions of the problem
+  MultiFluidBase const & fluid0 = cm.getConstitutiveRelation< MultiFluidBase >( m_fluidModelNames[0] );
+  m_numPhases     = fluid0.numFluidPhases();
+  m_numComponents = fluid0.numFluidComponents();
+  m_numDofPerCell = m_numComponents + 1;
+
+  // 2. Register and resize all fields as necessary
   meshBodies.forSubGroups< MeshBody >( [&]( MeshBody & meshBody )
   {
     MeshLevel & mesh = meshBody.getMeshLevel( 0 );
 
-    forTargetSubRegions( mesh, [&]( localIndex const, ElementSubRegionBase & elementSubRegion )
+    forTargetSubRegions( mesh, [&]( localIndex const targetIndex, ElementSubRegionBase & subRegion )
     {
+      MultiFluidBase const & fluid = getConstitutiveModel< MultiFluidBase >( subRegion, m_fluidModelNames[targetIndex] );
 
-      elementSubRegion.registerWrapper< array1d< real64 > >( viewKeyStruct::pressureString() ).setPlotLevel( PlotLevel::LEVEL_0 );
-
-      elementSubRegion.registerWrapper< array1d< real64 > >( viewKeyStruct::deltaPressureString() ).
-        setRestartFlags( RestartFlags::NO_WRITE );
-
-      elementSubRegion.registerWrapper< array1d< real64 > >( viewKeyStruct::bcPressureString() );
-
-      elementSubRegion.registerWrapper< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::globalCompDensityString() ).
+      subRegion.registerWrapper< array1d< real64 > >( viewKeyStruct::pressureString() ).
         setPlotLevel( PlotLevel::LEVEL_0 );
 
-      elementSubRegion.registerWrapper< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::deltaGlobalCompDensityString() ).
+      subRegion.registerWrapper< array1d< real64 > >( viewKeyStruct::deltaPressureString() ).
         setRestartFlags( RestartFlags::NO_WRITE );
 
-      elementSubRegion.registerWrapper< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::globalCompFractionString() ).
-        setPlotLevel( PlotLevel::LEVEL_0 );
+      subRegion.registerWrapper< array1d< real64 > >( viewKeyStruct::bcPressureString() );
 
-      elementSubRegion.registerWrapper< array3d< real64, compflow::LAYOUT_COMP_DC > >( viewKeyStruct::dGlobalCompFraction_dGlobalCompDensityString() ).
-        setRestartFlags( RestartFlags::NO_WRITE );
+      // The resizing of the arrays needs to happen here, before the call to initializePreSubGroups,
+      // to make sure that the dimensions are properly set before the timeHistoryOutput starts its initialization.
 
-      elementSubRegion.registerWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseVolumeFractionString() ).
-        setPlotLevel( PlotLevel::LEVEL_0 );
+      subRegion.registerWrapper< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::globalCompDensityString() ).
+        setPlotLevel( PlotLevel::LEVEL_0 ).
+        setDimLabels( 1, fluid.componentNames() ).
+        reference().resizeDimension< 1 >( m_numComponents );
+      subRegion.registerWrapper< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::deltaGlobalCompDensityString() ).
+        setRestartFlags( RestartFlags::NO_WRITE ).
+        reference().resizeDimension< 1 >( m_numComponents );
 
-      elementSubRegion.registerWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::dPhaseVolumeFraction_dPressureString() ).
-        setRestartFlags( RestartFlags::NO_WRITE );
+      subRegion.registerWrapper< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::globalCompFractionString() ).
+        setPlotLevel( PlotLevel::LEVEL_0 ).
+        setDimLabels( 1, fluid.componentNames() ).
+        reference().resizeDimension< 1 >( m_numComponents );
+      subRegion.registerWrapper< array3d< real64, compflow::LAYOUT_COMP_DC > >( viewKeyStruct::dGlobalCompFraction_dGlobalCompDensityString() ).
+        setRestartFlags( RestartFlags::NO_WRITE ).
+        reference().resizeDimension< 1, 2 >( m_numComponents, m_numComponents );
 
-      elementSubRegion.registerWrapper< array3d< real64, compflow::LAYOUT_PHASE_DC > >( viewKeyStruct::dPhaseVolumeFraction_dGlobalCompDensityString() ).
-        setRestartFlags( RestartFlags::NO_WRITE );
+      subRegion.registerWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseVolumeFractionString() ).
+        setPlotLevel( PlotLevel::LEVEL_0 ).
+        setDimLabels( 1, fluid.phaseNames() ).
+        reference().resizeDimension< 1 >( m_numPhases );
+      subRegion.registerWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::dPhaseVolumeFraction_dPressureString() ).
+        setRestartFlags( RestartFlags::NO_WRITE ).
+        reference().resizeDimension< 1 >( m_numPhases );
+      subRegion.registerWrapper< array3d< real64, compflow::LAYOUT_PHASE_DC > >( viewKeyStruct::dPhaseVolumeFraction_dGlobalCompDensityString() ).
+        setRestartFlags( RestartFlags::NO_WRITE ).
+        reference().resizeDimension< 1, 2 >( m_numPhases, m_numComponents );
 
-      elementSubRegion.registerWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseMobilityString() ).
-        setPlotLevel( PlotLevel::LEVEL_0 );
-
-      elementSubRegion.registerWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::dPhaseMobility_dPressureString() ).
-        setRestartFlags( RestartFlags::NO_WRITE );
-
-      elementSubRegion.registerWrapper< array3d< real64, compflow::LAYOUT_PHASE_DC > >( viewKeyStruct::dPhaseMobility_dGlobalCompDensityString() ).
-        setRestartFlags( RestartFlags::NO_WRITE );
+      subRegion.registerWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseMobilityString() ).
+        setPlotLevel( PlotLevel::LEVEL_0 ).
+        setDimLabels( 1, fluid.phaseNames() ).
+        reference().resizeDimension< 1 >( m_numPhases );
+      subRegion.registerWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::dPhaseMobility_dPressureString() ).
+        setRestartFlags( RestartFlags::NO_WRITE ).
+        reference().resizeDimension< 1 >( m_numPhases );
+      subRegion.registerWrapper< array3d< real64, compflow::LAYOUT_PHASE_DC > >( viewKeyStruct::dPhaseMobility_dGlobalCompDensityString() ).
+        setRestartFlags( RestartFlags::NO_WRITE ).
+        reference().resizeDimension< 1, 2 >( m_numPhases, m_numComponents );
 
       if( m_computeCFLNumbers )
       {
-        elementSubRegion.registerWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseOutfluxString() ).
-          setRestartFlags( RestartFlags::NO_WRITE );
-        elementSubRegion.registerWrapper< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::componentOutfluxString() ).
-          setRestartFlags( RestartFlags::NO_WRITE );
-        elementSubRegion.registerWrapper< array1d< real64 > >( viewKeyStruct::phaseCFLNumberString() ).
+        subRegion.registerWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseOutfluxString() ).
+          setRestartFlags( RestartFlags::NO_WRITE ).
+          reference().resizeDimension< 1 >( m_numPhases );
+        subRegion.registerWrapper< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::componentOutfluxString() ).
+          setRestartFlags( RestartFlags::NO_WRITE ).
+          reference().resizeDimension< 1 >( m_numComponents );
+        subRegion.registerWrapper< array1d< real64 > >( viewKeyStruct::phaseCFLNumberString() ).
           setPlotLevel( PlotLevel::LEVEL_0 ).
           setRestartFlags( RestartFlags::NO_WRITE );
-        elementSubRegion.registerWrapper< array1d< real64 > >( viewKeyStruct::componentCFLNumberString() )
-          .setPlotLevel( PlotLevel::LEVEL_0 )
-          .setRestartFlags( RestartFlags::NO_WRITE );
+        subRegion.registerWrapper< array1d< real64 > >( viewKeyStruct::componentCFLNumberString() ).
+          setPlotLevel( PlotLevel::LEVEL_0 ).
+          setRestartFlags( RestartFlags::NO_WRITE );
       }
 
-      elementSubRegion.registerWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseVolumeFractionOldString() );
-      elementSubRegion.registerWrapper< array1d< real64 > >( viewKeyStruct::totalDensityOldString() );
-      elementSubRegion.registerWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseDensityOldString() );
-      elementSubRegion.registerWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseMobilityOldString() );
-      elementSubRegion.registerWrapper< array3d< real64, compflow::LAYOUT_PHASE_COMP > >( viewKeyStruct::phaseComponentFractionOldString() );
-      elementSubRegion.registerWrapper< array1d< real64 > >( viewKeyStruct::porosityString() );
-      elementSubRegion.registerWrapper< array1d< real64 > >( viewKeyStruct::porosityOldString() );
+      subRegion.registerWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseVolumeFractionOldString() ).
+        reference().resizeDimension< 1 >( m_numPhases );
+      subRegion.registerWrapper< array1d< real64 > >( viewKeyStruct::totalDensityOldString() );
+      subRegion.registerWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseDensityOldString() ).
+        reference().resizeDimension< 1 >( m_numPhases );
+      subRegion.registerWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseMobilityOldString() ).
+        reference().resizeDimension< 1 >( m_numPhases );
+      subRegion.registerWrapper< array3d< real64, compflow::LAYOUT_PHASE_COMP > >( viewKeyStruct::phaseComponentFractionOldString() ).
+        reference().resizeDimension< 1, 2 >( m_numPhases, m_numComponents );
+      subRegion.registerWrapper< array1d< real64 > >( viewKeyStruct::porosityString() );
+      subRegion.registerWrapper< array1d< real64 > >( viewKeyStruct::porosityOldString() );
 
     } );
 
@@ -182,11 +211,6 @@ void CompositionalMultiphaseBase::registerDataOnMesh( Group & meshBodies )
         setRegisteringObjects( this->getName() ).
         setDescription( "An array that holds the pressures at the faces." );
     }
-
-    // Now that the data has been registered on the mesh, we are ready to resize the fields as necessary.
-    // This needs to happen here, before the call to initializePreSubGroups,
-    // to make sure that the dimensions are properly set before the timeHistoryOutput starts its initialization.
-    resizeFields( mesh );
 
   } );
 }
@@ -282,69 +306,6 @@ void CompositionalMultiphaseBase::initializePreSubGroups()
       validateModelMapping< CapillaryPressureBase >( meshLevel.getElemManager(), m_capPressureModelNames );
     }
   }
-}
-
-void CompositionalMultiphaseBase::resizeFields( MeshLevel & meshLevel )
-{
-  DomainPartition const & domain = this->getGroupByPath< DomainPartition >( "/Problem/domain" );
-  ConstitutiveManager const & cm = domain.getConstitutiveManager();
-
-  // 1. Set key dimensions of the problem
-  MultiFluidBase const & fluid0 = cm.getConstitutiveRelation< MultiFluidBase >( m_fluidModelNames[0] );
-  m_numPhases     = fluid0.numFluidPhases();
-  m_numComponents = fluid0.numFluidComponents();
-  m_numDofPerCell = m_numComponents + 1;
-
-  // 2. Resize all fields as necessary
-  forTargetSubRegions( meshLevel, [&]( localIndex const targetIndex, ElementSubRegionBase & subRegion )
-  {
-    MultiFluidBase const & fluid = getConstitutiveModel< MultiFluidBase >( subRegion, m_fluidModelNames[targetIndex] );
-
-    subRegion.getWrapper< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::globalCompDensityString() ).
-      setDimLabels( 1, fluid.componentNames() ).
-      reference().resizeDimension< 1 >( m_numComponents );
-    subRegion.getReference< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::deltaGlobalCompDensityString() ).
-      resizeDimension< 1 >( m_numComponents );
-
-    subRegion.getWrapper< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::globalCompFractionString() ).
-      setDimLabels( 1, fluid.componentNames() ).
-      reference().resizeDimension< 1 >( m_numComponents );
-    subRegion.getReference< array3d< real64, compflow::LAYOUT_COMP_DC > >( viewKeyStruct::dGlobalCompFraction_dGlobalCompDensityString() ).
-      resizeDimension< 1, 2 >( m_numComponents, m_numComponents );
-
-    subRegion.getWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseVolumeFractionString() ).
-      setDimLabels( 1, fluid.phaseNames() ).
-      reference().resizeDimension< 1 >( m_numPhases );
-    subRegion.getReference< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::dPhaseVolumeFraction_dPressureString() ).
-      resizeDimension< 1 >( m_numPhases );
-    subRegion.getReference< array3d< real64, compflow::LAYOUT_PHASE_DC > >( viewKeyStruct::dPhaseVolumeFraction_dGlobalCompDensityString() ).
-      resizeDimension< 1, 2 >( m_numPhases, m_numComponents );
-
-    subRegion.getWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseMobilityString() ).
-      setDimLabels( 1, fluid.phaseNames() ).
-      reference().resizeDimension< 1 >( m_numPhases );
-    subRegion.getReference< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::dPhaseMobility_dPressureString() ).
-      resizeDimension< 1 >( m_numPhases );
-    subRegion.getReference< array3d< real64, compflow::LAYOUT_PHASE_DC > >( viewKeyStruct::dPhaseMobility_dGlobalCompDensityString() ).
-      resizeDimension< 1, 2 >( m_numPhases, m_numComponents );
-
-    subRegion.getReference< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseVolumeFractionOldString() ).
-      resizeDimension< 1 >( m_numPhases );
-    subRegion.getReference< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseMobilityOldString() ).
-      resizeDimension< 1 >( m_numPhases );
-    subRegion.getReference< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseDensityOldString() ).
-      resizeDimension< 1 >( m_numPhases );
-    subRegion.getReference< array3d< real64, compflow::LAYOUT_PHASE_COMP > >( viewKeyStruct::phaseComponentFractionOldString() ).
-      resizeDimension< 1, 2 >( m_numPhases, m_numComponents );
-
-    if( m_computeCFLNumbers )
-    {
-      subRegion.getReference< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseOutfluxString() ).
-        resizeDimension< 1 >( m_numPhases );
-      subRegion.getReference< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::componentOutfluxString() ).
-        resizeDimension< 1 >( m_numComponents );
-    }
-  } );
 }
 
 void CompositionalMultiphaseBase::updateComponentFraction( Group & dataGroup ) const

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.hpp
@@ -375,15 +375,6 @@ protected:
   void validateConstitutiveModels( constitutive::ConstitutiveManager const & cm ) const;
 
   /**
-   * @brief Resize the allocated multidimensional fields
-   * @param domain the domain containing the mesh and fields
-   *
-   * Resize fields along dimensions 1 and 2 (0 is the size of containing object, i.e. element subregion)
-   * once the number of phases/components is known (e.g. component fractions)
-   */
-  void resizeFields( MeshLevel & meshLevel );
-
-  /**
    * @brief Setup stored views into domain data for the current step
    */
   void resetViews( MeshLevel & mesh ) override;

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.hpp
@@ -381,7 +381,7 @@ protected:
    * Resize fields along dimensions 1 and 2 (0 is the size of containing object, i.e. element subregion)
    * once the number of phases/components is known (e.g. component fractions)
    */
-  void resizeFields( MeshLevel & meshLevel ) const;
+  void resizeFields( MeshLevel & meshLevel );
 
   /**
    * @brief Setup stored views into domain data for the current step

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
@@ -189,13 +189,18 @@ void CompositionalMultiphaseWell::registerDataOnMesh( Group & meshBodies )
       setRestartFlags( RestartFlags::NO_WRITE );
   } );
 
+  // Now that the data has been registered on the mesh, we are ready to resize the fields as necessary.
+  // This needs to happen here, before the call to initializePreSubGroups,
+  // to make sure that the dimensions are properly set before the timeHistoryOutput starts its initialization.
+  resizeFields( meshLevel );
+
 }
 
 namespace
 {
 
 template< typename MODEL1_TYPE, typename MODEL2_TYPE >
-void CompareMultiphaseModels( MODEL1_TYPE const & lhs, MODEL2_TYPE const & rhs )
+void compareMultiphaseModels( MODEL1_TYPE const & lhs, MODEL2_TYPE const & rhs )
 {
   GEOSX_ERROR_IF_NE_MSG( lhs.numFluidPhases(), rhs.numFluidPhases(),
                          "Mismatch in number of phases between constitutive models "
@@ -210,7 +215,7 @@ void CompareMultiphaseModels( MODEL1_TYPE const & lhs, MODEL2_TYPE const & rhs )
 }
 
 template< typename MODEL1_TYPE, typename MODEL2_TYPE >
-void CompareMulticomponentModels( MODEL1_TYPE const & lhs, MODEL2_TYPE const & rhs )
+void compareMulticomponentModels( MODEL1_TYPE const & lhs, MODEL2_TYPE const & rhs )
 {
   GEOSX_ERROR_IF_NE_MSG( lhs.numFluidComponents(), rhs.numFluidComponents(),
                          "Mismatch in number of components between constitutive models "
@@ -254,11 +259,11 @@ void CompositionalMultiphaseWell::validateConstitutiveModels( MeshLevel const & 
       if( reservoirRegionNames.count( flowTargetRegionNames[resTargetIndex] ) > 0 )
       {
         MultiFluidBase const & resFluid = cm.getConstitutiveRelation< MultiFluidBase >( flowFluidModels[resTargetIndex] );
-        CompareMultiphaseModels( wellFluid, resFluid );
-        CompareMulticomponentModels( wellFluid, resFluid );
+        compareMultiphaseModels( wellFluid, resFluid );
+        compareMulticomponentModels( wellFluid, resFluid );
 
         RelativePermeabilityBase const & resRelPerm = cm.getConstitutiveRelation< RelativePermeabilityBase >( flowRelPermModels[resTargetIndex] );
-        CompareMultiphaseModels( wellRelPerm, resRelPerm );
+        compareMultiphaseModels( wellRelPerm, resRelPerm );
       }
     }
   } );
@@ -347,75 +352,79 @@ void CompositionalMultiphaseWell::initializePreSubGroups()
 
   validateConstitutiveModels( meshLevel, cm );
 
-  // Set key dimensions (phases, components) from one of the fluids - they should all be compatible
+  MultiFluidBase const & fluid0 = cm.getConstitutiveRelation< MultiFluidBase >( m_fluidModelNames[0] );
+  validateModelMapping< MultiFluidBase >( meshLevel.getElemManager(), m_fluidModelNames );
+  validateModelMapping< RelativePermeabilityBase >( meshLevel.getElemManager(), m_relPermModelNames );
+  validateInjectionStreams( meshLevel );
+  validateWellConstraints( meshLevel, fluid0 );
+}
+
+void CompositionalMultiphaseWell::resizeFields( MeshLevel & meshLevel )
+{
+  DomainPartition const & domain = this->getGroupByPath< DomainPartition >( "/Problem/domain" );
+  ConstitutiveManager const & cm = domain.getConstitutiveManager();
+
+  // 1. Set key dimensions of the problem
   MultiFluidBase const & fluid0 = cm.getConstitutiveRelation< MultiFluidBase >( m_fluidModelNames[0] );
   m_numPhases     = fluid0.numFluidPhases();
   m_numComponents = fluid0.numFluidComponents();
   m_numDofPerWellElement = m_numComponents + 2; // 1 pressure + NC compositions + 1 connectionRate
 
-  validateModelMapping< MultiFluidBase >( meshLevel.getElemManager(), m_fluidModelNames );
-  validateModelMapping< RelativePermeabilityBase >( meshLevel.getElemManager(), m_relPermModelNames );
-  validateInjectionStreams( meshLevel );
-  validateWellConstraints( meshLevel, fluid0 );
-
+  // 2. Resize all fields as necessary
   forTargetSubRegions< WellElementSubRegion >( meshLevel, [&]( localIndex const targetIndex,
                                                                WellElementSubRegion & subRegion )
   {
-    resizeFields( subRegion, targetIndex );
+    PerforationData & perforationData = *subRegion.getPerforationData();
+    WellControls & wellControls = getWellControls( subRegion );
+
+    MultiFluidBase const & fluid = getConstitutiveModel< MultiFluidBase >( subRegion, m_fluidModelNames[targetIndex] );
+
+    subRegion.getWrapper< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::globalCompDensityString() ).
+      setDimLabels( 1, fluid.componentNames() ).
+      reference().resizeDimension< 1 >( m_numComponents );
+    subRegion.getReference< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::deltaGlobalCompDensityString() ).
+      resizeDimension< 1 >( m_numComponents );
+
+    subRegion.getWrapper< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::globalCompFractionString() ).
+      setDimLabels( 1, fluid.componentNames() ).
+      reference().resizeDimension< 1 >( m_numComponents );
+    subRegion.getReference< array3d< real64, compflow::LAYOUT_COMP_DC > >( viewKeyStruct::dGlobalCompFraction_dGlobalCompDensityString() ).
+      resizeDimension< 1, 2 >( m_numComponents, m_numComponents );
+
+    subRegion.getWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseVolumeFractionString() ).
+      setDimLabels( 1, fluid.phaseNames() ).
+      reference().resizeDimension< 1 >( m_numPhases );
+    subRegion.getReference< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::dPhaseVolumeFraction_dPressureString() ).
+      resizeDimension< 1 >( m_numPhases );
+    subRegion.getReference< array3d< real64, compflow::LAYOUT_PHASE_DC > >( viewKeyStruct::dPhaseVolumeFraction_dGlobalCompDensityString() ).
+      resizeDimension< 1, 2 >( m_numPhases, m_numComponents );
+
+    subRegion.getReference< array2d< real64, compflow::LAYOUT_FLUID_DC > >( viewKeyStruct::dTotalMassDensity_dGlobalCompDensityString() ).
+      resizeDimension< 1 >( m_numComponents );
+
+    perforationData.getReference< array2d< real64 > >( viewKeyStruct::compPerforationRateString() ).
+      resizeDimension< 1 >( m_numComponents );
+    perforationData.getReference< array3d< real64 > >( viewKeyStruct::dCompPerforationRate_dPresString() ).
+      resizeDimension< 1, 2 >( 2, m_numComponents );
+    perforationData.getReference< array4d< real64 > >( viewKeyStruct::dCompPerforationRate_dCompString() ).
+      resizeDimension< 1, 2, 3 >( 2, m_numComponents, m_numComponents );
+
+    wellControls.getReference< array1d< real64 > >( viewKeyStruct::dCurrentBHP_dCompDensString() ).
+      resizeDimension< 0 >( m_numComponents );
+
+    wellControls.getReference< array1d< real64 > >( viewKeyStruct::currentPhaseVolRateString() ).
+      resizeDimension< 0 >( m_numPhases );
+    wellControls.getReference< array1d< real64 > >( viewKeyStruct::dCurrentPhaseVolRate_dPresString() ).
+      resizeDimension< 0 >( m_numPhases );
+    wellControls.getReference< array2d< real64 > >( viewKeyStruct::dCurrentPhaseVolRate_dCompDensString() ).
+      resizeDimension< 0, 1 >( m_numPhases, m_numComponents );
+    wellControls.getReference< array1d< real64 > >( viewKeyStruct::dCurrentPhaseVolRate_dRateString() ).
+      resizeDimension< 0 >( m_numPhases );
+
+    wellControls.getReference< array1d< real64 > >( viewKeyStruct::dCurrentTotalVolRate_dCompDensString() ).
+      resizeDimension< 0 >( m_numComponents );
+
   } );
-}
-
-void CompositionalMultiphaseWell::resizeFields( WellElementSubRegion & subRegion, localIndex const targetIndex )
-{
-  PerforationData & perforationData = *subRegion.getPerforationData();
-  WellControls & wellControls = getWellControls( subRegion );
-
-  MultiFluidBase const & fluid = getConstitutiveModel< MultiFluidBase >( subRegion, m_fluidModelNames[targetIndex] );
-
-  subRegion.getWrapper< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::globalCompDensityString() ).
-    setDimLabels( 1, fluid.componentNames() ).
-    reference().resizeDimension< 1 >( m_numComponents );
-  subRegion.getReference< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::deltaGlobalCompDensityString() ).
-    resizeDimension< 1 >( m_numComponents );
-
-  subRegion.getWrapper< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::globalCompFractionString() ).
-    setDimLabels( 1, fluid.componentNames() ).
-    reference().resizeDimension< 1 >( m_numComponents );
-  subRegion.getReference< array3d< real64, compflow::LAYOUT_COMP_DC > >( viewKeyStruct::dGlobalCompFraction_dGlobalCompDensityString() ).
-    resizeDimension< 1, 2 >( m_numComponents, m_numComponents );
-
-  subRegion.getWrapper< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::phaseVolumeFractionString() ).
-    setDimLabels( 1, fluid.phaseNames() ).
-    reference().resizeDimension< 1 >( m_numPhases );
-  subRegion.getReference< array2d< real64, compflow::LAYOUT_PHASE > >( viewKeyStruct::dPhaseVolumeFraction_dPressureString() ).
-    resizeDimension< 1 >( m_numPhases );
-  subRegion.getReference< array3d< real64, compflow::LAYOUT_PHASE_DC > >( viewKeyStruct::dPhaseVolumeFraction_dGlobalCompDensityString() ).
-    resizeDimension< 1, 2 >( m_numPhases, m_numComponents );
-
-  subRegion.getReference< array2d< real64, compflow::LAYOUT_FLUID_DC > >( viewKeyStruct::dTotalMassDensity_dGlobalCompDensityString() ).
-    resizeDimension< 1 >( m_numComponents );
-
-  perforationData.getReference< array2d< real64 > >( viewKeyStruct::compPerforationRateString() ).
-    resizeDimension< 1 >( m_numComponents );
-  perforationData.getReference< array3d< real64 > >( viewKeyStruct::dCompPerforationRate_dPresString() ).
-    resizeDimension< 1, 2 >( 2, m_numComponents );
-  perforationData.getReference< array4d< real64 > >( viewKeyStruct::dCompPerforationRate_dCompString() ).
-    resizeDimension< 1, 2, 3 >( 2, m_numComponents, m_numComponents );
-
-  wellControls.getReference< array1d< real64 > >( viewKeyStruct::dCurrentBHP_dCompDensString() ).
-    resizeDimension< 0 >( m_numComponents );
-
-  wellControls.getReference< array1d< real64 > >( viewKeyStruct::currentPhaseVolRateString() ).
-    resizeDimension< 0 >( m_numPhases );
-  wellControls.getReference< array1d< real64 > >( viewKeyStruct::dCurrentPhaseVolRate_dPresString() ).
-    resizeDimension< 0 >( m_numPhases );
-  wellControls.getReference< array2d< real64 > >( viewKeyStruct::dCurrentPhaseVolRate_dCompDensString() ).
-    resizeDimension< 0, 1 >( m_numPhases, m_numComponents );
-  wellControls.getReference< array1d< real64 > >( viewKeyStruct::dCurrentPhaseVolRate_dRateString() ).
-    resizeDimension< 0 >( m_numPhases );
-
-  wellControls.getReference< array1d< real64 > >( viewKeyStruct::dCurrentTotalVolRate_dCompDensString() ).
-    resizeDimension< 0 >( m_numComponents );
 }
 
 void CompositionalMultiphaseWell::initializePostInitialConditionsPreSubGroups()

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.hpp
@@ -355,12 +355,6 @@ private:
    */
   void initializeWells( DomainPartition & domain ) override;
 
-  /**
-   * @brief Resize the allocated multidimensional fields
-   * @param meshLevel the mesh level object (to loop over wells)
-   */
-  void resizeFields( MeshLevel & meshLevel );
-
   /// the max number of fluid phases
   integer m_numPhases;
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.hpp
@@ -338,12 +338,14 @@ private:
 
   /**
    * @brief Compute all the perforation rates for this well
-   * @param well the well with its perforations
+   * @param subRegion the well element region for which the fields are resized
+   * @param targetIndex index of the target region
    */
   void computePerforationRates( WellElementSubRegion & subRegion, localIndex const targetIndex );
 
   /**
    * @brief Setup stored reservoir views into domain data for the current step
+   * @param domain the domain containing the well manager to access individual wells
    */
   void resetViews( DomainPartition & domain ) override;
 
@@ -355,10 +357,9 @@ private:
 
   /**
    * @brief Resize the allocated multidimensional fields
-   * @param subRegion the well element region for which the fields are resized
-   * @param targetIndex index of the target region
+   * @param meshLevel the mesh level object (to loop over wells)
    */
-  void resizeFields( WellElementSubRegion & subRegion, localIndex const targetIndex );
+  void resizeFields( MeshLevel & meshLevel );
 
   /// the max number of fluid phases
   integer m_numPhases;


### PR DESCRIPTION
This PR moves the `resizeFields` function to `registerDataOnMesh` in the compositional solvers (flow and well) to make sure that the data is already resized when the time history output kicks in. 

It solves #1510.

This PR does not break the integrated tests, so there is no rebaseline necessary.