### PR TITLE
Biot's tensor

### DIFF
--- a/src/coreComponents/constitutive/CMakeLists.txt
+++ b/src/coreComponents/constitutive/CMakeLists.txt
@@ -64,6 +64,7 @@ set( constitutive_headers
      solid/InvariantDecompositions.hpp
      solid/PoreVolumeCompressibleSolid.hpp
      solid/PoroElastic.hpp
+     solid/PorousElasticTransverseIsotropic.hpp
      solid/PorousSolid.hpp
      solid/PropertyConversions.hpp
      solid/SolidBase.hpp
@@ -122,6 +123,7 @@ set( constitutive_sources
      solid/ElasticTransverseIsotropic.cpp
      solid/PoreVolumeCompressibleSolid.cpp
      solid/PoroElastic.cpp
+     solid/PorousElasticTransverseIsotropic.cpp
      solid/PorousSolid.cpp
      solid/SolidBase.cpp
      solid/TriaxialDriver.cpp

--- a/src/coreComponents/constitutive/ConstitutivePassThru.hpp
+++ b/src/coreComponents/constitutive/ConstitutivePassThru.hpp
@@ -29,6 +29,7 @@
 #include "solid/DruckerPragerExtended.hpp"
 #include "solid/ElasticIsotropic.hpp"
 #include "solid/ElasticTransverseIsotropic.hpp"
+#include "solid/PorousElasticTransverseIsotropic.hpp"
 #include "solid/PorousSolid.hpp"
 #include "solid/PoroElastic.hpp"
 
@@ -152,7 +153,7 @@ struct ConstitutivePassThru< PorousSolidBase >
     ConstitutivePassThruHandler< PorousSolid< DruckerPragerExtended >,
                                  PorousSolid< DruckerPrager >,
                                  PorousSolid< ElasticIsotropic >,
-                                 PorousSolid< ElasticTransverseIsotropic >,
+                                 PorousElasticTransverseIsotropic,
                                  PorousSolid< DamageSpectral< ElasticIsotropic > >,
                                  PorousSolid< DamageVolDev< ElasticIsotropic > >,
                                  PorousSolid< Damage< ElasticIsotropic > > >::execute( constitutiveRelation,

--- a/src/coreComponents/constitutive/solid/ElasticTransverseIsotropic.hpp
+++ b/src/coreComponents/constitutive/solid/ElasticTransverseIsotropic.hpp
@@ -146,6 +146,35 @@ public:
   GEOSX_HOST_DEVICE
   virtual void getElasticStiffness( localIndex const k, real64 ( &stiffness )[6][6] ) const override final;
 
+  GEOSX_HOST_DEVICE
+  virtual real64 getC11( localIndex const k ) const override final
+  {
+    return m_c11[k];
+  }
+
+  GEOSX_HOST_DEVICE
+  virtual real64 getC13( localIndex const k ) const override final
+  {
+    return m_c13[k];
+  }
+
+  GEOSX_HOST_DEVICE
+  virtual real64 getC33( localIndex const k ) const override final
+  {
+    return m_c33[k];
+  }
+
+  GEOSX_HOST_DEVICE
+  virtual real64 getC44( localIndex const k ) const override final
+  {
+    return m_c44[k];
+  }
+
+  GEOSX_HOST_DEVICE
+  virtual real64 getC66( localIndex const k ) const override final
+  {
+    return m_c66[k];
+  }
 
 private:
 
@@ -482,7 +511,6 @@ public:
    * @return reference to mutable 11 component of Voigt stiffness tensor.
    */
   arrayView1d< real64 > getC11() { return m_c11; }
-
 
   /**
    * @brief Const-Getter for 13 component of Voigt stiffness tensor.

--- a/src/coreComponents/constitutive/solid/PorousElasticTransverseIsotropic.cpp
+++ b/src/coreComponents/constitutive/solid/PorousElasticTransverseIsotropic.cpp
@@ -1,0 +1,40 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 Total, S.A
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+
+/**
+ * @file PorousElasticTransverseIsotropic.cpp
+ */
+
+#include "PorousElasticTransverseIsotropic.hpp"
+#include "ElasticTransverseIsotropic.hpp"
+
+namespace geosx
+{
+
+using namespace dataRepository;
+
+namespace constitutive
+{
+PorousElasticTransverseIsotropic::PorousElasticTransverseIsotropic( string const & name,
+                                                                    Group * const parent ):
+  CoupledSolid< SOLID_TYPE, BiotPorosity, ConstantPermeability >( name, parent )
+{}
+
+PorousElasticTransverseIsotropic::~PorousElasticTransverseIsotropic() = default;
+
+REGISTER_CATALOG_ENTRY( ConstitutiveBase, PorousElasticTransverseIsotropic, string const &, Group * const )
+
+}
+} /* namespace geosx */

--- a/src/coreComponents/constitutive/solid/PorousElasticTransverseIsotropic.cpp
+++ b/src/coreComponents/constitutive/solid/PorousElasticTransverseIsotropic.cpp
@@ -29,7 +29,7 @@ namespace constitutive
 {
 PorousElasticTransverseIsotropic::PorousElasticTransverseIsotropic( string const & name,
                                                                     Group * const parent ):
-  CoupledSolid< SOLID_TYPE, BiotPorosity, ConstantPermeability >( name, parent )
+  CoupledSolid< ElasticTransverseIsotropic, BiotPorosity, ConstantPermeability >( name, parent )
 {}
 
 PorousElasticTransverseIsotropic::~PorousElasticTransverseIsotropic() = default;

--- a/src/coreComponents/constitutive/solid/PorousElasticTransverseIsotropic.hpp
+++ b/src/coreComponents/constitutive/solid/PorousElasticTransverseIsotropic.hpp
@@ -1,0 +1,169 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 Total, S.A
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+
+/**
+ * @file PorousElasticTransverseIsotropic.hpp
+ */
+
+#ifndef GEOSX_CONSTITUTIVE_SOLID_POROUSELASTICTRANSVERSEISOTROPIC_HPP_
+#define GEOSX_CONSTITUTIVE_SOLID_POROUSELASTICTRANSVERSEISOTROPIC_HPP_
+
+#include "constitutive/solid/CoupledSolid.hpp"
+#include "constitutive/solid/ElasticTransverseIsotropic.hpp"
+#include "constitutive/solid/porosity/BiotPorosity.hpp"
+#include "constitutive/solid/SolidBase.hpp"
+#include "constitutive/permeability/ConstantPermeability.hpp"
+
+namespace geosx
+{
+namespace constitutive
+{
+
+/**
+ * @brief Provides kernel-callable constitutive update routines
+ */
+using SOLID_TYPE = ElasticTransverseIsotropic;
+class PorousElasticTransverseIsotropicUpdates : public CoupledSolidUpdates< SOLID_TYPE, BiotPorosity, ConstantPermeability >
+{
+public:
+
+  using DiscretizationOps = typename SOLID_TYPE::KernelWrapper::DiscretizationOps;
+
+  /**
+   * @brief Constructor
+   */
+  PorousElasticTransverseIsotropicUpdates( SOLID_TYPE const & solidModel,
+                                           BiotPorosity const & porosityModel,
+                                           ConstantPermeability const & permModel ):
+    CoupledSolidUpdates< SOLID_TYPE, BiotPorosity, ConstantPermeability >( solidModel, porosityModel, permModel )
+  {}
+
+  GEOSX_HOST_DEVICE
+  void smallStrainUpdate( localIndex const k,
+                          localIndex const q,
+                          real64 const & deltaPressure,
+                          real64 const ( &strainIncrement )[6],
+                          real64 ( & stress )[6],
+                          real64 & dPorosity_dPressure,
+                          real64 & dPorosity_dVolStrain,
+                          real64 & dTotalStress_dPressure,
+                          DiscretizationOps & stiffness ) const
+  {
+    m_solidUpdate.smallStrainUpdate( k, q, strainIncrement, stress, stiffness );
+
+    updateBiotCoefficient( k );
+
+    m_porosityUpdate.updatePorosity( k,
+                                     q,
+                                     deltaPressure,
+                                     strainIncrement,
+                                     dPorosity_dPressure,
+                                     dPorosity_dVolStrain,
+                                     dTotalStress_dPressure );
+  }
+
+  GEOSX_HOST_DEVICE
+  void updateBiotCoefficient( localIndex const k ) const
+  {
+    real64 const c11 = m_solidUpdate.getC11( k );
+    real64 const c13 = m_solidUpdate.getC11( k );
+    real64 const c33 = m_solidUpdate.getC11( k );
+    real64 const c66 = m_solidUpdate.getC11( k );
+
+    real64 const c12 = c11 - 2.0 * c66;
+
+    m_porosityUpdate.updateBiotCoefficient( k, c11, c12, c13, c33 );
+  }
+
+private:
+
+  using CoupledSolidUpdates< SOLID_TYPE, BiotPorosity, ConstantPermeability >::m_solidUpdate;
+  using CoupledSolidUpdates< SOLID_TYPE, BiotPorosity, ConstantPermeability >::m_porosityUpdate;
+  using CoupledSolidUpdates< SOLID_TYPE, BiotPorosity, ConstantPermeability >::m_permUpdate;
+
+};
+
+/**
+ * @brief PorousElasticTransverseIsotropicBase class used for dispatch of all Porous solids.
+ */
+class PorousElasticTransverseIsotropicBase : public SolidBase
+{};
+
+/**
+ * @brief Class to represent a porous material for poromechanics simulations.
+ * It is used as an interface to access all constitutive models relative to the properties of a porous material.
+ *
+ * @tparam SOLID_TYPE type of solid model
+ */
+class PorousElasticTransverseIsotropic : public CoupledSolid< SOLID_TYPE, BiotPorosity, ConstantPermeability >
+{
+public:
+
+  /// Alias for ElasticIsotropicUpdates
+  using KernelWrapper = PorousElasticTransverseIsotropicUpdates;
+
+  /**
+   * @brief Constructor
+   * @param name Object name
+   * @param parent Object's parent group
+   */
+  PorousElasticTransverseIsotropic( string const & name, dataRepository::Group * const parent );
+
+  /// Destructor
+  virtual ~PorousElasticTransverseIsotropic() override;
+
+  /**
+   * @brief Catalog name
+   * @return Static catalog string
+   */
+  static string catalogName() { return string( "Porous" ) + SOLID_TYPE::m_catalogNameString; }
+
+  /**
+   * @brief Get catalog name
+   * @return Catalog name string
+   */
+  virtual string getCatalogName() const override { return catalogName(); }
+
+  /**
+   * @brief Create a instantiation of the PorousElasticTransverseIsotropicUpdates class
+   *        that refers to the data in this.
+   * @return An instantiation of PorousElasticTransverseIsotropicUpdates.
+   */
+  KernelWrapper createKernelUpdates() const
+  {
+    return KernelWrapper( getSolidModel(),
+                          getPorosityModel(),
+                          getPermModel() );
+  }
+
+  /**
+   * @brief Const/non-mutable accessor for density
+   * @return Accessor
+   */
+  arrayView2d< real64 const > const getDensity() const
+  {
+    return getSolidModel().getDensity();
+  }
+
+private:
+  using CoupledSolid< SOLID_TYPE, BiotPorosity, ConstantPermeability >::getSolidModel;
+  using CoupledSolid< SOLID_TYPE, BiotPorosity, ConstantPermeability >::getPorosityModel;
+  using CoupledSolid< SOLID_TYPE, BiotPorosity, ConstantPermeability >::getPermModel;
+};
+
+}
+} /* namespace geosx */
+
+#endif /* GEOSX_CONSTITUTIVE_SOLID_POROUSELASTICTRANSVERSEISOTROPIC_HPP_ */

--- a/src/coreComponents/constitutive/solid/PorousElasticTransverseIsotropic.hpp
+++ b/src/coreComponents/constitutive/solid/PorousElasticTransverseIsotropic.hpp
@@ -24,6 +24,7 @@
 #include "constitutive/solid/ElasticTransverseIsotropic.hpp"
 #include "constitutive/solid/porosity/BiotPorosity.hpp"
 #include "constitutive/solid/SolidBase.hpp"
+#include "constitutive/solid/PorousSolid.hpp"
 #include "constitutive/permeability/ConstantPermeability.hpp"
 
 namespace geosx
@@ -34,45 +35,18 @@ namespace constitutive
 /**
  * @brief Provides kernel-callable constitutive update routines
  */
-using SOLID_TYPE = ElasticTransverseIsotropic;
-class PorousElasticTransverseIsotropicUpdates : public CoupledSolidUpdates< SOLID_TYPE, BiotPorosity, ConstantPermeability >
+class PorousElasticTransverseIsotropicUpdates : public PorousSolidUpdates< ElasticTransverseIsotropic >
 {
 public:
-
-  using DiscretizationOps = typename SOLID_TYPE::KernelWrapper::DiscretizationOps;
 
   /**
    * @brief Constructor
    */
-  PorousElasticTransverseIsotropicUpdates( SOLID_TYPE const & solidModel,
+  PorousElasticTransverseIsotropicUpdates( ElasticTransverseIsotropic const & solidModel,
                                            BiotPorosity const & porosityModel,
                                            ConstantPermeability const & permModel ):
-    CoupledSolidUpdates< SOLID_TYPE, BiotPorosity, ConstantPermeability >( solidModel, porosityModel, permModel )
+    PorousSolidUpdates< ElasticTransverseIsotropic >( solidModel, porosityModel, permModel )
   {}
-
-  GEOSX_HOST_DEVICE
-  void smallStrainUpdate( localIndex const k,
-                          localIndex const q,
-                          real64 const & deltaPressure,
-                          real64 const ( &strainIncrement )[6],
-                          real64 ( & stress )[6],
-                          real64 & dPorosity_dPressure,
-                          real64 & dPorosity_dVolStrain,
-                          real64 & dTotalStress_dPressure,
-                          DiscretizationOps & stiffness ) const
-  {
-    m_solidUpdate.smallStrainUpdate( k, q, strainIncrement, stress, stiffness );
-
-    updateBiotCoefficient( k );
-
-    m_porosityUpdate.updatePorosity( k,
-                                     q,
-                                     deltaPressure,
-                                     strainIncrement,
-                                     dPorosity_dPressure,
-                                     dPorosity_dVolStrain,
-                                     dTotalStress_dPressure );
-  }
 
   GEOSX_HOST_DEVICE
   void updateBiotCoefficient( localIndex const k ) const
@@ -86,13 +60,6 @@ public:
 
     m_porosityUpdate.updateBiotCoefficient( k, c11, c12, c13, c33 );
   }
-
-private:
-
-  using CoupledSolidUpdates< SOLID_TYPE, BiotPorosity, ConstantPermeability >::m_solidUpdate;
-  using CoupledSolidUpdates< SOLID_TYPE, BiotPorosity, ConstantPermeability >::m_porosityUpdate;
-  using CoupledSolidUpdates< SOLID_TYPE, BiotPorosity, ConstantPermeability >::m_permUpdate;
-
 };
 
 /**
@@ -105,9 +72,9 @@ class PorousElasticTransverseIsotropicBase : public SolidBase
  * @brief Class to represent a porous material for poromechanics simulations.
  * It is used as an interface to access all constitutive models relative to the properties of a porous material.
  *
- * @tparam SOLID_TYPE type of solid model
+ * @tparam ElasticTransverseIsotropic type of solid model
  */
-class PorousElasticTransverseIsotropic : public CoupledSolid< SOLID_TYPE, BiotPorosity, ConstantPermeability >
+class PorousElasticTransverseIsotropic : public CoupledSolid< ElasticTransverseIsotropic, BiotPorosity, ConstantPermeability >
 {
 public:
 
@@ -128,7 +95,7 @@ public:
    * @brief Catalog name
    * @return Static catalog string
    */
-  static string catalogName() { return string( "Porous" ) + SOLID_TYPE::m_catalogNameString; }
+  static string catalogName() { return string( "Porous" ) + ElasticTransverseIsotropic::m_catalogNameString; }
 
   /**
    * @brief Get catalog name
@@ -158,9 +125,10 @@ public:
   }
 
 private:
-  using CoupledSolid< SOLID_TYPE, BiotPorosity, ConstantPermeability >::getSolidModel;
-  using CoupledSolid< SOLID_TYPE, BiotPorosity, ConstantPermeability >::getPorosityModel;
-  using CoupledSolid< SOLID_TYPE, BiotPorosity, ConstantPermeability >::getPermModel;
+
+  using CoupledSolid< ElasticTransverseIsotropic, BiotPorosity, ConstantPermeability >::getSolidModel;
+  using CoupledSolid< ElasticTransverseIsotropic, BiotPorosity, ConstantPermeability >::getPorosityModel;
+  using CoupledSolid< ElasticTransverseIsotropic, BiotPorosity, ConstantPermeability >::getPermModel;
 };
 
 }

--- a/src/coreComponents/constitutive/solid/PorousSolid.hpp
+++ b/src/coreComponents/constitutive/solid/PorousSolid.hpp
@@ -91,7 +91,7 @@ public:
     m_porosityUpdate.updateBiotCoefficient( k, bulkModulus );
   }
 
-private:
+protected:
 
   using CoupledSolidUpdates< SOLID_TYPE, BiotPorosity, ConstantPermeability >::m_solidUpdate;
   using CoupledSolidUpdates< SOLID_TYPE, BiotPorosity, ConstantPermeability >::m_porosityUpdate;

--- a/src/coreComponents/constitutive/solid/PorousSolid.hpp
+++ b/src/coreComponents/constitutive/solid/PorousSolid.hpp
@@ -85,26 +85,10 @@ public:
   GEOSX_HOST_DEVICE
   void updateBiotCoefficient( localIndex const k ) const
   {
+    // This call is not general like this.
+    real64 const bulkModulus = m_solidUpdate.getBulkModulus( k );
 
-    string solidType = SOLID_TYPE::m_catalogNameString;
-
-    if( solidType == "ElasticIsotropic" )
-    {
-      real64 const bulkModulus = m_solidUpdate.getBulkModulus( k );
-
-      m_porosityUpdate.updateBiotCoefficient( k, bulkModulus );
-    }
-    else if( solidType == "ElasticTransverseIsotropic" )
-    {
-      real64 const c11 = m_solidUpdate.getC11( k );
-      real64 const c13 = m_solidUpdate.getC13( k );
-      real64 const c33 = m_solidUpdate.getC33( k );
-      real64 const c66 = m_solidUpdate.getC66( k );
-
-      real64 const c12 = c11 - 2.0 * c66;
-
-      m_porosityUpdate.updateBiotCoefficient( k, c11, c12, c13, c33 );
-    }
+    m_porosityUpdate.updateBiotCoefficient( k, bulkModulus );
   }
 
 private:

--- a/src/coreComponents/constitutive/solid/PorousSolid.hpp
+++ b/src/coreComponents/constitutive/solid/PorousSolid.hpp
@@ -85,10 +85,26 @@ public:
   GEOSX_HOST_DEVICE
   void updateBiotCoefficient( localIndex const k ) const
   {
-    // This call is not general like this.
-    real64 const bulkModulus = m_solidUpdate.getBulkModulus( k );
 
-    m_porosityUpdate.updateBiotCoefficient( k, bulkModulus );
+    string solidType = SOLID_TYPE::m_catalogNameString;
+
+    if( solidType == "ElasticIsotropic" )
+    {
+      real64 const bulkModulus = m_solidUpdate.getBulkModulus( k );
+
+      m_porosityUpdate.updateBiotCoefficient( k, bulkModulus );
+    }
+    else if( solidType == "ElasticTransverseIsotropic" )
+    {
+      real64 const c11 = m_solidUpdate.getC11( k );
+      real64 const c13 = m_solidUpdate.getC13( k );
+      real64 const c33 = m_solidUpdate.getC33( k );
+      real64 const c66 = m_solidUpdate.getC66( k );
+
+      real64 const c12 = c11 - 2.0 * c66;
+
+      m_porosityUpdate.updateBiotCoefficient( k, c11, c12, c13, c33 );
+    }
   }
 
 private:

--- a/src/coreComponents/constitutive/solid/SolidBase.hpp
+++ b/src/coreComponents/constitutive/solid/SolidBase.hpp
@@ -132,6 +132,131 @@ public:
     return 0;
   }
 
+  /**
+   * @brief Get c11
+   * @param[in] k Element index.
+   * @return the stiffness component c11 of element k
+   */
+  GEOSX_HOST_DEVICE
+  virtual real64 getC11( localIndex const k ) const
+  {
+    GEOSX_UNUSED_VAR( k );
+    GEOSX_ERROR( "getC11() not implemented for this model" );
+
+    return 0;
+  }
+
+  /**
+   * @brief Get c12
+   * @param[in] k Element index.
+   * @return the stiffness component c12 of element k
+   */
+  GEOSX_HOST_DEVICE
+  virtual real64 getC12( localIndex const k ) const
+  {
+    GEOSX_UNUSED_VAR( k );
+    GEOSX_ERROR( "getC12() not implemented for this model" );
+
+    return 0;
+  }
+
+  /**
+   * @brief Get c13
+   * @param[in] k Element index.
+   * @return the stiffness component c13 of element k
+   */
+  GEOSX_HOST_DEVICE
+  virtual real64 getC13( localIndex const k ) const
+  {
+    GEOSX_UNUSED_VAR( k );
+    GEOSX_ERROR( "getC13() not implemented for this model" );
+
+    return 0;
+  }
+
+  /**
+   * @brief Get c22
+   * @param[in] k Element index.
+   * @return the stiffness component c22 of element k
+   */
+  GEOSX_HOST_DEVICE
+  virtual real64 getC22( localIndex const k ) const
+  {
+    GEOSX_UNUSED_VAR( k );
+    GEOSX_ERROR( "getC22() not implemented for this model" );
+
+    return 0;
+  }
+
+  /**
+   * @brief Get c23
+   * @param[in] k Element index.
+   * @return the stiffness component c23 of element k
+   */
+  GEOSX_HOST_DEVICE
+  virtual real64 getC23( localIndex const k ) const
+  {
+    GEOSX_UNUSED_VAR( k );
+    GEOSX_ERROR( "getC23() not implemented for this model" );
+
+    return 0;
+  }
+
+  /**
+   * @brief Get c33
+   * @param[in] k Element index.
+   * @return the stiffness component c33 of element k
+   */
+  GEOSX_HOST_DEVICE
+  virtual real64 getC33( localIndex const k ) const
+  {
+    GEOSX_UNUSED_VAR( k );
+    GEOSX_ERROR( "getC33() not implemented for this model" );
+
+    return 0;
+  }
+
+  /**
+   * @brief Get c44
+   * @param[in] k Element index.
+   * @return the stiffness component c44 of element k
+   */
+  GEOSX_HOST_DEVICE
+  virtual real64 getC44( localIndex const k ) const
+  {
+    GEOSX_UNUSED_VAR( k );
+    GEOSX_ERROR( "getC44() not implemented for this model" );
+
+    return 0;
+  }
+
+  /**
+   * @brief Get c55
+   * @param[in] k Element index.
+   * @return the stiffness component c55 of element k
+   */
+  GEOSX_HOST_DEVICE
+  virtual real64 getC55( localIndex const k ) const
+  {
+    GEOSX_UNUSED_VAR( k );
+    GEOSX_ERROR( "getC55() not implemented for this model" );
+
+    return 0;
+  }
+
+  /**
+   * @brief Get c66
+   * @param[in] k Element index.
+   * @return the stiffness component c66 of element k
+   */
+  GEOSX_HOST_DEVICE
+  virtual real64 getC66( localIndex const k ) const
+  {
+    GEOSX_UNUSED_VAR( k );
+    GEOSX_ERROR( "getC66() not implemented for this model" );
+
+    return 0;
+  }
 
   /**
    * @brief Small strain update.

--- a/src/coreComponents/constitutive/solid/SolidBase.hpp
+++ b/src/coreComponents/constitutive/solid/SolidBase.hpp
@@ -127,7 +127,7 @@ public:
   virtual real64 getBulkModulus( localIndex const k ) const
   {
     GEOSX_UNUSED_VAR( k );
-    GEOSX_ERROR( "getBulkModulus() not implemented for this model" );
+    GEOSX_ERROR( "getBulkModulus() is not implemented for this model" );
 
     return 0;
   }
@@ -141,7 +141,7 @@ public:
   virtual real64 getC11( localIndex const k ) const
   {
     GEOSX_UNUSED_VAR( k );
-    GEOSX_ERROR( "getC11() not implemented for this model" );
+    GEOSX_ERROR( "getC11() is not implemented for this model" );
 
     return 0;
   }
@@ -155,7 +155,7 @@ public:
   virtual real64 getC12( localIndex const k ) const
   {
     GEOSX_UNUSED_VAR( k );
-    GEOSX_ERROR( "getC12() not implemented for this model" );
+    GEOSX_ERROR( "getC12() is not implemented for this model" );
 
     return 0;
   }
@@ -169,7 +169,7 @@ public:
   virtual real64 getC13( localIndex const k ) const
   {
     GEOSX_UNUSED_VAR( k );
-    GEOSX_ERROR( "getC13() not implemented for this model" );
+    GEOSX_ERROR( "getC13() is not implemented for this model" );
 
     return 0;
   }
@@ -183,7 +183,7 @@ public:
   virtual real64 getC22( localIndex const k ) const
   {
     GEOSX_UNUSED_VAR( k );
-    GEOSX_ERROR( "getC22() not implemented for this model" );
+    GEOSX_ERROR( "getC22() is not implemented for this model" );
 
     return 0;
   }
@@ -197,7 +197,7 @@ public:
   virtual real64 getC23( localIndex const k ) const
   {
     GEOSX_UNUSED_VAR( k );
-    GEOSX_ERROR( "getC23() not implemented for this model" );
+    GEOSX_ERROR( "getC23() is not implemented for this model" );
 
     return 0;
   }
@@ -211,7 +211,7 @@ public:
   virtual real64 getC33( localIndex const k ) const
   {
     GEOSX_UNUSED_VAR( k );
-    GEOSX_ERROR( "getC33() not implemented for this model" );
+    GEOSX_ERROR( "getC33() is not implemented for this model" );
 
     return 0;
   }
@@ -225,7 +225,7 @@ public:
   virtual real64 getC44( localIndex const k ) const
   {
     GEOSX_UNUSED_VAR( k );
-    GEOSX_ERROR( "getC44() not implemented for this model" );
+    GEOSX_ERROR( "getC44() is not implemented for this model" );
 
     return 0;
   }
@@ -239,7 +239,7 @@ public:
   virtual real64 getC55( localIndex const k ) const
   {
     GEOSX_UNUSED_VAR( k );
-    GEOSX_ERROR( "getC55() not implemented for this model" );
+    GEOSX_ERROR( "getC55() is not implemented for this model" );
 
     return 0;
   }
@@ -253,7 +253,7 @@ public:
   virtual real64 getC66( localIndex const k ) const
   {
     GEOSX_UNUSED_VAR( k );
-    GEOSX_ERROR( "getC66() not implemented for this model" );
+    GEOSX_ERROR( "getC66() is not implemented for this model" );
 
     return 0;
   }

--- a/src/coreComponents/constitutive/solid/porosity/BiotPorosity.cpp
+++ b/src/coreComponents/constitutive/solid/porosity/BiotPorosity.cpp
@@ -34,6 +34,10 @@ BiotPorosity::BiotPorosity( string const & name, Group * const parent ):
     setInputFlag( InputFlags::REQUIRED ).
     setDescription( "Grain bulk modulus" );
 
+  registerWrapper( viewKeyStruct::grainShearModulusString(), &m_grainShearModulus ).
+    setInputFlag( InputFlags::OPTIONAL ). //TODO change to REQUIRED after modifying the xml
+    setDescription( "Grain shear modulus" );
+
   registerWrapper( viewKeyStruct::biotCoefficientString(), &m_biotCoefficient ).
     setDescription( "Biot coefficient." );
 }

--- a/src/coreComponents/constitutive/solid/porosity/BiotPorosity.hpp
+++ b/src/coreComponents/constitutive/solid/porosity/BiotPorosity.hpp
@@ -21,6 +21,7 @@
 
 #include "PorosityBase.hpp"
 #include "LvArray/src/tensorOps.hpp"
+#include "constitutive/solid/PropertyConversions.hpp"
 
 namespace geosx
 {
@@ -50,13 +51,15 @@ public:
                        arrayView2d< real64 > const & dPorosity_dPressure,
                        arrayView1d< real64 > const & referencePorosity,
                        arrayView1d< real64 > const & biotCoefficient,
-                       real64 const & grainBulkModulus ):
+                       real64 const & grainBulkModulus,
+                       real64 const & grainShearModulus ):
     PorosityBaseUpdates( newPorosity,
                          oldPorosity,
                          dPorosity_dPressure,
                          referencePorosity ),
     m_biotCoefficient( biotCoefficient ),
-    m_grainBulkModulus( grainBulkModulus )
+    m_grainBulkModulus( grainBulkModulus ),
+    m_grainShearModulus( grainShearModulus )
   {}
 
 
@@ -89,13 +92,74 @@ public:
   void updateBiotCoefficient( localIndex const k,
                               real64 const bulkModulus ) const
   {
-    m_biotCoefficient[k] = 1 - bulkModulus / m_grainBulkModulus;
+    m_biotCoefficient[k] = 1.0 - bulkModulus / m_grainBulkModulus;
+  }
+
+  /**
+   * @brief update transversely isotropic Biot's tensor.
+   * @param c11 (1,1) component of the stiffness matrix
+   * @param c12 (1,2) component of the stiffness matrix
+   * @param c13 (1,3) component of the stiffness matrix
+   * @param c33 (3,3) component of the stiffness matrix
+   */
+  GEOSX_HOST_DEVICE
+  void updateBiotTensor( localIndex const k,
+                         real64 const c11,
+                         real64 const c12,
+                         real64 const c13,
+                         real64 const c33 ) const
+  {
+    // Grain compliance tensor (isotropic grain is assumed)
+    real64 grainPoissonRatio = conversions::BulkModAndShearMod::
+                                 toPoissonRatio( m_grainBulkModulus, m_grainShearModulus );
+
+    real64 grainYoungModulus = conversions::BulkModAndShearMod::
+                                 toYoungsMod( m_grainBulkModulus, m_grainShearModulus );
+
+    real64 s11Grain = 1.0 / grainYoungModulus;
+    real64 s12Grain = -grainPoissonRatio / grainYoungModulus;
+    real64 s13Grain = s12Grain;
+    real64 s33Grain = s11Grain;
+
+    // Components of Biot's matrix
+    m_b11[k] = 1.0 - ( s11Grain + s12Grain ) * ( c11 + c12 )
+               - s13Grain * ( c11 + c12 + 2.0 * c13 )
+               - s33Grain * c13;
+
+    m_b33[k] = 1.0 - 2.0 * s11Grain * c13
+               - 2.0 * s12Grain * c13
+               - 2.0 * s13Grain * ( c13 + c33 )
+               - s33Grain * c33;
+
+    m_b22[k] = m_b11[k];
+  }
+
+  /**
+   * @brief Biot's coefficient is approximated by the average of the Biot's tensor diagonal.
+   */
+  GEOSX_HOST_DEVICE
+  void updateBiotCoefficient( localIndex const k,
+                              real64 const c11,
+                              real64 const c12,
+                              real64 const c13,
+                              real64 const c33 ) const
+  {
+    updateBiotTensor( k, c11, c12, c13, c33 );
+
+    m_biotCoefficient[k] = ( m_b11[k] + m_b22[k] + m_b33[k] ) / 3.0;
   }
 
 protected:
+
   arrayView1d< real64 > m_biotCoefficient;
 
   real64 m_grainBulkModulus;
+
+  real64 m_grainShearModulus;
+
+  arrayView1d< real64 > m_b11; ///< (1,1) element of TI Biot's matrix
+  arrayView1d< real64 > m_b22; ///< (2,2) element of TI Biot's matrix
+  arrayView1d< real64 > m_b33; ///< (3,3) element of TI Biot's matrix
 };
 
 
@@ -120,8 +184,7 @@ public:
   {
     static constexpr char const * biotCoefficientString() { return "biotCoefficient"; }
     static constexpr char const * grainBulkModulusString() { return "grainBulkModulus"; }
-
-
+    static constexpr char const * grainShearModulusString() { return "grainShearModulus"; }
   } viewKeys;
 
   using KernelWrapper = BiotPorosityUpdates;
@@ -137,7 +200,8 @@ public:
                           m_dPorosity_dPressure,
                           m_referencePorosity,
                           m_biotCoefficient,
-                          m_grainBulkModulus );
+                          m_grainBulkModulus,
+                          m_grainShearModulus );
   }
 
 
@@ -146,7 +210,9 @@ protected:
 
   array1d< real64 > m_biotCoefficient;
 
-  real64 m_grainBulkModulus;
+  real64 m_grainBulkModulus; ///< Bulk modulus of the solid grain
+
+  real64 m_grainShearModulus; ///< Shear modulus of the solid grain
 };
 
 }/* namespace constitutive */

--- a/src/coreComponents/constitutive/solid/porosity/BiotPorosity.hpp
+++ b/src/coreComponents/constitutive/solid/porosity/BiotPorosity.hpp
@@ -117,7 +117,7 @@ public:
                                        toYoungsMod( m_grainBulkModulus, m_grainShearModulus );
 
     real64 const s11Grain = 1.0 / grainYoungModulus;
-    real64 const s12Grain = - grainPoissonRatio / grainYoungModulus;
+    real64 const s12Grain = -grainPoissonRatio / grainYoungModulus;
     real64 const s13Grain = s12Grain;
     real64 const s33Grain = s11Grain;
 

--- a/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoromechanicsSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoromechanicsSolver.cpp
@@ -21,6 +21,7 @@
 
 #include "common/DataLayouts.hpp"
 #include "constitutive/ConstitutiveManager.hpp"
+#include "constitutive/solid/PorousElasticTransverseIsotropic.hpp"
 #include "constitutive/solid/PorousSolid.hpp"
 #include "constitutive/fluid/SingleFluidBase.hpp"
 #include "discretizationMethods/NumericalMethodsManager.hpp"

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolver.cpp
@@ -22,6 +22,7 @@
 
 #include "common/DataLayouts.hpp"
 #include "constitutive/ConstitutiveManager.hpp"
+#include "constitutive/solid/PorousElasticTransverseIsotropic.hpp"
 #include "constitutive/solid/PorousSolid.hpp"
 #include "constitutive/fluid/SingleFluidBase.hpp"
 #include "discretizationMethods/NumericalMethodsManager.hpp"


### PR DESCRIPTION
This PR adds a function for computing Biot's tensor from the drained tiffness of the porous rock and the elastic moduli of the solid grain. This address an issues listed in #1508.  An approximation for Biot's coefficient of transversely isotropic rock is also given. 