### PR TITLE
Refactor PAMELA field import

### DIFF
--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -665,15 +665,18 @@ int MpiWrapper::allGather( arrayView1d< T const > const & sendValues,
 template< typename T >
 int MpiWrapper::allReduce( T const * const sendbuf,
                            T * const recvbuf,
-                           int count,
+                           int const count,
                            MPI_Op MPI_PARAM( op ),
                            MPI_Comm MPI_PARAM( comm ) )
 {
 #ifdef GEOSX_USE_MPI
   MPI_Datatype const MPI_TYPE = getMpiType< T >();
-  return MPI_Allreduce( sendbuf, recvbuf, count, MPI_TYPE, op, comm );
+  return MPI_Allreduce( sendbuf == recvbuf ? MPI_IN_PLACE : sendbuf, recvbuf, count, MPI_TYPE, op, comm );
 #else
-  memcpy( recvbuf, sendbuf, count*sizeof(T) );
+  if( sendbuf != recvbuf )
+  {
+    memcpy( recvbuf, sendbuf, count * sizeof( T ) );
+  }
   return 0;
 #endif
 }

--- a/src/coreComponents/constitutive/permeability/CarmanKozenyPermeability.cpp
+++ b/src/coreComponents/constitutive/permeability/CarmanKozenyPermeability.cpp
@@ -51,12 +51,10 @@ CarmanKozenyPermeability::deliverClone( string const & name,
 void CarmanKozenyPermeability::allocateConstitutiveData( dataRepository::Group & parent,
                                                          localIndex const numConstitutivePointsPerParentIndex )
 {
-  m_dPerm_dPorosity.resize( 0, 3 );
+  // NOTE: enforcing 1 quadrature point
+  m_dPerm_dPorosity.resize( 0, 1, 3 );
   PermeabilityBase::allocateConstitutiveData( parent, numConstitutivePointsPerParentIndex );
 }
-
-void CarmanKozenyPermeability::postProcessInput()
-{}
 
 REGISTER_CATALOG_ENTRY( ConstitutiveBase, CarmanKozenyPermeability, string const &, Group * const )
 

--- a/src/coreComponents/constitutive/permeability/CarmanKozenyPermeability.hpp
+++ b/src/coreComponents/constitutive/permeability/CarmanKozenyPermeability.hpp
@@ -31,9 +31,9 @@ class CarmanKozenyPermeabilityUpdate : public PermeabilityBaseUpdate
 {
 public:
 
-  CarmanKozenyPermeabilityUpdate( arrayView2d< real64 > const & permeability,
-                                  arrayView2d< real64 > const & dPerm_dPressure,
-                                  arrayView2d< real64 > const & dPerm_dPorosity,
+  CarmanKozenyPermeabilityUpdate( arrayView3d< real64 > const & permeability,
+                                  arrayView3d< real64 > const & dPerm_dPressure,
+                                  arrayView3d< real64 > const & dPerm_dPorosity,
                                   real64 const particleDiameter,
                                   real64 const sphericity )
     : PermeabilityBaseUpdate( permeability, dPerm_dPressure ),
@@ -52,17 +52,15 @@ public:
                                    localIndex const q,
                                    real64 const & porosity ) const override
   {
-    GEOSX_UNUSED_VAR( q ); // to do: perm will have to be define per quadrature point.
-
     compute( porosity,
-             m_permeability[k],
-             m_dPerm_dPorosity[k] );
+             m_permeability[k][q],
+             m_dPerm_dPorosity[k][q] );
   }
 
 private:
 
   /// dPermeability_dPorosity
-  arrayView2d< real64 > m_dPerm_dPorosity;
+  arrayView3d< real64 > m_dPerm_dPorosity;
 
   /// Particle diameter
   real64 m_particleDiameter;
@@ -76,9 +74,8 @@ private:
 class CarmanKozenyPermeability : public PermeabilityBase
 {
 public:
-  CarmanKozenyPermeability( string const & name, Group * const parent );
 
-  virtual ~CarmanKozenyPermeability() override = default;
+  CarmanKozenyPermeability( string const & name, Group * const parent );
 
   std::unique_ptr< ConstitutiveBase > deliverClone( string const & name,
                                                     Group * const parent ) const override;
@@ -114,12 +111,10 @@ public:
     static constexpr char const * sphericityString() { return "sphericity"; }
   } viewKeys;
 
-protected:
-  virtual void postProcessInput() override;
-
 private:
+
   /// dPermeability_dPorosity
-  array2d< real64 > m_dPerm_dPorosity;
+  array3d< real64 > m_dPerm_dPorosity;
 
   /// Particle diameter
   real64 m_particleDiameter;
@@ -155,4 +150,4 @@ void CarmanKozenyPermeabilityUpdate::compute( real64 const & porosity,
 } /* namespace geosx */
 
 
-#endif //GEOSX_CONSTITUTIVE_PERMEABILITY_FRACTUREPERMEABILITY_HPP_
+#endif //GEOSX_CONSTITUTIVE_PERMEABILITY_CARMANKOZENYPERMEABILITY_HPP_

--- a/src/coreComponents/constitutive/permeability/ConstantPermeability.cpp
+++ b/src/coreComponents/constitutive/permeability/ConstantPermeability.cpp
@@ -36,8 +36,6 @@ ConstantPermeability::ConstantPermeability( string const & name, Group * const p
     setDescription( "xx, yy and zz components of a diagonal permeability tensor." );
 }
 
-ConstantPermeability::~ConstantPermeability() = default;
-
 std::unique_ptr< ConstitutiveBase >
 ConstantPermeability::deliverClone( string const & name,
                                     Group * const parent ) const
@@ -52,14 +50,16 @@ void ConstantPermeability::allocateConstitutiveData( dataRepository::Group & par
 {
   PermeabilityBase::allocateConstitutiveData( parent, numConstitutivePointsPerParentIndex );
 
-  for( localIndex ei=0; ei < parent.size(); ei++ )
+  for( localIndex ei = 0; ei < parent.size(); ++ei )
   {
-//    for( localIndex q=0; q < numConstitutivePointsPerParentIndex; q++ )
-//    {
-    m_permeability[ei][0] =  m_permeabilityComponents[0];
-    m_permeability[ei][1] =  m_permeabilityComponents[1];
-    m_permeability[ei][2] =  m_permeabilityComponents[2];
-//    }
+    // NOTE: enforcing 1 quadrature point
+    //for( localIndex q = 0; q < numConstitutivePointsPerParentIndex; ++q )
+    for( localIndex q = 0; q < 1; ++q )
+    {
+      m_permeability[ei][q][0] =  m_permeabilityComponents[0];
+      m_permeability[ei][q][1] =  m_permeabilityComponents[1];
+      m_permeability[ei][q][2] =  m_permeabilityComponents[2];
+    }
   }
 }
 

--- a/src/coreComponents/constitutive/permeability/ConstantPermeability.hpp
+++ b/src/coreComponents/constitutive/permeability/ConstantPermeability.hpp
@@ -31,8 +31,8 @@ class ConstantPermeabilityUpdate : public PermeabilityBaseUpdate
 {
 public:
 
-  ConstantPermeabilityUpdate( arrayView2d< real64 > const & permeability,
-                              arrayView2d< real64 > const & dPerm_dPressure )
+  ConstantPermeabilityUpdate( arrayView3d< real64 > const & permeability,
+                              arrayView3d< real64 > const & dPerm_dPressure )
     : PermeabilityBaseUpdate( permeability, dPerm_dPressure )
   {}
 
@@ -44,9 +44,8 @@ private:
 class ConstantPermeability : public PermeabilityBase
 {
 public:
-  ConstantPermeability( string const & name, Group * const parent );
 
-  virtual ~ConstantPermeability() override;
+  ConstantPermeability( string const & name, Group * const parent );
 
   std::unique_ptr< ConstitutiveBase > deliverClone( string const & name,
                                                     Group * const parent ) const override;
@@ -78,9 +77,11 @@ public:
   } viewKeys;
 
 protected:
+
   virtual void postProcessInput() override;
 
 private:
+
   R1Tensor m_permeabilityComponents;
 
 };

--- a/src/coreComponents/constitutive/permeability/ParallelPlatesPermeability.cpp
+++ b/src/coreComponents/constitutive/permeability/ParallelPlatesPermeability.cpp
@@ -43,7 +43,8 @@ ParallelPlatesPermeability::deliverClone( string const & name,
 void ParallelPlatesPermeability::allocateConstitutiveData( dataRepository::Group & parent,
                                                            localIndex const numConstitutivePointsPerParentIndex )
 {
-  m_dPerm_dAperture.resize( 0, 3 );
+  // NOTE: enforcing 1 quadrature point
+  m_dPerm_dAperture.resize( 0, 1, 3 );
 
   PermeabilityBase::allocateConstitutiveData( parent, numConstitutivePointsPerParentIndex );
 }

--- a/src/coreComponents/constitutive/permeability/ParallelPlatesPermeability.hpp
+++ b/src/coreComponents/constitutive/permeability/ParallelPlatesPermeability.hpp
@@ -31,9 +31,9 @@ class ParallelPlatesPermeabilityUpdate : public PermeabilityBaseUpdate
 {
 public:
 
-  ParallelPlatesPermeabilityUpdate( arrayView2d< real64 > const & permeability,
-                                    arrayView2d< real64 > const & dPerm_dPressure,
-                                    arrayView2d< real64 > const & dPerm_dAperture )
+  ParallelPlatesPermeabilityUpdate( arrayView3d< real64 > const & permeability,
+                                    arrayView3d< real64 > const & dPerm_dPressure,
+                                    arrayView3d< real64 > const & dPerm_dAperture )
     : PermeabilityBaseUpdate( permeability, dPerm_dPressure ),
     m_dPerm_dAperture( dPerm_dAperture )
   {}
@@ -48,14 +48,14 @@ public:
                            localIndex const q,
                            real64 const & effectiveAperture ) const override
   {
-    GEOSX_UNUSED_VAR( q );
-
     compute( effectiveAperture,
-             m_permeability[k],
-             m_dPerm_dAperture[k] );
+             m_permeability[k][q],
+             m_dPerm_dAperture[k][q] );
   }
+
 private:
-  arrayView2d< real64 > m_dPerm_dAperture;
+
+  arrayView3d< real64 > m_dPerm_dAperture;
 
 };
 
@@ -63,9 +63,8 @@ private:
 class ParallelPlatesPermeability : public PermeabilityBase
 {
 public:
-  ParallelPlatesPermeability( string const & name, Group * const parent );
 
-  virtual ~ParallelPlatesPermeability() override = default;
+  ParallelPlatesPermeability( string const & name, Group * const parent );
 
   std::unique_ptr< ConstitutiveBase > deliverClone( string const & name,
                                                     Group * const parent ) const override;
@@ -96,7 +95,8 @@ public:
   {} viewKeys;
 
 private:
-  array2d< real64 > m_dPerm_dAperture;
+
+  array3d< real64 > m_dPerm_dAperture;
 
 };
 

--- a/src/coreComponents/constitutive/permeability/PermeabilityBase.cpp
+++ b/src/coreComponents/constitutive/permeability/PermeabilityBase.cpp
@@ -43,8 +43,6 @@ PermeabilityBase::PermeabilityBase( string const & name, Group * const parent ):
     setApplyDefaultValue( 0.0 );     // will be overwritten
 }
 
-PermeabilityBase::~PermeabilityBase() = default;
-
 std::unique_ptr< ConstitutiveBase >
 PermeabilityBase::deliverClone( string const & name,
                                 Group * const parent ) const
@@ -55,14 +53,12 @@ PermeabilityBase::deliverClone( string const & name,
 void PermeabilityBase::allocateConstitutiveData( dataRepository::Group & parent,
                                                  localIndex const numConstitutivePointsPerParentIndex )
 {
-  m_permeability.resize( 0, 3 );
-  m_dPerm_dPressure.resize( 0, 3 );
+  // NOTE: enforcing 1 quadrature point
+  m_permeability.resize( 0, 1, 3 );
+  m_dPerm_dPressure.resize( 0, 1, 3 );
 
   ConstitutiveBase::allocateConstitutiveData( parent, numConstitutivePointsPerParentIndex );
 }
-
-void PermeabilityBase::postProcessInput()
-{}
 
 REGISTER_CATALOG_ENTRY( ConstitutiveBase, PermeabilityBase, string const &, Group * const )
 }

--- a/src/coreComponents/constitutive/permeability/PermeabilityBase.hpp
+++ b/src/coreComponents/constitutive/permeability/PermeabilityBase.hpp
@@ -81,24 +81,23 @@ public:
 
 protected:
 
-  PermeabilityBaseUpdate( arrayView2d< real64 > const & permeability,
-                          arrayView2d< real64 > const & dPerm_dPressure )
+  PermeabilityBaseUpdate( arrayView3d< real64 > const & permeability,
+                          arrayView3d< real64 > const & dPerm_dPressure )
     : m_permeability( permeability ),
     m_dPerm_dPressure( dPerm_dPressure )
   {}
 
-  arrayView2d< real64 > m_permeability;
+  arrayView3d< real64 > m_permeability;
 
-  arrayView2d< real64 > m_dPerm_dPressure;
+  arrayView3d< real64 > m_dPerm_dPressure;
 };
 
 
 class PermeabilityBase : public ConstitutiveBase
 {
 public:
-  PermeabilityBase( string const & name, Group * const parent );
 
-  virtual ~PermeabilityBase() override;
+  PermeabilityBase( string const & name, Group * const parent );
 
   std::unique_ptr< ConstitutiveBase > deliverClone( string const & name,
                                                     Group * const parent ) const override;
@@ -110,9 +109,9 @@ public:
 
   virtual string getCatalogName() const override { return catalogName(); }
 
-  arrayView2d< real64 const > const permeability() const { return m_permeability; }
+  arrayView3d< real64 const > permeability() const { return m_permeability; }
 
-  arrayView2d< real64 const > const dPerm_dPressure() const { return m_dPerm_dPressure; }
+  arrayView3d< real64 const > dPerm_dPressure() const { return m_dPerm_dPressure; }
 
   struct viewKeyStruct : public ConstitutiveBase::viewKeyStruct
   {
@@ -122,11 +121,10 @@ public:
   } viewKeys;
 
 protected:
-  virtual void postProcessInput() override;
 
-  array2d< real64 > m_permeability;
+  array3d< real64 > m_permeability;
 
-  array2d< real64 > m_dPerm_dPressure;
+  array3d< real64 > m_dPerm_dPressure;
 };
 
 }/* namespace constitutive */

--- a/src/coreComponents/constitutive/permeability/StrainDependentPermeability.cpp
+++ b/src/coreComponents/constitutive/permeability/StrainDependentPermeability.cpp
@@ -31,8 +31,6 @@ StrainDependentPermeability::StrainDependentPermeability( string const & name, G
   PermeabilityBase( name, parent )
 {}
 
-StrainDependentPermeability::~StrainDependentPermeability() = default;
-
 std::unique_ptr< ConstitutiveBase >
 StrainDependentPermeability::deliverClone( string const & name,
                                            Group * const parent ) const
@@ -45,9 +43,6 @@ void StrainDependentPermeability::allocateConstitutiveData( dataRepository::Grou
 {
   PermeabilityBase::allocateConstitutiveData( parent, numConstitutivePointsPerParentIndex );
 }
-
-void StrainDependentPermeability::postProcessInput()
-{}
 
 REGISTER_CATALOG_ENTRY( ConstitutiveBase, StrainDependentPermeability, string const &, Group * const )
 

--- a/src/coreComponents/constitutive/permeability/StrainDependentPermeability.hpp
+++ b/src/coreComponents/constitutive/permeability/StrainDependentPermeability.hpp
@@ -31,8 +31,8 @@ class StrainDependentPermeabilityUpdate : public PermeabilityBaseUpdate
 {
 public:
 
-  StrainDependentPermeabilityUpdate( arrayView2d< real64 > const & permeability,
-                                     arrayView2d< real64 > const & dPerm_dPressure )
+  StrainDependentPermeabilityUpdate( arrayView3d< real64 > const & permeability,
+                                     arrayView3d< real64 > const & dPerm_dPressure )
     : PermeabilityBaseUpdate( permeability, dPerm_dPressure )
   {}
 
@@ -56,9 +56,8 @@ private:
 class StrainDependentPermeability : public PermeabilityBase
 {
 public:
-  StrainDependentPermeability( string const & name, Group * const parent );
 
-  virtual ~StrainDependentPermeability() override;
+  StrainDependentPermeability( string const & name, Group * const parent );
 
   std::unique_ptr< ConstitutiveBase > deliverClone( string const & name,
                                                     Group * const parent ) const override;
@@ -82,11 +81,6 @@ public:
     return KernelWrapper( m_permeability,
                           m_dPerm_dPressure );
   }
-
-
-
-protected:
-  virtual void postProcessInput() override;
 
 private:
 

--- a/src/coreComponents/finiteVolume/TwoPointFluxApproximation.cpp
+++ b/src/coreComponents/finiteVolume/TwoPointFluxApproximation.cpp
@@ -72,8 +72,8 @@ void TwoPointFluxApproximation::computeCellStencil( MeshLevel & mesh ) const
   ElementRegionManager::ElementViewAccessor< arrayView2d< real64 const > > const elemCenter =
     elemManager.constructArrayViewAccessor< real64, 2 >( CellBlock::viewKeyStruct::elementCenterString() );
 
-  ElementRegionManager::ElementViewAccessor< arrayView2d< real64 const > > const coefficient =
-    elemManager.constructMaterialArrayViewAccessor< real64, 2 >( m_coeffName,
+  ElementRegionManager::ElementViewAccessor< arrayView3d< real64 const > > const coefficient =
+    elemManager.constructMaterialArrayViewAccessor< real64, 3 >( m_coeffName,
                                                                  m_targetRegions,
                                                                  m_coefficientModelNames );
 
@@ -156,13 +156,13 @@ void TwoPointFluxApproximation::computeCellStencil( MeshLevel & mesh ) const
 
       real64 const c2fDistance = LvArray::tensorOps::normalize< 3 >( cellToFaceVec );
 
-      LvArray::tensorOps::hadamardProduct< 3 >( faceConormal, coefficient[er][esr][ei], faceNormal );
+      LvArray::tensorOps::hadamardProduct< 3 >( faceConormal, coefficient[er][esr][ei][0], faceNormal );
       real64 halfWeight = LvArray::tensorOps::AiBi< 3 >( cellToFaceVec, faceConormal );
 
       // correct negative weight issue arising from non-K-orthogonal grids
       if( halfWeight < 0.0 )
       {
-        LvArray::tensorOps::hadamardProduct< 3 >( faceConormal, coefficient[er][esr][ei], cellToFaceVec );
+        LvArray::tensorOps::hadamardProduct< 3 >( faceConormal, coefficient[er][esr][ei][0], cellToFaceVec );
         halfWeight = LvArray::tensorOps::AiBi< 3 >( cellToFaceVec, faceConormal );
       }
 
@@ -218,8 +218,8 @@ void TwoPointFluxApproximation::addToFractureStencil( MeshLevel & mesh,
   ElementRegionManager::ElementViewAccessor< arrayView1d< integer const > > const elemGhostRank =
     elemManager.constructArrayViewAccessor< integer, 1 >( ObjectManagerBase::viewKeyStruct::ghostRankString() );
 
-  ElementRegionManager::ElementViewAccessor< arrayView2d< real64 const > > const coefficient =
-    elemManager.constructMaterialArrayViewAccessor< real64, 2 >( m_coeffName,
+  ElementRegionManager::ElementViewAccessor< arrayView3d< real64 const > > const coefficient =
+    elemManager.constructMaterialArrayViewAccessor< real64, 3 >( m_coeffName,
                                                                  m_targetRegions,
                                                                  m_coefficientModelNames );
 
@@ -602,7 +602,7 @@ void TwoPointFluxApproximation::addToFractureStencil( MeshLevel & mesh,
 
             real64 const c2fDistance = LvArray::tensorOps::normalize< 3 >( cellToFaceVec );
 
-            LvArray::tensorOps::hadamardProduct< 3 >( faceConormal, coefficient[er][esr][ei], faceNormal[faceIndex] );
+            LvArray::tensorOps::hadamardProduct< 3 >( faceConormal, coefficient[er][esr][ei][0], faceNormal[faceIndex] );
             real64 const ht = LvArray::tensorOps::AiBi< 3 >( cellToFaceVec, faceConormal ) * faceArea[faceIndex] / c2fDistance;
 
             // the trans multiplier here is that of the original face (copied when the face was split)
@@ -729,8 +729,8 @@ void TwoPointFluxApproximation::addEDFracToFractureStencil( MeshLevel & mesh,
   arrayView1d< real64 const > const connectivityIndex = fractureSubRegion.getConnectivityIndex();
 
 
-  ElementRegionManager::ElementViewAccessor< arrayView2d< real64 const > > const coeffTensor =
-    elemManager.constructMaterialArrayViewAccessor< real64, 2 >( m_coeffName,
+  ElementRegionManager::ElementViewAccessor< arrayView3d< real64 const > > const coeffTensor =
+    elemManager.constructMaterialArrayViewAccessor< real64, 3 >( m_coeffName,
                                                                  m_targetRegions,
                                                                  m_coefficientModelNames );
 
@@ -756,7 +756,7 @@ void TwoPointFluxApproximation::addEDFracToFractureStencil( MeshLevel & mesh,
       localIndex const ei  = surfaceElementsToCells.m_toElementIndex[kes][0];
 
       // Here goes EDFM transmissibility computation.
-      real64 const avPerm = LvArray::tensorOps::l2Norm< 3 >( coeffTensor[er][esr][ei] );
+      real64 const avPerm = LvArray::tensorOps::l2Norm< 3 >( coeffTensor[er][esr][ei][0] );
       real64 const ht = connectivityIndex[kes] * avPerm;   // Using matrix perm coz assuming fracture is highly permeable for now.
 
       //
@@ -809,8 +809,8 @@ void TwoPointFluxApproximation::computeBoundaryStencil( MeshLevel & mesh,
   ElementRegionManager::ElementViewAccessor< arrayView1d< integer const > > const elemGhostRank =
     elemManager.constructArrayViewAccessor< integer, 1 >( ObjectManagerBase::viewKeyStruct::ghostRankString() );
 
-  ElementRegionManager::ElementViewAccessor< arrayView2d< real64 const > > const coefficient =
-    elemManager.constructMaterialArrayViewAccessor< real64, 2 >( m_coeffName,
+  ElementRegionManager::ElementViewAccessor< arrayView3d< real64 const > > const coefficient =
+    elemManager.constructMaterialArrayViewAccessor< real64, 3 >( m_coeffName,
                                                                  m_targetRegions,
                                                                  m_coefficientModelNames );
 
@@ -875,13 +875,13 @@ void TwoPointFluxApproximation::computeBoundaryStencil( MeshLevel & mesh,
 
       real64 const c2fDistance = LvArray::tensorOps::normalize< 3 >( cellToFaceVec );
 
-      LvArray::tensorOps::hadamardProduct< 3 >( faceConormal, coefficient[er][esr][ei], faceNormal );
+      LvArray::tensorOps::hadamardProduct< 3 >( faceConormal, coefficient[er][esr][ei][0], faceNormal );
       real64 faceWeight = LvArray::tensorOps::AiBi< 3 >( cellToFaceVec, faceConormal );
 
       // correct negative weight issue arising from non-K-orthogonal grids
       if( faceWeight < 0.0 )
       {
-        LvArray::tensorOps::hadamardProduct< 3 >( faceConormal, coefficient[er][esr][ei], cellToFaceVec );
+        LvArray::tensorOps::hadamardProduct< 3 >( faceConormal, coefficient[er][esr][ei][0], cellToFaceVec );
         faceWeight = LvArray::tensorOps::AiBi< 3 >( cellToFaceVec, faceConormal );
       }
 

--- a/src/coreComponents/mainInterface/ProblemManager.cpp
+++ b/src/coreComponents/mainInterface/ProblemManager.cpp
@@ -164,6 +164,8 @@ void ProblemManager::problemSetup()
   registerDataOnMeshRecursive( getDomainPartition().getMeshBodies() );
 
   initialize();
+
+  importFields();
 }
 
 
@@ -558,6 +560,19 @@ void ProblemManager::generateMesh()
 }
 
 
+void ProblemManager::importFields()
+{
+  GEOSX_MARK_FUNCTION;
+  DomainPartition & domain = getDomainPartition();
+  MeshManager & meshManager = this->getGroup< MeshManager >( groupKeys.meshManager );
+
+  meshManager.forSubGroups< MeshGeneratorBase >( [&]( MeshGeneratorBase & generator )
+  {
+    generator.importFields( domain );
+    generator.freeResources();
+  } );
+}
+
 void ProblemManager::applyNumericalMethods()
 {
 
@@ -569,6 +584,7 @@ void ProblemManager::applyNumericalMethods()
 
   setRegionQuadrature( meshBodies, constitutiveManager, regionQuadrature );
 }
+
 
 map< std::pair< string, string >, localIndex > ProblemManager::calculateRegionQuadrature( Group & meshBodies )
 {
@@ -691,7 +707,6 @@ void ProblemManager::setRegionQuadrature( Group & meshBodies,
     }
   }
 }
-
 
 bool ProblemManager::runSimulation()
 {

--- a/src/coreComponents/mainInterface/ProblemManager.hpp
+++ b/src/coreComponents/mainInterface/ProblemManager.hpp
@@ -113,6 +113,11 @@ public:
   void generateMesh();
 
   /**
+   * @brief Import field data from external sources (e.g. mesh generator).
+   */
+  void importFields();
+
+  /**
    * @brief Allocates constitutive relations according to the discretizations
    *   on each subregion.
    */

--- a/src/coreComponents/mesh/MeshManager.cpp
+++ b/src/coreComponents/mesh/MeshManager.cpp
@@ -75,5 +75,13 @@ void MeshManager::generateMeshLevels( DomainPartition & domain )
   } );
 }
 
+void MeshManager::importFields( DomainPartition & domain )
+{
+  forSubGroups< MeshGeneratorBase >( [&]( MeshGeneratorBase & meshGen )
+  {
+    meshGen.importFields( domain );
+  } );
+}
+
 
 } /* namespace geosx */

--- a/src/coreComponents/mesh/MeshManager.hpp
+++ b/src/coreComponents/mesh/MeshManager.hpp
@@ -58,15 +58,21 @@ public:
 
   /**
    * @brief Generate the meshes of the physical DomainPartition.
-   * @param[in] domain a pointer to the physical DomainPartition
+   * @param[in] domain a reference to the physical domain
    */
   void generateMeshes( DomainPartition & domain );
 
   /**
    * @brief Generate the different mesh levels in a MeshBody of the domain.
-   * @param[in] domain a pointer to the physical DomainPartition
+   * @param[in] domain a reference to the physical domain
    */
   void generateMeshLevels( DomainPartition & domain );
+
+  /**
+   * @brief Import data from external sources (e.g. dataset that comes with a mesh).
+   * @param[in] domain a reference to the physical domain
+   */
+  void importFields( DomainPartition & domain );
 
 private:
 

--- a/src/coreComponents/mesh/PerforationData.cpp
+++ b/src/coreComponents/mesh/PerforationData.cpp
@@ -110,7 +110,7 @@ void decideWellDirection( VEC_TYPE const & topToBottomVec,
 
 void PerforationData::computeWellTransmissibility( MeshLevel const & mesh,
                                                    WellElementSubRegion const & wellElemSubRegion,
-                                                   array1d< array1d< arrayView2d< real64 const > > > const & perm )
+                                                   array1d< array1d< arrayView3d< real64 const > > > const & perm )
 {
   NodeManager const & nodeManager = mesh.getNodeManager();
   arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const & X = nodeManager.referencePosition();
@@ -126,9 +126,9 @@ void PerforationData::computeWellTransmissibility( MeshLevel const & mesh,
     {
       WellElementRegion const & wellRegion = dynamicCast< WellElementRegion const & >( wellElemSubRegion.getParent().getParent() );
       GEOSX_LOG_RANK_IF( isZero( m_wellTransmissibility[iperf] ),
-                         "\n \nWarning! A perforation is defined with a zero transmissibility in " << wellRegion.getWellGeneratorName() << "! \n"
-                                                                                                   << "The simulation is going to proceed with this zero transmissibility,\n"
-                                                                                                   << "but a better strategy to shut down a perforation is to remove the <Perforation> block from the XML\n \n" );
+                         "\n \nWarning! A perforation is defined with a zero transmissibility in " << wellRegion.getWellGeneratorName() << "! \n" <<
+                         "The simulation is going to proceed with this zero transmissibility,\n" <<
+                         "but a better strategy to shut down a perforation is to remove the <Perforation> block from the XML\n \n" );
       continue;
     }
 
@@ -173,7 +173,7 @@ void PerforationData::computeWellTransmissibility( MeshLevel const & mesh,
     // check if this is a vertical well or a horizontal well
     // assign d1, d2, h, k1, and k2 accordingly
     decideWellDirection( topToBottomVec,
-                         dx, dy, dz, perm[er][esr][ei],
+                         dx, dy, dz, perm[er][esr][ei][0],
                          d1, d2, h, k1, k2 );
 
     real64 const k21 = k1 > 0

--- a/src/coreComponents/mesh/PerforationData.hpp
+++ b/src/coreComponents/mesh/PerforationData.hpp
@@ -193,7 +193,7 @@ public:
    */
   void computeWellTransmissibility( MeshLevel const & mesh,
                                     WellElementSubRegion const & wellElemSubRegion,
-                                    array1d< array1d< arrayView2d< real64 const > > > const & perm );
+                                    array1d< array1d< arrayView3d< real64 const > > > const & perm );
 
   ///@}
 

--- a/src/coreComponents/mesh/generators/MeshGeneratorBase.hpp
+++ b/src/coreComponents/mesh/generators/MeshGeneratorBase.hpp
@@ -73,7 +73,25 @@ public:
    * @param[in] domain the domain partition from which to construct the mesh object
    */
   virtual void generateMesh( DomainPartition & domain ) = 0;
+
+  /**
+   * @brief Import data from external sources (e.g. dataset that comes with a mesh).
+   * @param[in] domain the domain partition
+   */
+  virtual void importFields( DomainPartition & domain ) const
+  {
+    GEOSX_UNUSED_VAR( domain )
+  }
+
+  /**
+   * @brief Free internal resources associated with mesh/data import.
+   *
+   * This is relevant for mesh generators that load external mesh files.
+   * Once this method is called, they can release any memory allocated.
+   */
+  virtual void freeResources() {}
 };
+
 }
 
 #endif /* GEOSX_MESH_GENERATORS_MESHGENERATORBASE_HPP */

--- a/src/coreComponents/mesh/generators/PAMELAMeshGenerator.cpp
+++ b/src/coreComponents/mesh/generators/PAMELAMeshGenerator.cpp
@@ -18,31 +18,26 @@
 
 #include "PAMELAMeshGenerator.hpp"
 
-#include "Elements/Element.hpp"
-#include "MeshDataWriters/Variable.hpp"
+#include "codingUtilities/StringUtilities.hpp"
+#include "common/TypeDispatch.hpp"
 #include "mesh/DomainPartition.hpp"
+#include "mesh/MeshBody.hpp"
 
-#include <math.h>
-
-#include "mesh/mpiCommunications/PartitionBase.hpp"
-#include "mesh/mpiCommunications/SpatialPartition.hpp"
+// PAMELA includes
+#include "Elements/Element.hpp"
 #include "Mesh/MeshFactory.hpp"
-
+#include "MeshDataWriters/Variable.hpp"
 #include "MeshDataWriters/MeshParts.hpp"
 
-#include "mesh/MeshBody.hpp"
+#include <unordered_set>
 
 namespace geosx
 {
 using namespace dataRepository;
 
-/// TODO when we are going to port to c++17, we can remove that
-string const PAMELAMeshGenerator::DecodePAMELALabels::m_separator = "_";
-
 PAMELAMeshGenerator::PAMELAMeshGenerator( string const & name, Group * const parent ):
   MeshGeneratorBase( name, parent )
 {
-
   registerWrapper( viewKeyStruct::filePathString(), &m_filePath ).
     setInputFlag( InputFlags::REQUIRED ).
     setRestartFlags( RestartFlags::NO_WRITE ).
@@ -61,319 +56,435 @@ PAMELAMeshGenerator::PAMELAMeshGenerator( string const & name, Group * const par
     setDefaultValue( 0 ).setDescription( "0 : Z coordinate is upward, 1 : Z coordinate is downward" );
 }
 
-PAMELAMeshGenerator::~PAMELAMeshGenerator()
-{}
-
 void PAMELAMeshGenerator::postProcessInput()
 {
-  m_pamelaMesh =
-    std::unique_ptr< PAMELA::Mesh >
-      ( PAMELA::MeshFactory::makeMesh( m_filePath ) );
-  m_pamelaMesh->CreateFacesFromCells();
-  m_pamelaMesh->PerformPolyhedronPartitioning( PAMELA::ELEMENTS::FAMILY::POLYGON,
-                                               PAMELA::ELEMENTS::FAMILY::POLYGON );
-  m_pamelaMesh->CreateLineGroupWithAdjacency(
-    "TopologicalC2C",
-    m_pamelaMesh->getAdjacencySet()->get_TopologicalAdjacency( PAMELA::ELEMENTS::FAMILY::POLYHEDRON, PAMELA::ELEMENTS::FAMILY::POLYHEDRON,
-                                                               PAMELA::ELEMENTS::FAMILY::POLYGON ));
+  GEOSX_THROW_IF_NE_MSG( m_fieldsToImport.size(), m_fieldNamesInGEOSX.size(),
+                         "Mismatch between number of values in " << viewKeyStruct::fieldsToImportString() <<
+                         " and " << viewKeyStruct::fieldNamesInGEOSXString() << " attrabutes",
+                         InputError );
 }
 
-Group * PAMELAMeshGenerator::createChild( string const & GEOSX_UNUSED_PARAM( childKey ), string const & GEOSX_UNUSED_PARAM( childName ) )
+Group * PAMELAMeshGenerator::createChild( string const & childKey, string const & childName )
 {
-  return nullptr;
+  GEOSX_THROW( "Invalid child XML node " << childName << " of type " << childKey, InputError );
 }
 
-void PAMELAMeshGenerator::generateMesh( DomainPartition & domain )
+namespace
 {
-  GEOSX_LOG_RANK_0( "Writing into the GEOSX mesh data structure" );
-  domain.getMetisNeighborList() = m_pamelaMesh->getNeighborList();
-  Group & meshBodies = domain.getGroup( string( "MeshBodies" ));
-  MeshBody & meshBody = meshBodies.registerGroup< MeshBody >( this->getName() );
 
-  //TODO for the moment we only consider on mesh level "Level0"
-  MeshLevel & meshLevel0 = meshBody.registerGroup< MeshLevel >( string( "Level0" ));
-  NodeManager & nodeManager = meshLevel0.getNodeManager();
-  CellBlockManager & cellBlockManager = domain.getGroup< CellBlockManager >( keys::cellManager );
+string const & getNameSeparator()
+{
+  static string const separator( "_" );
+  return separator;
+}
 
+string makeRegionLabel( string const & regionName, string const & regionCellType )
+{
+  return regionName + getNameSeparator() + regionCellType;
+}
 
-  // Use the PartMap of PAMELA to get the mesh
-  auto const polyhedronPartMap = std::get< 0 >( PAMELA::getPolyhedronPartMap( m_pamelaMesh.get(), 0 ));
+/*!
+ * @brief Given the PAMELA Surface or Region label, return a simple unique name for GEOSX
+ * @details Surface labels in PAMELA are composed of different parts such as the index, the type of cells, etc.
+ * @param[in] pamelaLabel the surface or region label within PAMELA
+ * @return the name of the surface or the region
+ */
+string retrieveSurfaceOrRegionName( string const & pamelaLabel )
+{
+  string_array const splitLabel = stringutilities::tokenize( pamelaLabel, getNameSeparator() );
 
-  // Vertices are written first
+  // The PAMELA label looks like: PART00002_POLYGON_POLYGON_GROUP_Ovbd1_Ovbd2_14
+  // But we only want to keep Ovbd1_Ovbd2
+  // So we find the word GROUP, and then we keep what is after, except the last piece
+
+  auto const it = std::find( std::begin( splitLabel ), std::end( splitLabel ), "GROUP" );
+  GEOSX_THROW_IF( it == std::end( splitLabel ),
+                  "GEOSX assumes that PAMELA places the word GROUP before the region/surface name",
+                  InputError );
+  return stringutilities::join( std::next( it ), std::prev( std::end( splitLabel ) ), getNameSeparator() );
+}
+
+string const & getElementLabel( PAMELA::ELEMENTS::TYPE const type )
+{
+  static std::map< PAMELA::ELEMENTS::TYPE, string > const typeToLabelMap =
+  {
+    { PAMELA::ELEMENTS::TYPE::VTK_VERTEX, "VERTEX" },
+    { PAMELA::ELEMENTS::TYPE::VTK_LINE, "LINE" },
+    { PAMELA::ELEMENTS::TYPE::VTK_TRIANGLE, "TRIANGLE" },
+    { PAMELA::ELEMENTS::TYPE::VTK_QUAD, "QUAD" },
+    { PAMELA::ELEMENTS::TYPE::VTK_TETRA, "TETRA" },
+    { PAMELA::ELEMENTS::TYPE::VTK_HEXAHEDRON, "HEX" },
+    { PAMELA::ELEMENTS::TYPE::VTK_WEDGE, "WEDGE" },
+    { PAMELA::ELEMENTS::TYPE::VTK_PYRAMID, "PYRAMID" }
+  };
+  GEOSX_THROW_IF( typeToLabelMap.count( type ) == 0, "Unsupported PAMELA element type", std::runtime_error );
+  return typeToLabelMap.at( type );
+}
+
+ElementType toGeosxElementType( PAMELA::ELEMENTS::TYPE const type )
+{
+  switch( type )
+  {
+    case PAMELA::ELEMENTS::TYPE::VTK_LINE: return ElementType::Line;
+    case PAMELA::ELEMENTS::TYPE::VTK_TRIANGLE: return ElementType::Triangle;
+    case PAMELA::ELEMENTS::TYPE::VTK_QUAD: return ElementType::Quadrilateral;
+    case PAMELA::ELEMENTS::TYPE::VTK_TETRA: return ElementType::Tetrahedron;
+    case PAMELA::ELEMENTS::TYPE::VTK_PYRAMID: return ElementType::Pyramid;
+    case PAMELA::ELEMENTS::TYPE::VTK_WEDGE: return ElementType::Prism;
+    case PAMELA::ELEMENTS::TYPE::VTK_HEXAHEDRON: return ElementType::Hexahedron;
+    default:
+    {
+      GEOSX_THROW( "Unsupported PAMELA element type", std::runtime_error );
+    }
+  }
+}
+
+PAMELA::ELEMENTS::TYPE toPamelaElementType( ElementType const type )
+{
+  switch( type )
+  {
+    case ElementType::Line: return PAMELA::ELEMENTS::TYPE::VTK_LINE;
+    case ElementType::Triangle: return PAMELA::ELEMENTS::TYPE::VTK_TRIANGLE;
+    case ElementType::Quadrilateral: return PAMELA::ELEMENTS::TYPE::VTK_QUAD;
+    case ElementType::Tetrahedron: return PAMELA::ELEMENTS::TYPE::VTK_TETRA;
+    case ElementType::Pyramid: return PAMELA::ELEMENTS::TYPE::VTK_PYRAMID;
+    case ElementType::Prism: return PAMELA::ELEMENTS::TYPE::VTK_WEDGE;
+    case ElementType::Hexahedron: return PAMELA::ELEMENTS::TYPE::VTK_HEXAHEDRON;
+    default:
+    {
+      GEOSX_THROW( "Unsupported PAMELA element type", std::runtime_error );
+    }
+  }
+}
+
+std::vector< int > getPamelaNodeOrder( PAMELA::ELEMENTS::TYPE const type )
+{
+  switch( type )
+  {
+    case PAMELA::ELEMENTS::TYPE::VTK_LINE: return { 0, 1 };
+    case PAMELA::ELEMENTS::TYPE::VTK_TRIANGLE: return { 0, 1, 2 };
+    case PAMELA::ELEMENTS::TYPE::VTK_QUAD: return { };
+    case PAMELA::ELEMENTS::TYPE::VTK_TETRA: return { 0, 1, 2, 3 };
+    case PAMELA::ELEMENTS::TYPE::VTK_PYRAMID: return { 0, 1, 2, 3, 4 };
+    case PAMELA::ELEMENTS::TYPE::VTK_WEDGE: return { 0, 3, 1, 4, 2, 5 };
+    case PAMELA::ELEMENTS::TYPE::VTK_HEXAHEDRON: return { 0, 1, 3, 2, 4, 5, 7, 6 };
+    default:
+    {
+      GEOSX_THROW( "Unsupported PAMELA element type", std::runtime_error );
+    }
+  }
+}
+
+/// @return mesh length scale
+real64 importNodes( PAMELA::Mesh & srcMesh, // PAMELA is not const-correct,
+                    real64 const scaleFactor[3],
+                    NodeManager & nodeManager )
+{
+  nodeManager.resize( LvArray::integerConversion< localIndex >( srcMesh.get_PointCollection()->size_all() ) );
   arrayView2d< real64, nodes::REFERENCE_POSITION_USD > const & X = nodeManager.referencePosition();
-  nodeManager.resize( m_pamelaMesh->get_PointCollection()->size_all());
 
   arrayView1d< globalIndex > const & nodeLocalToGlobal = nodeManager.localToGlobalMap();
 
-  Group & nodeSets = nodeManager.sets();
-  SortedArray< localIndex > & allNodes  = nodeSets.registerWrapper< SortedArray< localIndex > >( string( "all" ) ).reference();
+  SortedArray< localIndex > & allNodes = nodeManager.sets().registerWrapper< SortedArray< localIndex > >( "all" ).reference();
 
-  real64 xMax[3] = { std::numeric_limits< real64 >::min() };
-  real64 xMin[3] = { std::numeric_limits< real64 >::max() };
+  constexpr real64 minReal = LvArray::NumericLimits< real64 >::min;
+  constexpr real64 maxReal = LvArray::NumericLimits< real64 >::max;
+  real64 xMin[3] = { maxReal, maxReal, maxReal };
+  real64 xMax[3] = { minReal, minReal, minReal };
 
-  double zReverseFactor = 1.;
-  if( m_isZReverse )
-  {
-    zReverseFactor = -1.;
-  }
-  for( auto const & verticesIterator : *m_pamelaMesh->get_PointCollection())
+  for( auto const & verticesIterator : *srcMesh.get_PointCollection() )
   {
     localIndex const vertexLocalIndex = verticesIterator->get_localIndex();
     globalIndex const vertexGlobalIndex = verticesIterator->get_globalIndex();
-    X( vertexLocalIndex, 0 ) = verticesIterator->get_coordinates().x * m_scale;
-    X( vertexLocalIndex, 1 ) = verticesIterator->get_coordinates().y * m_scale;
-    X( vertexLocalIndex, 2 ) = verticesIterator->get_coordinates().z * m_scale * zReverseFactor;
+    X( vertexLocalIndex, 0 ) = verticesIterator->get_coordinates().x * scaleFactor[0];
+    X( vertexLocalIndex, 1 ) = verticesIterator->get_coordinates().y * scaleFactor[1];
+    X( vertexLocalIndex, 2 ) = verticesIterator->get_coordinates().z * scaleFactor[2];
     allNodes.insert( vertexLocalIndex );
-
     nodeLocalToGlobal[vertexLocalIndex] = vertexGlobalIndex;
-    for( int i = 0; i < 3; i++ )
+    for( int i = 0; i < 3; ++i )
     {
-      if( X( vertexLocalIndex, i ) > xMax[i] )
-      {
-        xMax[i] = X( vertexLocalIndex, i );
-      }
-      if( X( vertexLocalIndex, i ) < xMin[i] )
-      {
-        xMin[i] = X( vertexLocalIndex, i );
-      }
+      xMin[i] = std::min( xMin[i], X( vertexLocalIndex, i ) );
+      xMax[i] = std::max( xMax[i], X( vertexLocalIndex, i ) );
     }
   }
 
+  MpiWrapper::allReduce( xMin, xMin, 3, MPI_MIN, MPI_COMM_GEOSX );
+  MpiWrapper::allReduce( xMax, xMax, 3, MPI_MAX, MPI_COMM_GEOSX );
   LvArray::tensorOps::subtract< 3 >( xMax, xMin );
-  meshBody.setGlobalLengthScale( LvArray::tensorOps::l2Norm< 3 >( xMax ) );
+  return LvArray::tensorOps::l2Norm< 3 >( xMax );
+}
 
-  // First loop which iterate on the regions
-  array1d< globalIndex > globalIndexRegionOffset( polyhedronPartMap.size() +1 );
+void importCellBlock( PAMELA::SubPart< PAMELA::Polyhedron * > * const cellBlockPtr,
+                      string const & cellBlockName,
+                      CellBlockManager & cellBlockManager )
+{
+  GEOSX_ASSERT( cellBlockPtr != nullptr );
+
+  CellBlock & cellBlock = cellBlockManager.getGroup( keys::cellBlocks ).registerGroup< CellBlock >( cellBlockName );
+  cellBlock.setElementType( toGeosxElementType( cellBlockPtr->ElementType ) );
+
+  localIndex const nbCells = LvArray::integerConversion< localIndex >( cellBlockPtr->SubCollection.size_owned() );
+  cellBlock.resize( nbCells );
+
+  std::vector< int > const nodeOrder = getPamelaNodeOrder( cellBlockPtr->ElementType );
+  arrayView2d< localIndex, cells::NODE_MAP_USD > const cellToVertex = cellBlock.nodeList().toView();
+  arrayView1d< globalIndex > const & localToGlobal = cellBlock.localToGlobalMap();
+
+  // Iterate on cells
+  auto & subCollection = cellBlockPtr->SubCollection;
+  for( auto cellItr = subCollection.begin_owned(); cellItr != subCollection.end_owned(); ++cellItr )
+  {
+    PAMELA::Polyhedron const * const cellPtr = *cellItr;
+    GEOSX_ASSERT( cellPtr != nullptr );
+    localIndex const cellLocalIndex = cellPtr->get_localIndex();
+    globalIndex const cellGlobalIndex = cellPtr->get_globalIndex();
+
+    std::vector< PAMELA::Point * > const & cornerList = cellPtr->get_vertexList();
+    GEOSX_ASSERT_EQ( cornerList.size(), nodeOrder.size() );
+
+    for( localIndex i = 0; i < LvArray::integerConversion< localIndex >( cornerList.size() ); ++i )
+    {
+      cellToVertex[cellLocalIndex][i] = cornerList[nodeOrder[i]]->get_localIndex();
+    }
+    localToGlobal[cellLocalIndex] = cellGlobalIndex;
+  }
+}
+
+void importSurface( PAMELA::Part< PAMELA::Polygon * > * const surfacePtr,
+                    NodeManager & nodeManager )
+{
+  GEOSX_ASSERT( surfacePtr != nullptr );
+  string const surfaceName = retrieveSurfaceOrRegionName( surfacePtr->Label );
+  SortedArray< localIndex > & curNodeSet = nodeManager.sets().registerWrapper< SortedArray< localIndex > >( surfaceName ).reference();
+
+  for( auto const & subPart : surfacePtr->SubParts )
+  {
+    PAMELA::SubPart< PAMELA::Polygon * > * const cellBlockPtr = subPart.second;
+    GEOSX_ASSERT( cellBlockPtr != nullptr );
+    if( cellBlockPtr->ElementType == PAMELA::ELEMENTS::TYPE::VTK_TRIANGLE || cellBlockPtr->ElementType == PAMELA::ELEMENTS::TYPE::VTK_QUAD )
+    {
+      auto & subCollection = cellBlockPtr->SubCollection;
+      for( auto cellItr = subCollection.begin_owned(); cellItr != subCollection.end_owned(); cellItr++ )
+      {
+        PAMELA::Polygon const * const cellPtr = *cellItr;
+        GEOSX_ASSERT( cellPtr != nullptr );
+        std::vector< PAMELA::Point * > const & cornerList = cellPtr->get_vertexList();
+        for( auto corner : cornerList )
+        {
+          curNodeSet.insert( corner->get_localIndex() );
+        }
+      }
+    }
+  }
+}
+
+} // namespace
+
+void PAMELAMeshGenerator::generateMesh( DomainPartition & domain )
+{
+  GEOSX_LOG_RANK_0( "Reading external mesh from " << m_filePath );
+  m_pamelaMesh = std::unique_ptr< PAMELA::Mesh >( PAMELA::MeshFactory::makeMesh( m_filePath ) );
+  m_pamelaMesh->CreateFacesFromCells();
+  m_pamelaMesh->PerformPolyhedronPartitioning( PAMELA::ELEMENTS::FAMILY::POLYGON,
+                                               PAMELA::ELEMENTS::FAMILY::POLYGON );
+  m_pamelaMesh->CreateLineGroupWithAdjacency( "TopologicalC2C",
+                                              m_pamelaMesh->getAdjacencySet()->get_TopologicalAdjacency( PAMELA::ELEMENTS::FAMILY::POLYHEDRON,
+                                                                                                         PAMELA::ELEMENTS::FAMILY::POLYHEDRON,
+                                                                                                         PAMELA::ELEMENTS::FAMILY::POLYGON ) );
+
+  GEOSX_LOG_RANK_0( "Writing into the GEOSX mesh data structure" );
+  domain.getMetisNeighborList() = m_pamelaMesh->getNeighborList();
+  Group & meshBodies = domain.getMeshBodies();
+  MeshBody & meshBody = meshBodies.registerGroup< MeshBody >( this->getName() );
+
+  //TODO for the moment we only consider on mesh level "Level0"
+  MeshLevel & meshLevel0 = meshBody.registerGroup< MeshLevel >( "Level0" );
+  NodeManager & nodeManager = meshLevel0.getNodeManager();
+  CellBlockManager & cellBlockManager = domain.getGroup< CellBlockManager >( keys::cellManager );
+
+  real64 const scaleFactor[3] = { m_scale, m_scale, m_scale * ( m_isZReverse ? -1 : 1 ) };
+  real64 const lengthScale = importNodes( *m_pamelaMesh, scaleFactor, nodeManager );
+  meshBody.setGlobalLengthScale( lengthScale );
+
+  // Use the PartMap of PAMELA to get the mesh
+  PAMELA::PartMap< PAMELA::Polyhedron * > const polyhedronPartMap = std::get< 0 >( PAMELA::getPolyhedronPartMap( m_pamelaMesh.get(), 0 ) );
+
+  // Import cell blocks
   for( auto const & polyhedronPart : polyhedronPartMap )
   {
-    auto const regionPtr = polyhedronPart.second;
-    string regionName = DecodePAMELALabels::retrieveSurfaceOrRegionName( regionPtr->Label );
+    PAMELA::Part< PAMELA::Polyhedron * > * const regionPtr = polyhedronPart.second;
+    GEOSX_ASSERT( regionPtr != nullptr );
+    string const regionName = retrieveSurfaceOrRegionName( regionPtr->Label );
 
     // Iterate on cell types
     for( auto const & subPart : regionPtr->SubParts )
     {
-      auto const cellBlockPAMELA = subPart.second;
-      PAMELA::ELEMENTS::TYPE const cellBlockType = cellBlockPAMELA->ElementType;
-      string const & cellBlockName = ElementToLabel.at( cellBlockType );
-      CellBlock * cellBlock = nullptr;
-      if( cellBlockName == "HEX" )
+      if( PAMELA::ELEMENTS::TypeToFamily.at( static_cast< int >( subPart.second->ElementType ) ) == PAMELA::ELEMENTS::FAMILY::POLYHEDRON )
       {
-        localIndex const nbCells = cellBlockPAMELA->SubCollection.size_owned();
-        cellBlock =
-          &cellBlockManager.getGroup( keys::cellBlocks ).registerGroup< CellBlock >( DecodePAMELALabels::makeRegionLabel( regionName, cellBlockName ) );
-        cellBlock->setElementType( ElementType::Hexahedron );
-        auto & cellToVertex = cellBlock->nodeList();
-        cellBlock->resize( nbCells );
-        cellToVertex.resize( nbCells, 8 );
-
-        arrayView1d< globalIndex > const & localToGlobal = cellBlock->localToGlobalMap();
-
-        // Iterate on cells
-        for( auto cellItr = cellBlockPAMELA->SubCollection.begin_owned();
-             cellItr != cellBlockPAMELA->SubCollection.end_owned();
-             cellItr++ )
-        {
-          localIndex cellLocalIndex = (*cellItr)->get_localIndex();
-          globalIndex cellGlobalIndex = (*cellItr)->get_globalIndex();
-          auto const cornerList = (*cellItr)->get_vertexList();
-
-          cellToVertex[cellLocalIndex][0] =
-            cornerList[0]->get_localIndex();
-          cellToVertex[cellLocalIndex][1] =
-            cornerList[1]->get_localIndex();
-          cellToVertex[cellLocalIndex][2] =
-            cornerList[3]->get_localIndex();
-          cellToVertex[cellLocalIndex][3] =
-            cornerList[2]->get_localIndex();
-          cellToVertex[cellLocalIndex][4] =
-            cornerList[4]->get_localIndex();
-          cellToVertex[cellLocalIndex][5] =
-            cornerList[5]->get_localIndex();
-          cellToVertex[cellLocalIndex][6] =
-            cornerList[7]->get_localIndex();
-          cellToVertex[cellLocalIndex][7] =
-            cornerList[6]->get_localIndex();
-
-          localToGlobal[cellLocalIndex] = cellGlobalIndex;
-        }
-      }
-      else if( cellBlockName == "TETRA" )
-      {
-        localIndex const nbCells = cellBlockPAMELA->SubCollection.size_owned();
-        cellBlock =
-          &cellBlockManager.getGroup( keys::cellBlocks ).registerGroup< CellBlock >( DecodePAMELALabels::makeRegionLabel( regionName, cellBlockName ) );
-        cellBlock->setElementType( ElementType::Tetrahedron );
-        auto & cellToVertex = cellBlock->nodeList();
-        cellBlock->resize( nbCells );
-        cellToVertex.resize( nbCells, 4 );
-
-        arrayView1d< globalIndex > const & localToGlobal = cellBlock->localToGlobalMap();
-
-        // Iterate on cells
-        for( auto cellItr = cellBlockPAMELA->SubCollection.begin_owned();
-             cellItr != cellBlockPAMELA->SubCollection.end_owned();
-             cellItr++ )
-        {
-          localIndex cellLocalIndex = (*cellItr)->get_localIndex();
-          globalIndex cellGlobalIndex = (*cellItr)->get_globalIndex();
-          auto const cornerList = (*cellItr)->get_vertexList();
-
-          cellToVertex[cellLocalIndex][0] =
-            cornerList[0]->get_localIndex();
-          cellToVertex[cellLocalIndex][1] =
-            cornerList[1]->get_localIndex();
-          cellToVertex[cellLocalIndex][2] =
-            cornerList[2]->get_localIndex();
-          cellToVertex[cellLocalIndex][3] =
-            cornerList[3]->get_localIndex();
-
-          localToGlobal[cellLocalIndex] = cellGlobalIndex;
-        }
-      }
-      else if( cellBlockName == "WEDGE" )
-      {
-        localIndex const nbCells = cellBlockPAMELA->SubCollection.size_owned();
-        cellBlock =
-          &cellBlockManager.getGroup( keys::cellBlocks ).registerGroup< CellBlock >( DecodePAMELALabels::makeRegionLabel( regionName, cellBlockName ) );
-        cellBlock->setElementType( ElementType::Prism );
-        auto & cellToVertex = cellBlock->nodeList();
-        cellBlock->resize( nbCells );
-        cellToVertex.resize( nbCells, 6 );
-
-        arrayView1d< globalIndex > const & localToGlobal = cellBlock->localToGlobalMap();
-
-        // Iterate on cells
-        for( auto cellItr = cellBlockPAMELA->SubCollection.begin_owned();
-             cellItr != cellBlockPAMELA->SubCollection.end_owned();
-             cellItr++ )
-        {
-          localIndex cellLocalIndex = (*cellItr)->get_localIndex();
-          globalIndex cellGlobalIndex = (*cellItr)->get_globalIndex();
-          auto const cornerList = (*cellItr)->get_vertexList();
-
-          cellToVertex[cellLocalIndex][0] =
-            cornerList[0]->get_localIndex();
-          cellToVertex[cellLocalIndex][1] =
-            cornerList[3]->get_localIndex();
-          cellToVertex[cellLocalIndex][2] =
-            cornerList[1]->get_localIndex();
-          cellToVertex[cellLocalIndex][3] =
-            cornerList[4]->get_localIndex();
-          cellToVertex[cellLocalIndex][4] =
-            cornerList[2]->get_localIndex();
-          cellToVertex[cellLocalIndex][5] =
-            cornerList[5]->get_localIndex();
-
-          localToGlobal[cellLocalIndex] = cellGlobalIndex;
-        }
-      }
-      else if( cellBlockName == "PYRAMID" )
-      {
-        localIndex const nbCells = cellBlockPAMELA->SubCollection.size_owned();
-        cellBlock =
-          &cellBlockManager.getGroup( keys::cellBlocks ).registerGroup< CellBlock >( DecodePAMELALabels::makeRegionLabel( regionName, cellBlockName ) );
-        cellBlock->setElementType( ElementType::Pyramid );
-        auto & cellToVertex = cellBlock->nodeList();
-        cellBlock->resize( nbCells );
-        cellToVertex.resize( nbCells, 5 );
-
-        arrayView1d< globalIndex > const & localToGlobal = cellBlock->localToGlobalMap();
-
-        // Iterate on cells
-        for( auto cellItr = cellBlockPAMELA->SubCollection.begin_owned();
-             cellItr != cellBlockPAMELA->SubCollection.end_owned();
-             cellItr++ )
-        {
-          localIndex cellLocalIndex = (*cellItr)->get_localIndex();
-          globalIndex cellGlobalIndex = (*cellItr)->get_globalIndex();
-          auto const cornerList = (*cellItr)->get_vertexList();
-
-          cellToVertex[cellLocalIndex][0] =
-            cornerList[0]->get_localIndex();
-          cellToVertex[cellLocalIndex][1] =
-            cornerList[1]->get_localIndex();
-          cellToVertex[cellLocalIndex][2] =
-            cornerList[2]->get_localIndex();
-          cellToVertex[cellLocalIndex][3] =
-            cornerList[3]->get_localIndex();
-          cellToVertex[cellLocalIndex][4] =
-            cornerList[4]->get_localIndex();
-
-          localToGlobal[cellLocalIndex] = cellGlobalIndex;
-        }
-      }
-
-      /// Import ppt
-      if( cellBlock != nullptr && cellBlock->size() > 0 )
-      {
-        for( localIndex fieldIndex = 0; fieldIndex < m_fieldNamesInGEOSX.size(); fieldIndex++ )
-        {
-          auto const meshProperty = regionPtr->FindVariableByName( m_fieldsToImport[fieldIndex] );
-          PAMELA::VARIABLE_DIMENSION const dimension = meshProperty->Dimension;
-          if( dimension == PAMELA::VARIABLE_DIMENSION::SCALAR )
-          {
-            real64_array & property = cellBlock->addProperty< real64_array >( m_fieldNamesInGEOSX[fieldIndex] );
-            GEOSX_ERROR_IF( property.size() != LvArray::integerConversion< localIndex >( meshProperty->size() ),
-                            "Viewer size (" << property.size() << ") mismatch with property size in PAMELA ("
-                                            << meshProperty->size() << ") on " <<cellBlock->getName() );
-            for( int cellIndex = 0; cellIndex < property.size(); cellIndex++ )
-            {
-              property[cellIndex] = meshProperty->get_data( cellIndex )[0];
-            }
-          }
-          else if( dimension == PAMELA::VARIABLE_DIMENSION::VECTOR )
-          {
-            array2d< real64 > & property = cellBlock->addProperty< array2d< real64 > >( m_fieldNamesInGEOSX[fieldIndex] );
-            property.resizeDimension< 1 >( 3 );
-            GEOSX_ERROR_IF( property.size() != LvArray::integerConversion< localIndex >( meshProperty->size() ),
-                            "Viewer size (" << property.size() << ") mismatch with property size in PAMELA ("
-                                            << meshProperty->size() << ") on " << cellBlock->getName() );
-            for( int cellIndex = 0; cellIndex < cellBlock->size(); cellIndex++ )
-            {
-              for( int dim = 0; dim < 3; dim++ )
-              {
-                property( cellIndex, dim ) = meshProperty->get_data( cellIndex )[dim];
-              }
-            }
-          }
-          else
-          {
-            GEOSX_ERROR( "Dimension of " <<  m_fieldNamesInGEOSX[fieldIndex] << " is not supported for import in GEOSX" );
-          }
-        }
+        string const cellBlockName = makeRegionLabel( regionName, getElementLabel( subPart.second->ElementType ) );
+        importCellBlock( subPart.second, cellBlockName, cellBlockManager );
+        m_cellBlockRegions.emplace( cellBlockName, polyhedronPart.first );
       }
     }
   }
 
-  /// Import surfaces
-  auto const polygonPartMap = std::get< 0 >( PAMELA::getPolygonPartMap( m_pamelaMesh.get(), 0 ));
+  // Import surfaces
+  PAMELA::PartMap< PAMELA::Polygon * > const polygonPartMap = std::get< 0 >( PAMELA::getPolygonPartMap( m_pamelaMesh.get(), 0 ));
   for( auto const & polygonPart : polygonPartMap )
   {
-    auto const surfacePtr = polygonPart.second;
-
-    string surfaceName = DecodePAMELALabels::retrieveSurfaceOrRegionName( surfacePtr->Label );
-    SortedArray< localIndex > & curNodeSet  = nodeSets.registerWrapper< SortedArray< localIndex > >( string( surfaceName ) ).reference();
-    for( auto const & subPart : surfacePtr->SubParts )
-    {
-      auto const cellBlockPAMELA = subPart.second;
-      PAMELA::ELEMENTS::TYPE const cellBlockType = cellBlockPAMELA->ElementType;
-      string const cellBlockName = ElementToLabel.at( cellBlockType );
-      if( cellBlockName == "TRIANGLE"  || cellBlockName == "QUAD" )
-      {
-        for( auto cellItr = cellBlockPAMELA->SubCollection.begin_owned();
-             cellItr != cellBlockPAMELA->SubCollection.end_owned();
-             cellItr++ )
-        {
-          auto const cornerList = (*cellItr)->get_vertexList();
-          for( auto corner :cornerList )
-          {
-            curNodeSet.insert( corner->get_localIndex() );
-          }
-        }
-      }
-    }
+    PAMELA::Part< PAMELA::Polygon * > * const surfacePtr = polygonPart.second;
+    importSurface( surfacePtr, nodeManager );
   }
 
+}
+
+void PAMELAMeshGenerator::freeResources()
+{
+  m_pamelaMesh.reset();
+  m_cellBlockRegions.clear();
+}
+
+namespace
+{
+
+void importRegularField( PAMELA::VariableDouble & source,
+                         std::vector< int > const & indexMap,
+                         WrapperBase & wrapper )
+{
+  // Scalar material fields are stored as 1D arrays, vector/tensor are 2D
+  using ImportTypes = types::ArrayTypes< types::RealTypes, types::DimsRange< 1, 2 > >;
+  types::dispatch( ImportTypes{}, wrapper.getTypeId(), true, [&]( auto array )
+  {
+    using ArrayType = decltype( array );
+    Wrapper< ArrayType > & wrapperT = Wrapper< ArrayType >::cast( wrapper );
+    auto const view = wrapperT.referenceAsView();
+
+    GEOSX_ERROR_IF_NE_MSG( view.size() / view.size( 0 ), LvArray::integerConversion< localIndex >( source.offset ),
+                           "PAMELA import: mismatch in number of components for field " << source.Label );
+
+    // Sanity check, shouldn't happen
+    GEOSX_ERROR_IF_NE_MSG( view.size( 0 ), LvArray::integerConversion< localIndex >( indexMap.size() ),
+                           "PAMELA import: mismatch in size for field " << source.Label );
+
+    for( int i = 0; i < view.size( 0 ); ++i )
+    {
+      // get_data() currently returns a new vector for each cell, but auto const & makes sure
+      // this code keeps working if/when PAMELA is fixed to return a more reasonable type (span/pointer)
+      auto const & data = source.get_data( indexMap[i] );
+      int comp = 0;
+      LvArray::forValuesInSlice( view[i], [&]( auto & val )
+      {
+        val = data[comp++];
+      } );
+    }
+  } );
+}
+
+void importMaterialField( PAMELA::VariableDouble & source,
+                          std::vector< int > const & indexMap,
+                          WrapperBase & wrapper )
+{
+  // Scalar material fields are stored as 2D arrays, vector/tensor are 3D
+  using ImportTypes = types::ArrayTypes< types::RealTypes, types::DimsRange< 2, 3 > >;
+  types::dispatch( ImportTypes{}, wrapper.getTypeId(), true, [&]( auto array )
+  {
+    using ArrayType = decltype( array );
+    Wrapper< ArrayType > & wrapperT = Wrapper< ArrayType >::cast( wrapper );
+    auto const view = wrapperT.referenceAsView();
+
+    GEOSX_ERROR_IF_NE_MSG( view.size() / ( view.size( 0 ) * view.size( 1 ) ), LvArray::integerConversion< localIndex >( source.offset ),
+                           "PAMELA import: mismatch in number of components for field " << source.Label );
+
+    // Sanity check, shouldn't happen
+    GEOSX_ERROR_IF_NE_MSG( view.size( 0 ), LvArray::integerConversion< localIndex >( indexMap.size() ),
+                           "PAMELA import: mismatch in size for field " << source.Label );
+
+    for( int i = 0; i < view.size( 0 ); ++i )
+    {
+      // get_data() currently returns a new vector for each cell, but auto const & makes sure
+      // this code keeps working if/when PAMELA is fixed to return a more reasonable type (span/pointer)
+      auto const & data = source.get_data( indexMap[i] );
+
+      // For material fields, copy identical values into each quadrature point
+      for( int q = 0; q < view.size( 1 ); ++q )
+      {
+        int comp = 0;
+        LvArray::forValuesInSlice( view[i][q], [&]( auto & val )
+        {
+          val = data[comp++];
+        } );
+      }
+    }
+  } );
+}
+
+std::unordered_set< string > getMaterialWrapperNames( ElementSubRegionBase const & subRegion )
+{
+  using namespace constitutive;
+  std::unordered_set< string > materialWrapperNames;
+  subRegion.getConstitutiveModels().forSubGroups< ConstitutiveBase >( [&]( ConstitutiveBase const & material )
+  {
+    material.forWrappers( [&]( WrapperBase const & wrapper )
+    {
+      if( wrapper.sizedFromParent() )
+      {
+        materialWrapperNames.insert( ConstitutiveBase::makeFieldName( material.getName(), wrapper.getName() ) );
+      }
+    } );
+  } );
+  return materialWrapperNames;
+}
+
+}
+
+void PAMELAMeshGenerator::importFields( DomainPartition & domain ) const
+{
+  GEOSX_LOG_RANK_0( "Importing field data from mesh dataset" );
+  GEOSX_ASSERT_MSG( m_pamelaMesh, "Must call generateMesh() before importFields()" );
+
+  ElementRegionManager & elemManager = domain.getMeshBody( this->getName() ).getMeshLevel( 0 ).getElemManager();
+
+  PAMELA::PartMap< PAMELA::Polyhedron * > const polyhedronPartMap = std::get< 0 >( PAMELA::getPolyhedronPartMap( m_pamelaMesh.get(), 0 ) );
+
+  elemManager.forElementSubRegions< CellElementSubRegion >( [&]( CellElementSubRegion & subRegion )
+  {
+    // Use stored map of names to get access to PAMELA region again
+    GEOSX_ASSERT_EQ( m_cellBlockRegions.count( subRegion.getName() ), 1 );
+    string const & srcRegionName = m_cellBlockRegions.at( subRegion.getName() );
+    PAMELA::Part< PAMELA::Polyhedron * > * const regionPtr = polyhedronPartMap.at( srcRegionName );
+    GEOSX_ASSERT( regionPtr != nullptr );
+
+    // Use element type to get the PAMELA cell block (sub-part) corresponding to subregion
+    PAMELA::ELEMENTS::TYPE const elemType = toPamelaElementType( subRegion.getElementType() );
+    PAMELA::SubPart< PAMELA::Polyhedron * > * const cellBlockPtr = regionPtr->SubParts.at( static_cast< int >( elemType ) );
+    GEOSX_ASSERT( cellBlockPtr != nullptr );
+
+    // Make a list of material field wrapper names on current subregion
+    std::unordered_set< string > const materialWrapperNames = getMaterialWrapperNames( subRegion );
+
+    for( localIndex fieldIndex = 0; fieldIndex < m_fieldsToImport.size(); fieldIndex++ )
+    {
+      string const & sourceName = m_fieldsToImport[fieldIndex];
+      string const & wrapperName = m_fieldNamesInGEOSX[fieldIndex];
+
+      // Find source
+      PAMELA::VariableDouble * const meshProperty = regionPtr->FindVariableByName( sourceName );
+      GEOSX_ASSERT( meshProperty != nullptr );
+
+      // Find destination
+      WrapperBase & wrapper = subRegion.getWrapperBase( wrapperName );
+
+      // Decide if field is constitutive or not
+      if( materialWrapperNames.count( wrapperName ) > 0 )
+      {
+        importMaterialField( *meshProperty, cellBlockPtr->IndexMapping, wrapper );
+      }
+      else
+      {
+        importRegularField( *meshProperty, cellBlockPtr->IndexMapping, wrapper );
+      }
+    }
+  } );
 }
 
 REGISTER_CATALOG_ENTRY( MeshGeneratorBase, PAMELAMeshGenerator, string const &, Group * const )

--- a/src/coreComponents/mesh/generators/PAMELAMeshGenerator.hpp
+++ b/src/coreComponents/mesh/generators/PAMELAMeshGenerator.hpp
@@ -19,25 +19,22 @@
 #ifndef GEOSX_MESH_GENERATORS_PAMELAMESHGENERATOR_HPP
 #define GEOSX_MESH_GENERATORS_PAMELAMESHGENERATOR_HPP
 
-#include "dataRepository/Group.hpp"
-#include "codingUtilities/Utilities.hpp"
-#include "codingUtilities/StringUtilities.hpp"
+#include "mesh/generators/MeshGeneratorBase.hpp"
 
-//This is an include of PAMELA
-#include "Mesh/Mesh.hpp"
-#include "MeshDataWriters/Writer.hpp"
-
-#include "MeshGeneratorBase.hpp"
+namespace PAMELA
+{
+/// Forward declare Mesh class for unique_ptr member
+class Mesh;
+}
 
 namespace geosx
 {
-
 
 /**
  *  @class PAMELAMeshGenerator
  *  @brief The PAMELAMeshGenerator class provides a class implementation of PAMELA generated meshes.
  */
-class PAMELAMeshGenerator : public MeshGeneratorBase
+class PAMELAMeshGenerator final : public MeshGeneratorBase
 {
 public:
 /**
@@ -47,8 +44,6 @@ public:
  */
   PAMELAMeshGenerator( const string & name,
                        Group * const parent );
-
-  virtual ~PAMELAMeshGenerator() override;
 
 /**
  * @brief Return the name of the PAMELAMeshGenerator in object Catalog.
@@ -77,19 +72,23 @@ public:
 
   virtual void generateMesh( DomainPartition & domain ) override;
 
+  virtual void importFields( DomainPartition & domain ) const override;
+
+  virtual void freeResources() override;
+
 protected:
 
   /**
    * @brief This function provides capability to post process input values prior to
    * any other initialization operations.
    */
-  void postProcessInput() override final;
+  void postProcessInput() final;
 
 
 private:
 
   /// Unique Pointer to the Mesh in the data structure of PAMELA.
-  std::unique_ptr< PAMELA::Mesh >  m_pamelaMesh;
+  std::unique_ptr< PAMELA::Mesh > m_pamelaMesh;
 
   /// Names of the fields to be copied from PAMELA to GEOSX data structure
   string_array m_fieldsToImport;
@@ -100,78 +99,14 @@ private:
   /// Scale factor that will be applied to the point coordinates
   real64 m_scale;
 
-  /// String array of the GEOSX user decalred fields
+  /// String array of the GEOSX user declared fields
   string_array m_fieldNamesInGEOSX;
 
   /// z pointing direction flag, 0 (default) is upward, 1 is downward
-  int m_isZReverse;
+  integer m_isZReverse;
 
-  /// Map from PAMELA enumeration element type to string
-  const std::unordered_map< PAMELA::ELEMENTS::TYPE, string, PAMELA::ELEMENTS::EnumClassHash > ElementToLabel
-    =
-    {
-    { PAMELA::ELEMENTS::TYPE::VTK_VERTEX, "VERTEX"},
-    { PAMELA::ELEMENTS::TYPE::VTK_LINE, "LINE"  },
-    { PAMELA::ELEMENTS::TYPE::VTK_TRIANGLE, "TRIANGLE" },
-    { PAMELA::ELEMENTS::TYPE::VTK_QUAD, "QUAD" },
-    { PAMELA::ELEMENTS::TYPE::VTK_TETRA, "TETRA" },
-    { PAMELA::ELEMENTS::TYPE::VTK_HEXAHEDRON, "HEX" },
-    { PAMELA::ELEMENTS::TYPE::VTK_WEDGE, "WEDGE" },
-    { PAMELA::ELEMENTS::TYPE::VTK_PYRAMID, "PYRAMID" }
-    };
-
-  class DecodePAMELALabels
-  {
-public:
-    /*!
-     * @brief Make a region label which is composed of the name of the region and the type
-     * @details Some examples :
-     * If the region names are not specified in the input mesh file, there will one region per type of cells
-     * such as DEFAULT_TETRA, DEFAULT_HEX etc. Otherwise, if the region names are set it will be RESERVOIR_TETRA;
-     * RESERVOIR_HEX etc
-     * @param[in] regionName the name of the region
-     * @param[in] regionCellType the type of the cells (TETRA, HEX, WEDGE or PYRAMID)
-     * @return the region label
-     */
-    static string makeRegionLabel( string const & regionName, string const & regionCellType )
-    {
-      return regionName + m_separator + regionCellType;
-    }
-
-    /*!
-     * @brief Knowing the PAMELA Surface or Regionc label, return a simple unique name for GEOSX
-     * @details surface labels in PAMELA are composed of different informations such as the index, the type of cells etc)
-     * @param[in] pamelaLabel the surface or region label within PAMELA
-     * @return the name of the surface or the region
-     */
-    static string retrieveSurfaceOrRegionName( string const & pamelaLabel )
-    {
-      string_array const splitLabel = stringutilities::tokenize( pamelaLabel, m_separator );
-
-      // The PAMELA label looks like: PART00002_POLYGON_POLYGON_GROUP_Ovbd1_Ovbd2_14
-      // But we only want to keep Ovbd1_Ovbd2
-      // So we find the word GROUP, and then we keep what is after, except the last piece
-
-      auto it = std::find( std::begin( splitLabel ), std::end( splitLabel ), "GROUP" );
-
-      GEOSX_THROW_IF( it == std::end( splitLabel ),
-                      "GEOSX assumes that PAMELA places the word GROUP before the region/surface name", InputError );
-
-      localIndex const id = std::distance( std::begin( splitLabel ), it );
-      string name = "";
-      for( localIndex i = id+1; i < splitLabel.size()-1; ++i )
-      {
-        name += ( i == id+1 ) ? splitLabel[i] : "_"+splitLabel[i];
-      }
-
-      GEOSX_THROW_IF( name == "",
-                      "Something unexpected happened when converting the PAMELA label into a GEOSX label", InputError );
-
-      return name;
-    }
-private:
-    static string const m_separator;
-  };
+  /// Map of cell block (subregion) names to PAMELA region names
+  std::unordered_map< string, string > m_cellBlockRegions;
 };
 
 }

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseHybridFVM.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseHybridFVM.cpp
@@ -190,7 +190,7 @@ void CompositionalMultiphaseHybridFVM::precomputeData( MeshLevel & mesh )
   {
     arrayView2d< real64 const > const & elemCenter =
       subRegion.template getReference< array2d< real64 > >( CellBlock::viewKeyStruct::elementCenterString() );
-    arrayView2d< real64 const > const & elemPerm =
+    arrayView3d< real64 const > const & elemPerm =
       getConstitutiveModel< PermeabilityBase >( subRegion, m_permeabilityModelNames[targetIndex] ).permeability();
     arrayView1d< real64 const > const elemGravCoef =
       subRegion.template getReference< array1d< real64 > >( viewKeyStruct::gravityCoefString() );

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseHybridFVMKernels.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseHybridFVMKernels.cpp
@@ -1535,7 +1535,7 @@ FluxKernel::
   arrayView1d< real64 const > const & elemVolume =
     subRegion.getReference< array1d< real64 > >( CellBlock::viewKeyStruct::elementVolumeString() );
 
-  arrayView2d< real64 const > const & elemPerm = permeabilityModel.permeability();
+  arrayView3d< real64 const > const & elemPerm = permeabilityModel.permeability();
 
   // get the cell-centered depth
   arrayView1d< real64 const > const & elemGravCoef =
@@ -1550,7 +1550,7 @@ FluxKernel::
     stackArray2d< real64, NF *NF > transMatrix( NF, NF );
     stackArray2d< real64, NF *NF > transMatrixGrav( NF, NF );
 
-    real64 const perm[ 3 ] = { elemPerm[ei][0], elemPerm[ei][1], elemPerm[ei][2] };
+    real64 const perm[ 3 ] = { elemPerm[ei][0][0], elemPerm[ei][0][1], elemPerm[ei][0][2] };
 
     // recompute the local transmissibility matrix at each iteration
     // we can decide later to precompute transMatrix if needed

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseHybridFVMKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseHybridFVMKernels.hpp
@@ -832,7 +832,7 @@ struct PrecomputeKernel
           ArrayOfArraysView< localIndex const > const & faceToNodes,
           arrayView2d< real64 const > const & elemCenter,
           arrayView1d< real64 const > const & elemVolume,
-          arrayView2d< real64 const > const & elemPerm,
+          arrayView3d< real64 const > const & elemPerm,
           arrayView1d< real64 const > const & elemGravCoef,
           arrayView2d< localIndex const > const & elemToFaces,
           arrayView1d< real64 const > const & transMultiplier,
@@ -845,7 +845,7 @@ struct PrecomputeKernel
     {
       stackArray2d< real64, NF *NF > transMatrix( NF, NF );
 
-      real64 const perm[ 3 ] = { elemPerm[ei][0], elemPerm[ei][1], elemPerm[ei][2] };
+      real64 const perm[ 3 ] = { elemPerm[ei][0][0], elemPerm[ei][0][1], elemPerm[ei][0][2] };
 
       IP_TYPE::template compute< NF >( nodePosition,
                                        transMultiplier,

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseHybridFVM.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseHybridFVM.cpp
@@ -269,7 +269,7 @@ void SinglePhaseHybridFVM::assembleFluxTerms( real64 const GEOSX_UNUSED_PARAM( t
     SingleFluidBase const & fluid =
       getConstitutiveModel< SingleFluidBase >( subRegion, m_fluidModelNames[targetIndex] );
 
-    arrayView2d< real64 const > const & permeability =
+    arrayView3d< real64 const > const & permeability =
       getConstitutiveModel< PermeabilityBase >( subRegion, m_permeabilityModelNames[targetIndex] ).permeability();
 
     mimeticInnerProductDispatch( mimeticInnerProductBase,

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseHybridFVMKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseHybridFVMKernels.hpp
@@ -533,7 +533,7 @@ struct FluxKernel
           arrayView1d< integer const > const & faceGhostRank,
           arrayView1d< real64 const > const & facePres,
           arrayView1d< real64 const > const & dFacePres,
-          arrayView2d< real64 const > const & elemPerm,
+          arrayView3d< real64 const > const & elemPerm,
           arrayView1d< real64 const > const & faceGravCoef,
           arrayView1d< real64 const > const & transMultiplier,
           ElementViewConst< arrayView1d< real64 const > > const & mob,
@@ -580,7 +580,7 @@ struct FluxKernel
       // transmissibility matrix
       stackArray2d< real64, NF *NF > transMatrix( NF, NF );
 
-      real64 const perm[ 3 ] = { elemPerm[ei][0], elemPerm[ei][1], elemPerm[ei][2] };
+      real64 const perm[ 3 ] = { elemPerm[ei][0][0], elemPerm[ei][0][1], elemPerm[ei][0][2] };
 
       // recompute the local transmissibility matrix at each iteration
       // we can decide later to precompute transMatrix if needed

--- a/src/coreComponents/physicsSolvers/fluidFlow/benchmarks/Egg/dead_oil_egg.xml
+++ b/src/coreComponents/physicsSolvers/fluidFlow/benchmarks/Egg/dead_oil_egg.xml
@@ -154,7 +154,7 @@
       name="mesh"
       file="../../../../../../../GEOSXDATA/DataSets/Egg/egg.msh"
       fieldsToImport="{ PERM }"
-      fieldNamesInGEOSX="{ permeability }"/>
+      fieldNamesInGEOSX="{ rockPerm_permeability }"/>
 
     <InternalWell
       name="wellProducer1"

--- a/src/coreComponents/physicsSolvers/fluidFlow/benchmarks/SPE10/dead_oil_spe10_layers_83_84_85.xml
+++ b/src/coreComponents/physicsSolvers/fluidFlow/benchmarks/SPE10/dead_oil_spe10_layers_83_84_85.xml
@@ -94,7 +94,7 @@
       name="mesh"
       file="../../../../../../../GEOSXDATA/DataSets/SPE10/EclipseBottomLayers/SPE10_LAYERS_83_84_85.GRDECL"
       fieldsToImport="{ PERM, PORO }"
-      fieldNamesInGEOSX="{ permeability, referencePorosity }"/>
+      fieldNamesInGEOSX="{ rockPerm_permeability, referencePorosity }"/>
 
     <InternalWell
       name="wellProducer1"
@@ -220,8 +220,20 @@
 
     <PeriodicEvent
       name="timeHistoryOutput"
-      timeFrequency="1.5e7"
-      target="/Outputs/timeHistoryOutput"/>
+      timeFrequency="1.5e7">
+      <PeriodicEvent
+        name="timeHistoryOutput1"
+        target="/Outputs/timeHistoryOutput1"/>
+      <PeriodicEvent
+        name="timeHistoryOutput2"
+        target="/Outputs/timeHistoryOutput2"/>
+      <PeriodicEvent
+        name="timeHistoryOutput3"
+        target="/Outputs/timeHistoryOutput3"/>
+      <PeriodicEvent
+        name="timeHistoryOutput4"
+        target="/Outputs/timeHistoryOutput4"/>
+    </PeriodicEvent>
 
     <PeriodicEvent
       name="solverApplications"
@@ -354,9 +366,24 @@
       name="restartOutput"/>
 
     <TimeHistory
-      name="timeHistoryOutput"
-      sources="{ /Tasks/wellRateCollection1, /Tasks/wellRateCollection2, /Tasks/wellRateCollection3, /Tasks/wellRateCollection4 }"
-      filename="wellRateHistory"/>
+      name="timeHistoryOutput1"
+      sources="{ /Tasks/wellRateCollection1 }"
+      filename="wellRateHistory1"/>
+
+    <TimeHistory
+      name="timeHistoryOutput2"
+      sources="{ /Tasks/wellRateCollection2 }"
+      filename="wellRateHistory2"/>
+
+    <TimeHistory
+      name="timeHistoryOutput3"
+      sources="{ /Tasks/wellRateCollection3 }"
+      filename="wellRateHistory3"/>
+
+    <TimeHistory
+      name="timeHistoryOutput4"
+      sources="{ /Tasks/wellRateCollection4 }"
+      filename="wellRateHistory4"/>
   </Outputs>
 
   <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_OUTPUT_END -->

--- a/src/coreComponents/physicsSolvers/multiphysics/ReservoirSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/ReservoirSolverBase.cpp
@@ -77,8 +77,8 @@ void ReservoirSolverBase::initializePostInitialConditionsPreSubGroups()
   // loop over the wells
   elemManager.forElementSubRegions< WellElementSubRegion >( [&]( WellElementSubRegion & subRegion )
   {
-    array1d< array1d< arrayView2d< real64 const > > > const permeability =
-      elemManager.constructMaterialArrayViewAccessor< real64, 2 >( PermeabilityBase::viewKeyStruct::permeabilityString(),
+    array1d< array1d< arrayView3d< real64 const > > > const permeability =
+      elemManager.constructMaterialArrayViewAccessor< real64, 3 >( PermeabilityBase::viewKeyStruct::permeabilityString(),
                                                                    m_flowSolver->targetRegionNames(),
                                                                    m_flowSolver->permeabilityModelNames() );
 

--- a/src/coreComponents/schema/docs/CarmanKozenyPermeability_other.rst
+++ b/src/coreComponents/schema/docs/CarmanKozenyPermeability_other.rst
@@ -3,9 +3,9 @@
 =============== ============== ============================= 
 Name            Type           Description                   
 =============== ============== ============================= 
-dPerm_dPorosity real64_array2d (no description available)    
-dPerm_dPressure real64_array2d  dPerm_dPressure of the rock. 
-permeability    real64_array2d  permeability of the rock.    
+dPerm_dPorosity real64_array3d (no description available)    
+dPerm_dPressure real64_array3d  dPerm_dPressure of the rock. 
+permeability    real64_array3d  permeability of the rock.    
 =============== ============== ============================= 
 
 

--- a/src/coreComponents/schema/docs/ConstantPermeability_other.rst
+++ b/src/coreComponents/schema/docs/ConstantPermeability_other.rst
@@ -3,8 +3,8 @@
 =============== ============== ============================= 
 Name            Type           Description                   
 =============== ============== ============================= 
-dPerm_dPressure real64_array2d  dPerm_dPressure of the rock. 
-permeability    real64_array2d  permeability of the rock.    
+dPerm_dPressure real64_array3d  dPerm_dPressure of the rock. 
+permeability    real64_array3d  permeability of the rock.    
 =============== ============== ============================= 
 
 

--- a/src/coreComponents/schema/docs/Dirichlet.rst
+++ b/src/coreComponents/schema/docs/Dirichlet.rst
@@ -5,7 +5,7 @@ Name                   Type         Default  Description
 ====================== ============ ======== ============================================================== 
 bcApplicationTableName string                Name of table that specifies the on/off application of the bc. 
 beginTime              real64       -1e+99   time at which BC will start being applied.                     
-component              integer      0        Component of field (if tensor) to apply boundary condition to  
+component              integer      -1       Component of field (if tensor) to apply boundary condition to  
 direction              R1Tensor     {0,0,0}  Direction to apply boundary condition to                       
 endTime                real64       1e+99    time at which bc will stop being applied                       
 fieldName              string                Name of field that boundary condition is applied to.           

--- a/src/coreComponents/schema/docs/FieldSpecification.rst
+++ b/src/coreComponents/schema/docs/FieldSpecification.rst
@@ -5,7 +5,7 @@ Name                   Type         Default  Description
 ====================== ============ ======== ============================================================== 
 bcApplicationTableName string                Name of table that specifies the on/off application of the bc. 
 beginTime              real64       -1e+99   time at which BC will start being applied.                     
-component              integer      0        Component of field (if tensor) to apply boundary condition to  
+component              integer      -1       Component of field (if tensor) to apply boundary condition to  
 direction              R1Tensor     {0,0,0}  Direction to apply boundary condition to                       
 endTime                real64       1e+99    time at which bc will stop being applied                       
 fieldName              string                Name of field that boundary condition is applied to.           

--- a/src/coreComponents/schema/docs/ParallelPlatesPermeability_other.rst
+++ b/src/coreComponents/schema/docs/ParallelPlatesPermeability_other.rst
@@ -3,9 +3,9 @@
 =============== ============== ============================= 
 Name            Type           Description                   
 =============== ============== ============================= 
-dPerm_dAperture real64_array2d (no description available)    
-dPerm_dPressure real64_array2d  dPerm_dPressure of the rock. 
-permeability    real64_array2d  permeability of the rock.    
+dPerm_dAperture real64_array3d (no description available)    
+dPerm_dPressure real64_array3d  dPerm_dPressure of the rock. 
+permeability    real64_array3d  permeability of the rock.    
 =============== ============== ============================= 
 
 

--- a/src/coreComponents/schema/docs/PermeabilityBase_other.rst
+++ b/src/coreComponents/schema/docs/PermeabilityBase_other.rst
@@ -3,8 +3,8 @@
 =============== ============== ============================= 
 Name            Type           Description                   
 =============== ============== ============================= 
-dPerm_dPressure real64_array2d  dPerm_dPressure of the rock. 
-permeability    real64_array2d  permeability of the rock.    
+dPerm_dPressure real64_array3d  dPerm_dPressure of the rock. 
+permeability    real64_array3d  permeability of the rock.    
 =============== ============== ============================= 
 
 

--- a/src/coreComponents/schema/docs/SourceFlux.rst
+++ b/src/coreComponents/schema/docs/SourceFlux.rst
@@ -5,7 +5,7 @@ Name                   Type         Default  Description
 ====================== ============ ======== ============================================================== 
 bcApplicationTableName string                Name of table that specifies the on/off application of the bc. 
 beginTime              real64       -1e+99   time at which BC will start being applied.                     
-component              integer      0        Component of field (if tensor) to apply boundary condition to  
+component              integer      -1       Component of field (if tensor) to apply boundary condition to  
 direction              R1Tensor     {0,0,0}  Direction to apply boundary condition to                       
 endTime                real64       1e+99    time at which bc will stop being applied                       
 fieldName              string                Name of field that boundary condition is applied to.           

--- a/src/coreComponents/schema/docs/StrainDependentPermeability_other.rst
+++ b/src/coreComponents/schema/docs/StrainDependentPermeability_other.rst
@@ -3,8 +3,8 @@
 =============== ============== ============================= 
 Name            Type           Description                   
 =============== ============== ============================= 
-dPerm_dPressure real64_array2d  dPerm_dPressure of the rock. 
-permeability    real64_array2d  permeability of the rock.    
+dPerm_dPressure real64_array3d  dPerm_dPressure of the rock. 
+permeability    real64_array3d  permeability of the rock.    
 =============== ============== ============================= 
 
 

--- a/src/coreComponents/schema/schema.xsd
+++ b/src/coreComponents/schema/schema.xsd
@@ -293,7 +293,7 @@
 		<!--beginTime => time at which BC will start being applied.-->
 		<xsd:attribute name="beginTime" type="real64" default="-1e+99" />
 		<!--component => Component of field (if tensor) to apply boundary condition to-->
-		<xsd:attribute name="component" type="integer" default="0" />
+		<xsd:attribute name="component" type="integer" default="-1" />
 		<!--direction => Direction to apply boundary condition to-->
 		<xsd:attribute name="direction" type="R1Tensor" default="{0,0,0}" />
 		<!--endTime => time at which bc will stop being applied-->
@@ -319,7 +319,7 @@
 		<!--beginTime => time at which BC will start being applied.-->
 		<xsd:attribute name="beginTime" type="real64" default="-1e+99" />
 		<!--component => Component of field (if tensor) to apply boundary condition to-->
-		<xsd:attribute name="component" type="integer" default="0" />
+		<xsd:attribute name="component" type="integer" default="-1" />
 		<!--direction => Direction to apply boundary condition to-->
 		<xsd:attribute name="direction" type="R1Tensor" default="{0,0,0}" />
 		<!--endTime => time at which bc will stop being applied-->
@@ -345,7 +345,7 @@
 		<!--beginTime => time at which BC will start being applied.-->
 		<xsd:attribute name="beginTime" type="real64" default="-1e+99" />
 		<!--component => Component of field (if tensor) to apply boundary condition to-->
-		<xsd:attribute name="component" type="integer" default="0" />
+		<xsd:attribute name="component" type="integer" default="-1" />
 		<!--direction => Direction to apply boundary condition to-->
 		<xsd:attribute name="direction" type="R1Tensor" default="{0,0,0}" />
 		<!--endTime => time at which bc will stop being applied-->

--- a/src/coreComponents/schema/schema.xsd.other
+++ b/src/coreComponents/schema/schema.xsd.other
@@ -940,11 +940,11 @@
 	</xsd:complexType>
 	<xsd:complexType name="CarmanKozenyPermeabilityType">
 		<!--dPerm_dPorosity => (no description available)-->
-		<xsd:attribute name="dPerm_dPorosity" type="real64_array2d" />
+		<xsd:attribute name="dPerm_dPorosity" type="real64_array3d" />
 		<!--dPerm_dPressure =>  dPerm_dPressure of the rock.-->
-		<xsd:attribute name="dPerm_dPressure" type="real64_array2d" />
+		<xsd:attribute name="dPerm_dPressure" type="real64_array3d" />
 		<!--permeability =>  permeability of the rock.-->
-		<xsd:attribute name="permeability" type="real64_array2d" />
+		<xsd:attribute name="permeability" type="real64_array3d" />
 	</xsd:complexType>
 	<xsd:complexType name="CompositionalMultiphaseFluidType">
 		<!--dPhaseCompFraction_dGlobalCompFraction => (no description available)-->
@@ -1012,9 +1012,9 @@
 	<xsd:complexType name="CompressibleSolidPressurePorosityConstantPermeabilityType" />
 	<xsd:complexType name="ConstantPermeabilityType">
 		<!--dPerm_dPressure =>  dPerm_dPressure of the rock.-->
-		<xsd:attribute name="dPerm_dPressure" type="real64_array2d" />
+		<xsd:attribute name="dPerm_dPressure" type="real64_array3d" />
 		<!--permeability =>  permeability of the rock.-->
-		<xsd:attribute name="permeability" type="real64_array2d" />
+		<xsd:attribute name="permeability" type="real64_array3d" />
 	</xsd:complexType>
 	<xsd:complexType name="ContactType">
 		<xsd:choice minOccurs="0" maxOccurs="1">
@@ -1207,11 +1207,11 @@
 	<xsd:complexType name="NullModelType" />
 	<xsd:complexType name="ParallelPlatesPermeabilityType">
 		<!--dPerm_dAperture => (no description available)-->
-		<xsd:attribute name="dPerm_dAperture" type="real64_array2d" />
+		<xsd:attribute name="dPerm_dAperture" type="real64_array3d" />
 		<!--dPerm_dPressure =>  dPerm_dPressure of the rock.-->
-		<xsd:attribute name="dPerm_dPressure" type="real64_array2d" />
+		<xsd:attribute name="dPerm_dPressure" type="real64_array3d" />
 		<!--permeability =>  permeability of the rock.-->
-		<xsd:attribute name="permeability" type="real64_array2d" />
+		<xsd:attribute name="permeability" type="real64_array3d" />
 	</xsd:complexType>
 	<xsd:complexType name="ParticleFluidType">
 		<!--collisionFactor => (no description available)-->
@@ -1231,9 +1231,9 @@
 	</xsd:complexType>
 	<xsd:complexType name="PermeabilityBaseType">
 		<!--dPerm_dPressure =>  dPerm_dPressure of the rock.-->
-		<xsd:attribute name="dPerm_dPressure" type="real64_array2d" />
+		<xsd:attribute name="dPerm_dPressure" type="real64_array3d" />
 		<!--permeability =>  permeability of the rock.-->
-		<xsd:attribute name="permeability" type="real64_array2d" />
+		<xsd:attribute name="permeability" type="real64_array3d" />
 	</xsd:complexType>
 	<xsd:complexType name="PoreVolumeCompressibleSolidType">
 		<!--dPVMult_dDensity => (no description available)-->
@@ -1387,9 +1387,9 @@
 	</xsd:complexType>
 	<xsd:complexType name="StrainDependentPermeabilityType">
 		<!--dPerm_dPressure =>  dPerm_dPressure of the rock.-->
-		<xsd:attribute name="dPerm_dPressure" type="real64_array2d" />
+		<xsd:attribute name="dPerm_dPressure" type="real64_array3d" />
 		<!--permeability =>  permeability of the rock.-->
-		<xsd:attribute name="permeability" type="real64_array2d" />
+		<xsd:attribute name="permeability" type="real64_array3d" />
 	</xsd:complexType>
 	<xsd:complexType name="TableRelativePermeabilityType">
 		<!--dPhaseRelPerm_dPhaseVolFraction => (no description available)-->

--- a/src/coreComponents/unitTests/meshTests/testPAMELAImport.cpp
+++ b/src/coreComponents/unitTests/meshTests/testPAMELAImport.cpp
@@ -61,23 +61,32 @@ void TestMeshImport( string const & inputStringMesh,
 
   Group & cellBlockManager = domain->getGroup( keys::cellManager );
 
-  // This method will call the CopyElementSubRegionFromCellBlocks that will trigger the property transfer.
   elemManager.generateMesh( cellBlockManager );
 
+  // Register the target field on the mesh prior to import
+  if( !propertyToTest.empty() )
+  {
+    elemManager.forElementSubRegions( [&]( ElementSubRegionBase & subRegion )
+    {
+      subRegion.registerWrapper< array2d< real64 > >( propertyToTest ).reference().resizeDimension< 1 >( 3 );
+    } );
+  }
+
+  // Trigger import of the field
+  meshManager.importFields( *domain );
 
   // Check if the computed center match with the imported center
   if( !propertyToTest.empty() )
   {
-    auto centerProperty = elemManager.constructArrayViewAccessor< real64, 2 >( propertyToTest );
-    elemManager.forElementSubRegionsComplete< ElementSubRegionBase >(
-      [&]( localIndex const er, localIndex const esr, ElementRegionBase &, ElementSubRegionBase & elemSubRegion )
+    elemManager.forElementSubRegions< ElementSubRegionBase >( [&]( ElementSubRegionBase & subRegion )
     {
-      elemSubRegion.calculateElementGeometricQuantities( nodeManager, faceManager );
-      arrayView2d< real64 const > const elemCenter = elemSubRegion.getElementCenter();
-      for( localIndex ei = 0; ei < elemSubRegion.size(); ei++ )
+      subRegion.calculateElementGeometricQuantities( nodeManager, faceManager );
+      arrayView2d< real64 const > const elemCenter = subRegion.getElementCenter();
+      arrayView2d< real64 const > const centerProperty = subRegion.getReference< array2d< real64 > >( propertyToTest );
+      for( localIndex ei = 0; ei < subRegion.size(); ei++ )
       {
         real64 center[ 3 ] = LVARRAY_TENSOROPS_INIT_LOCAL_3( elemCenter[ ei ] );
-        LvArray::tensorOps::subtract< 3 >( center, centerProperty[er][esr][ei] );
+        LvArray::tensorOps::subtract< 3 >( center, centerProperty[ei] );
         GEOSX_ERROR_IF_GT_MSG( LvArray::tensorOps::l2Norm< 3 >( center ), meshBody.getGlobalLengthScale() * 1e-8, "Property import of centers if wrong" );
       }
     } );

--- a/src/docs/sphinx/tutorials/step01/Tutorial.rst
+++ b/src/docs/sphinx/tutorials/step01/Tutorial.rst
@@ -302,24 +302,25 @@ and assigns physical properties to them: density, viscosity, compressibility...
 
 
 In this tutorial, the physical properties of the materials
-defined as ``water`` and ``rock`` are provided here,
+defined as ``water``, ``rock`` and ``rockPerm`` are provided here,
 each material being derived from a different material type:
-a ``CompressibleSinglePhaseFluid``
-for the water, and a ``PoreVolumeCompressibleSolid`` for the rock.
+``CompressibleSinglePhaseFluid``
+for the water, ``PoreVolumeCompressibleSolid`` for the rock, and
+``ConstantPermeability`` for rock permeability.
 The list of attributes differs between these constitutive materials.
 
 
-The names ``water`` and ``rock`` are defined by the user
+The names ``water``, ``rock`` and ``rockPerm`` are defined by the user
 as handles to specific instances of physical materials.
 GEOSX uses S.I. units throughout, not field units.
 Pressures, for instance, are in Pascal, not psia.
 
 
-Note that we had used the handles ``water`` and ``rock`` in the input file
+Note that we had used the handles ``water``, ``rock`` and ``rockPerm`` in the input file
 in the ElementRegions section of the XML file,
-before the registration of these materials took place here, in Constitutive element. This highlights an important aspect of using XML in GEOSX:
-the order in which objects are registered and used
-in the XML file is not important.
+before the registration of these materials took place here, in Constitutive element.
+This highlights an important aspect of using XML in GEOSX:
+the order in which objects are registered and used in the XML file is not important.
 
 
 .. literalinclude:: ../../../../coreComponents/physicsSolvers/fluidFlow/integratedTests/singlePhaseFlow/3D_10x10x10_compressible.xml

--- a/src/docs/sphinx/tutorials/step04/Tutorial.rst
+++ b/src/docs/sphinx/tutorials/step04/Tutorial.rst
@@ -244,7 +244,7 @@ hexahedral meshes in GEOSX.
 
 The **CellElementRegion** must also point to the constitutive models that are used to update
 the dynamic rock and fluid properties in the cells of the reservoir mesh.
-The names ``fluid``, ``rock``, and ``relperm`` used for this in the ``materialList``
+The names ``fluid``, ``rock``, ``rockPerm`` and ``relperm`` used for this in the ``materialList``
 correspond to the attribute ``name`` of the **Constitutive** block.
 
 We also define five **WellElementRegions** corresponding to the five wells.
@@ -266,10 +266,11 @@ Defining material properties with constitutive laws
 ---------------------------------------------------------------------
 
 For a simulation performed with the **CompositionalMultiphaseFlow** 
-physics solver, at least three types of constitutive models must be
+physics solver, at least four types of constitutive models must be
 specified in the **Constitutive** XML block:
 
 - a fluid model describing the thermodynamics behavior of the fluid mixture,
+- a rock permeability model,
 - a relative permeability model,
 - a rock compressibility model.
 
@@ -291,11 +292,13 @@ viscosities (i.e., 0.001 Pa.s). Therefore, we set the end point of the oil
 relative permeability to 0.1 to preserve the mobility ratio of the SPE10 test case.
      
 .. note::
-        The names and order of the phases listed for the attribute ``phaseNames`` must be identical in the fluid model (here, **BlackOilFluid**) and the relative permeability model (here, **BrooksCoreyRelativePermeability**). Otherwise, GEOSX will throw an error and terminate. 
+   The names and order of the phases listed for the attribute ``phaseNames`` must be identical in the fluid model
+   (here, **BlackOilFluid**) and the relative permeability model (here, **BrooksCoreyRelativePermeability**).
+   Otherwise, GEOSX will throw an error and terminate.
 
-We also introduce a model to define the rock compressibility. This step is similar
-to what is described in the previous tutorials (see for instance
-:ref:`TutorialSinglePhaseFlowWithInternalMesh`).
+We also introduce models to define rock compressibility and permeability.
+This step is similar to what is described in the previous tutorials
+(see for instance :ref:`TutorialSinglePhaseFlowWithInternalMesh`).
 
 We remind the reader that the attribute ``name`` of the constitutive models defined here
 must be used in the **ElementRegions** and **Solvers** XML blocks to point the element


### PR DESCRIPTION
This PR changes the order of field data import from external meshes. Instead of importing data together with the mesh into CellBlocks and creating new wrappers for each imported field, the data import step is delayed until after the entire data repository has been initialized (see `ProblemManager::problemSetup() and `ProblemManager::importFields()`). This means each imported field must match a field already existing in GEOSX (typically allocated by a physics solver or a constitutive model), and creation of new fields is not allowed at this point.

I've also somewhat refactored the field import code in `PAMELAMeshGenerator` using type dispatch, which is necessary to handle array layout permutations correctly. The import is also now aware of the distinction between normal and material fields - the latter have an extra quadrature point dimension, and we copy the same value into each quadrature point when importing.

Finally, the PR adds the quadrature point dimension to permeability, which is a material field but did not have it previously. This is necessary for field cases and benchmarks that import permeability (egg, SPE10, etc.) to work.

@AntoineMazuyer this adds more work to you VTK mesh reader, although you don't have to tackle it all in the same PR. It's ok for https://github.com/GEOSX/GEOSX/pull/1453 to get merged with just the mesh generation capability, and refactor the property import later.

@francoishamon and @AntoineMazuyer this should fix external mesh workflows for users, but be aware that they need to specify target field for import as `rockPerm_permeability` where `rockPerm` is the name of permeability model.

Related to https://github.com/GEOSX/integratedTests/pull/142