### PR TITLE
Fixed bug in total density for surface condition injection rate

### DIFF
--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
@@ -526,11 +526,6 @@ void CompositionalMultiphaseWell::updateVolRatesForConstraint( WellElementSubReg
   arrayView1d< real64 const > const & dPres =
     subRegion.getReference< array1d< real64 > >( viewKeyStruct::deltaPressureString() );
 
-  arrayView2d< real64 const, compflow::USD_COMP > const & compDens =
-    subRegion.getReference< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::globalCompDensityString() );
-  arrayView2d< real64 const, compflow::USD_COMP > const & dCompDens =
-    subRegion.getReference< array2d< real64, compflow::LAYOUT_COMP > >( viewKeyStruct::deltaGlobalCompDensityString() );
-
   arrayView1d< real64 const > const & connRate =
     subRegion.getReference< array1d< real64 > >( viewKeyStruct::mixtureConnRateString() );
   arrayView1d< real64 const > const & dConnRate =
@@ -548,6 +543,10 @@ void CompositionalMultiphaseWell::updateVolRatesForConstraint( WellElementSubReg
   arrayView3d< real64 const, multifluid::USD_PHASE > const & phaseFrac = fluid.phaseFraction();
   arrayView3d< real64 const, multifluid::USD_PHASE > const & dPhaseFrac_dPres = fluid.dPhaseFraction_dPressure();
   arrayView4d< real64 const, multifluid::USD_PHASE_DC > const & dPhaseFrac_dComp = fluid.dPhaseFraction_dGlobalCompFraction();
+
+  arrayView2d< real64 const, multifluid::USD_FLUID > const & totalDens = fluid.totalDensity();
+  arrayView2d< real64 const, multifluid::USD_FLUID > const & dTotalDens_dPres = fluid.dTotalDensity_dPressure();
+  arrayView3d< real64 const, multifluid::USD_FLUID_DC > const & dTotalDens_dComp = fluid.dTotalDensity_dGlobalCompFraction();
 
   arrayView3d< real64 const, multifluid::USD_PHASE > const & phaseDens = fluid.phaseDensity();
   arrayView3d< real64 const, multifluid::USD_PHASE > const & dPhaseDens_dPres = fluid.dPhaseDensity_dPressure();
@@ -589,12 +588,13 @@ void CompositionalMultiphaseWell::updateVolRatesForConstraint( WellElementSubReg
                                 fluidWrapper,
                                 pres,
                                 dPres,
-                                compDens,
-                                dCompDens,
                                 compFrac,
                                 dCompFrac_dCompDens,
                                 connRate,
                                 dConnRate,
+                                totalDens,
+                                dTotalDens_dPres,
+                                dTotalDens_dComp,
                                 phaseDens,
                                 dPhaseDens_dPres,
                                 dPhaseDens_dComp,
@@ -615,10 +615,13 @@ void CompositionalMultiphaseWell::updateVolRatesForConstraint( WellElementSubReg
                                 dCurrentPhaseVolRate_dRate,
                                 &iwelemRef] ( localIndex const )
     {
+      stackArray1d< real64, maxNumComp > work( numComp );
+
+      // Step 1: evaluate the phase and total density in the reference element
+
       //    We need to evaluate the density as follows:
       //      - Surface conditions: using the surface pressure provided by the user
       //      - Reservoir conditions: using the pressure in the top element
-
       if( useSurfaceConditions )
       {
         // we need to compute the surface density
@@ -630,31 +633,42 @@ void CompositionalMultiphaseWell::updateVolRatesForConstraint( WellElementSubReg
         fluidWrapper.update( iwelemRef, 0, refPres, temp, compFrac[iwelemRef] );
       }
 
-      // total volume rate
+      // Step 2: update the total volume rate
+
       real64 const currentTotalRate = connRate[iwelemRef] + dConnRate[iwelemRef];
-      real64 totalDens = 0;
+
+      // Step 2.1: compute the inverse of the total density and derivatives
+
+      real64 const totalDensInv = 1.0 / totalDens[iwelemRef][0];
+      real64 const dTotalDensInv_dPres = -dTotalDens_dPres[iwelemRef][0] * totalDensInv * totalDensInv;
+      stackArray1d< real64, maxNumComp > dTotalDensInv_dCompDens( numComp );
       for( localIndex ic = 0; ic < numComp; ++ic )
       {
-        totalDens += compDens[iwelemRef][ic] + dCompDens[iwelemRef][ic];
+        dTotalDensInv_dCompDens[ic] = -dTotalDens_dComp[iwelemRef][0][ic] * totalDensInv * totalDensInv;
       }
-      real64 const totalDensInv = 1.0 / totalDens;
+      applyChainRuleInPlace( numComp, dCompFrac_dCompDens[iwelemRef], dTotalDensInv_dCompDens, work.data() );
+
+      // Step 2.2: divide the total mass/molar rate by the total density to get the total volumetric rate
       currentTotalVolRate = currentTotalRate * totalDensInv;
-      dCurrentTotalVolRate_dPres = 0; // using the fact that totalDens = \sum_c compDens (independent of pressure)
+      dCurrentTotalVolRate_dPres = ( useSurfaceConditions ==  0 ) * currentTotalRate * dTotalDensInv_dPres;
       dCurrentTotalVolRate_dRate = totalDensInv;
       for( localIndex ic = 0; ic < numComp; ++ic )
       {
-        dCurrentTotalVolRate_dCompDens[ic] = -currentTotalVolRate * totalDensInv; // using the fact that totalDens = \sum_c compDens
+        dCurrentTotalVolRate_dCompDens[ic] = currentTotalRate * dTotalDensInv_dCompDens[ic];
       }
 
-      // phase volume rate
-      stackArray1d< real64, maxNumComp > work( numComp );
+      // Step 3: update the phase volume rate
       for( localIndex ip = 0; ip < numPhase; ++ip )
       {
+
+        // Step 3.1: compute the inverse of the (phase density * phase fraction) and derivatives
         real64 const phaseDensInv = 1.0 / phaseDens[iwelemRef][0][ip];
         real64 const phaseFracTimesPhaseDensInv = phaseFrac[iwelemRef][0][ip] * phaseDensInv;
         real64 const dPhaseFracTimesPhaseDensInv_dPres = dPhaseFrac_dPres[iwelemRef][0][ip] * phaseDensInv
                                                          - dPhaseDens_dPres[iwelemRef][0][ip] * phaseFracTimesPhaseDensInv * phaseDensInv;
 
+
+        // Step 3.2: divide the total mass/molar rate by the (phase density * phase fraction) to get the phase volumetric rate
         currentPhaseVolRate[ip] = currentTotalRate * phaseFracTimesPhaseDensInv;
         dCurrentPhaseVolRate_dPres[ip] = ( useSurfaceConditions ==  0 ) * currentTotalRate * dPhaseFracTimesPhaseDensInv_dPres;
         dCurrentPhaseVolRate_dRate[ip] = phaseFracTimesPhaseDensInv;

--- a/src/coreComponents/unitTests/wellsTests/testReservoirCompositionalMultiphaseMSWells.cpp
+++ b/src/coreComponents/unitTests/wellsTests/testReservoirCompositionalMultiphaseMSWells.cpp
@@ -430,7 +430,7 @@ void testNumericalJacobian( CompositionalMultiphaseReservoir & solver,
       {
         solver.resetStateToBeginningOfStep( domain );
 
-        // here is the perturbation in the pressure of the well element
+        // here is the perturbation in the rate of the well element
         real64 const dRate = perturbParameter * ( connRate[iwelem] + perturbParameter );
         dConnRate.move( LvArray::MemorySpace::host, true );
         dConnRate[iwelem] = dRate;


### PR DESCRIPTION
This PR solves the problem found in https://github.com/GEOSX/GEOSX/discussions/1457#discussion-3406287 about the injection rate set at surface condition.  The PR fixes the issue by making sure that the total density used to compute the volume injected is evaluated at surface condition, which was not the case before this PR.

This PR requires a rebaseline of four integrated tests using the surface condition injection rate condition.

Related to: https://github.com/GEOSX/integratedTests/pull/143

