### PR TITLE
Prevent VTK counter FPE

### DIFF
--- a/src/coreComponents/fileIO/vtk/VTKPolyDataWriterInterface.cpp
+++ b/src/coreComponents/fileIO/vtk/VTKPolyDataWriterInterface.cpp
@@ -760,7 +760,7 @@ void VTKPolyDataWriterInterface::write( real64 const time,
 #if defined(__APPLE__) && defined(__MACH__)
   LvArray::system::FloatingPointExceptionGuard guard;
 #endif
-  
+
   string const stepSubFolder = getTimeStepSubFolder( time );
   if( MpiWrapper::commRank( MPI_COMM_GEOSX ) == 0 )
   {

--- a/src/coreComponents/fileIO/vtk/VTKPolyDataWriterInterface.cpp
+++ b/src/coreComponents/fileIO/vtk/VTKPolyDataWriterInterface.cpp
@@ -755,6 +755,12 @@ void VTKPolyDataWriterInterface::write( real64 const time,
                                         integer const cycle,
                                         DomainPartition const & domain )
 {
+  // This guard prevents crashes observed on MacOS due to a floating point exception
+  // triggered inside VTK by a progress indicator
+  #if defined(__APPLE__) && defined(__MACH__)
+    LvArray::system::FloatingPointExceptionGuard guard;
+  #endif
+  
   string const stepSubFolder = getTimeStepSubFolder( time );
   if( MpiWrapper::commRank( MPI_COMM_GEOSX ) == 0 )
   {

--- a/src/coreComponents/fileIO/vtk/VTKPolyDataWriterInterface.cpp
+++ b/src/coreComponents/fileIO/vtk/VTKPolyDataWriterInterface.cpp
@@ -757,9 +757,9 @@ void VTKPolyDataWriterInterface::write( real64 const time,
 {
   // This guard prevents crashes observed on MacOS due to a floating point exception
   // triggered inside VTK by a progress indicator
-  #if defined(__APPLE__) && defined(__MACH__)
-    LvArray::system::FloatingPointExceptionGuard guard;
-  #endif
+#if defined(__APPLE__) && defined(__MACH__)
+  LvArray::system::FloatingPointExceptionGuard guard;
+#endif
   
   string const stepSubFolder = getTimeStepSubFolder( time );
   if( MpiWrapper::commRank( MPI_COMM_GEOSX ) == 0 )


### PR DESCRIPTION
This fixes #1529 by preventing a floating point exception in the `vtkXMLWriter::UpdateProgressDiscrete(float)` method. This behavior has only been observed on MacOS, hence the `#if`.