### PR TITLE
Fix VTK crash with empty subregions

### DIFF
--- a/src/coreComponents/dataRepository/wrapperHelpers.hpp
+++ b/src/coreComponents/dataRepository/wrapperHelpers.hpp
@@ -683,7 +683,13 @@ int numArrayDims( T const & GEOSX_UNUSED_PARAM( var ) )
 template< typename T, int NDIM, int USD >
 localIndex numArrayComp( ArrayView< T const, NDIM, USD > const & var )
 {
-  return var.size() / var.size( 0 );
+  return LvArray::indexing::multiplyAll< NDIM - 1 >( var.dims() + 1 );
+}
+
+template< typename T >
+localIndex numArrayComp( ArrayView< T const, 1, 0 > const & GEOSX_UNUSED_PARAM( var ) )
+{
+  return 1;
 }
 
 template< typename T >

--- a/src/coreComponents/fileIO/vtk/VTKPolyDataWriterInterface.cpp
+++ b/src/coreComponents/fileIO/vtk/VTKPolyDataWriterInterface.cpp
@@ -443,6 +443,25 @@ void setComponentMetadata( Wrapper< Array< T, 2, PERM > > const & wrapper,
 }
 
 /**
+ * @brief Produces a temporary array slice from a view that can be looped over.
+ * @param view the source view
+ * @return a fake slice that does not point to real data but has correct dims/strides.
+ * @note The slice is only valid as long as the @p view is in scope.
+ *       Values in the slice may be uninitialized and should not be used.
+ */
+template< typename T, int NDIM, int USD >
+ArraySlice< T const, NDIM - 1, USD - 1 >
+makeTemporarySlice( ArrayView< T const, NDIM, USD > const & view )
+{
+  // The following works in all compilers, but technically invokes undefined behavior:
+  // return ArraySlice< T, NDIM - 1, USD - 1 >( nullptr, view.dims() + 1, view.strides() + 1 );
+  localIndex const numComp = LvArray::indexing::multiplyAll< NDIM - 1 >( view.dims() + 1 );
+  static array1d< T > arr;
+  arr.template resizeWithoutInitializationOrDestruction( numComp );
+  return ArraySlice< T const, NDIM - 1, USD - 1 >( arr.data(), view.dims() + 1, view.strides() + 1 );
+}
+
+/**
  * @brief Generic component metadata handler for multidimensional arrays.
  * @param wrapper GEOSX typed wrapper over source array
  * @param data VTK typed data array
@@ -451,17 +470,7 @@ template< typename T, int NDIM, typename PERM >
 void setComponentMetadata( Wrapper< Array< T, NDIM, PERM > > const & wrapper,
                            vtkAOSDataArrayTemplate< T > & data )
 {
-  auto const view = wrapper.referenceAsView();
-
-  // check the size of the first dimension to handle the case of an empty region
-  if( view.size( 0 ) > 0 )
-  {
-    data.SetNumberOfComponents( view.size() / view.size( 0 ) );
-  }
-  else
-  {
-    data.SetNumberOfComponents( 0 );
-  }
+  data.SetNumberOfComponents( wrapper.numArrayComp() );
 
   Span< string const > labels[NDIM-1];
   for( integer dim = 1; dim < NDIM; ++dim )
@@ -469,15 +478,15 @@ void setComponentMetadata( Wrapper< Array< T, NDIM, PERM > > const & wrapper,
     labels[dim-1] = getDimLabels( wrapper, dim );
   }
 
-  if( view.size( 0 ) > 0 )
+  auto const view = wrapper.referenceAsView();
+  auto const slice = view.size( 0 ) > 0 ? view[0] : makeTemporarySlice( view );
+
+  integer compIndex = 0;
+  LvArray::forValuesInSliceWithIndices( slice, [&]( T const &, auto const ... indices )
   {
-    integer compIndex = 0;
-    LvArray::forValuesInSliceWithIndices( view[0], [&]( T const &, auto const ... indices )
-    {
-      using idx_seq = std::make_integer_sequence< integer, sizeof...(indices) >;
-      data.SetComponentName( compIndex++, makeComponentName( labels, idx_seq{}, indices ... ).c_str() );
-    } );
-  }
+    using idx_seq = std::make_integer_sequence< integer, sizeof...(indices) >;
+    data.SetComponentName( compIndex++, makeComponentName( labels, idx_seq{}, indices ... ).c_str() );
+  } );
 }
 
 template< class SUBREGION = Group >

--- a/src/coreComponents/mesh/generators/PAMELAMeshGenerator.cpp
+++ b/src/coreComponents/mesh/generators/PAMELAMeshGenerator.cpp
@@ -362,7 +362,7 @@ void importRegularField( PAMELA::VariableDouble & source,
     auto const view = wrapperT.reference().toView();
 
     localIndex const numComponentsSrc = LvArray::integerConversion< localIndex >( source.offset );
-    localIndex const numComponentsDst = view.size() / view.size( 0 );
+    localIndex const numComponentsDst = wrapperT.numArrayComp();
     GEOSX_ERROR_IF_NE_MSG( numComponentsDst, numComponentsSrc,
                            "PAMELA mesh import: mismatch in number of components for field " << source.Label );
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/integratedTests/compositionalMultiphaseWell/compositional_multiphase_wells_1d.xml
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/integratedTests/compositionalMultiphaseWell/compositional_multiphase_wells_1d.xml
@@ -106,7 +106,7 @@
     <PeriodicEvent
       name="outputs"
       timeFrequency="2.5e3"
-      target="/Outputs/siloOutput"/>
+      target="/Outputs/vtkOutput"/>
 
     <PeriodicEvent
       name="restarts"
@@ -230,8 +230,8 @@
   </FieldSpecifications>
 
   <Outputs>
-    <Silo
-      name="siloOutput"/>
+    <VTK
+      name="vtkOutput"/>
 
     <Restart
       name="restartOutput"/>

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/integratedTests/compositionalMultiphaseWell/dead_oil_wells_2d.xml
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/integratedTests/compositionalMultiphaseWell/dead_oil_wells_2d.xml
@@ -158,7 +158,7 @@
     <PeriodicEvent
       name="outputs"
       timeFrequency="5e4"
-      target="/Outputs/siloOutput"/>
+      target="/Outputs/vtkOutput"/>
 
     <PeriodicEvent
       name="restarts"
@@ -290,8 +290,8 @@
   </Functions>
 
   <Outputs>
-    <Silo
-      name="siloOutput"/>
+    <VTK
+      name="vtkOutput"/>
 
     <Restart
       name="restartOutput"/>

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/integratedTests/compositionalMultiphaseWell/staircase_co2_wells_hybrid_3d.xml
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/integratedTests/compositionalMultiphaseWell/staircase_co2_wells_hybrid_3d.xml
@@ -100,7 +100,7 @@
     <PeriodicEvent
       name="outputs"
       timeFrequency="5e4"
-      target="/Outputs/siloOutput"/>
+      target="/Outputs/vtkOutput"/>
 
     <PeriodicEvent
       name="solverApplications"
@@ -209,8 +209,8 @@
   </FieldSpecifications>
 
   <Outputs>
-    <Silo
-      name="siloOutput"/>
+    <VTK
+      name="vtkOutput"/>
 
     <Restart
       name="restartOutput"/>


### PR DESCRIPTION
This PR adds checks to avoid a division by zero when a subregion is empty on an MPI rank. This happens for example in the well subregions, and makes GEOSX crash. This is my bad, I should have added VTK output to the well integrated tests to catch errors like these. I propose to do it in this PR.

Requires a rebaseline for the integrated tests changed to VTK.

Related to https://github.com/GEOSX/integratedTests/pull/144