### PR TITLE
Fix for reference porosity import

### DIFF
--- a/src/coreComponents/mesh/generators/PAMELAMeshGenerator.cpp
+++ b/src/coreComponents/mesh/generators/PAMELAMeshGenerator.cpp
@@ -351,7 +351,8 @@ namespace
 
 void importRegularField( PAMELA::VariableDouble & source,
                          std::vector< int > const & indexMap,
-                         WrapperBase & wrapper )
+                         WrapperBase & wrapper,
+                         string const & objectName )
 {
   // Scalar material fields are stored as 1D arrays, vector/tensor are 2D
   using ImportTypes = types::ArrayTypes< types::RealTypes, types::DimsRange< 1, 2 > >;
@@ -364,11 +365,11 @@ void importRegularField( PAMELA::VariableDouble & source,
     localIndex const numComponentsSrc = LvArray::integerConversion< localIndex >( source.offset );
     localIndex const numComponentsDst = wrapperT.numArrayComp();
     GEOSX_ERROR_IF_NE_MSG( numComponentsDst, numComponentsSrc,
-                           "PAMELA mesh import: mismatch in number of components for field " << source.Label );
+                           objectName << ": mismatch in number of components for field " << source.Label );
 
     // Sanity check, shouldn't happen
     GEOSX_ERROR_IF_NE_MSG( view.size( 0 ), LvArray::integerConversion< localIndex >( indexMap.size() ),
-                           "PAMELA mesh import: mismatch in size for field " << source.Label );
+                           objectName << ": mismatch in size for field " << source.Label );
 
     for( int i = 0; i < view.size( 0 ); ++i )
     {
@@ -386,7 +387,8 @@ void importRegularField( PAMELA::VariableDouble & source,
 
 void importMaterialField( PAMELA::VariableDouble & source,
                           std::vector< int > const & indexMap,
-                          WrapperBase & wrapper )
+                          WrapperBase & wrapper,
+                          string const & objectName )
 {
   // Scalar material fields are stored as 2D arrays, vector/tensor are 3D
   using ImportTypes = types::ArrayTypes< types::RealTypes, types::DimsRange< 2, 3 > >;
@@ -399,11 +401,11 @@ void importMaterialField( PAMELA::VariableDouble & source,
     localIndex const numComponentsSrc = LvArray::integerConversion< localIndex >( source.offset );
     localIndex const numComponentsDst = view.size() / ( view.size( 0 ) * view.size( 1 ) );
     GEOSX_ERROR_IF_NE_MSG( numComponentsDst, numComponentsSrc,
-                           "PAMELA mesh import: mismatch in number of components for field " << source.Label );
+                           objectName << ": mismatch in number of components for field " << source.Label );
 
     // Sanity check, shouldn't happen
     GEOSX_ERROR_IF_NE_MSG( view.size( 0 ), LvArray::integerConversion< localIndex >( indexMap.size() ),
-                           "PAMELA mesh import: mismatch in size for field " << source.Label );
+                           objectName << ": mismatch in size for field " << source.Label );
 
     for( int i = 0; i < view.size( 0 ); ++i )
     {
@@ -445,7 +447,7 @@ std::unordered_set< string > getMaterialWrapperNames( ElementSubRegionBase const
 
 void PAMELAMeshGenerator::importFields( DomainPartition & domain ) const
 {
-  GEOSX_LOG_RANK_0( "Importing field data from mesh dataset" );
+  GEOSX_LOG_RANK_0( catalogName() << " " << getName() << ": importing field data from mesh dataset" );
   GEOSX_ASSERT_MSG( m_pamelaMesh, "Must call generateMesh() before importFields()" );
 
   ElementRegionManager & elemManager = domain.getMeshBody( this->getName() ).getMeshLevel( 0 ).getElemManager();
@@ -475,23 +477,24 @@ void PAMELAMeshGenerator::importFields( DomainPartition & domain ) const
 
       // Find source
       PAMELA::VariableDouble * const meshProperty = regionPtr->FindVariableByName( sourceName );
-      GEOSX_ASSERT( meshProperty != nullptr );
+      GEOSX_THROW_IF( meshProperty == nullptr,
+                      catalogName() << " " << getName() << ": field not found in source dataset: " << sourceName,
+                      InputError );
 
       // Find destination
       GEOSX_THROW_IF( !subRegion.hasWrapper( wrapperName ),
-                      "PAMELA mesh import: target field not found: " << wrapperName << ".\n" <<
-                      "Please check the spelling in " << viewKeyStruct::fieldNamesInGEOSXString() << " attribute.",
+                      catalogName() << " " << getName() << ": target field not found: " << wrapperName,
                       InputError );
       WrapperBase & wrapper = subRegion.getWrapperBase( wrapperName );
 
       // Decide if field is constitutive or not
-      if( materialWrapperNames.count( wrapperName ) > 0 )
+      if( materialWrapperNames.count( wrapperName ) > 0 && wrapper.numArrayDims() > 1 )
       {
-        importMaterialField( *meshProperty, cellBlockPtr->IndexMapping, wrapper );
+        importMaterialField( *meshProperty, cellBlockPtr->IndexMapping, wrapper, catalogName() + " " + getName() );
       }
       else
       {
-        importRegularField( *meshProperty, cellBlockPtr->IndexMapping, wrapper );
+        importRegularField( *meshProperty, cellBlockPtr->IndexMapping, wrapper, catalogName() + " " + getName() );
       }
     }
   } );

--- a/src/coreComponents/physicsSolvers/fluidFlow/benchmarks/Egg/dead_oil_egg.xml
+++ b/src/coreComponents/physicsSolvers/fluidFlow/benchmarks/Egg/dead_oil_egg.xml
@@ -154,7 +154,7 @@
       name="mesh"
       file="../../../../../../../GEOSXDATA/DataSets/Egg/egg.msh"
       fieldsToImport="{ PERM }"
-      fieldNamesInGEOSX="{ rockPerm_permeability, rockPorosity_referencePorosity }"/>
+      fieldNamesInGEOSX="{ rockPerm_permeability }"/>
 
     <InternalWell
       name="wellProducer1"
@@ -721,7 +721,7 @@
       initialCondition="1"
       setNames="{ all }"
       objectPath="ElementRegions/reservoir/DEFAULT_HEX"
-      fieldName="referencePorosity"
+      fieldName="rockPorosity_referencePorosity"
       scale="0.2"/>
 
     <FieldSpecification


### PR DESCRIPTION
Resolves https://github.com/GEOSX/GEOSX/issues/1553

Instead of making `referencePorosity` a pseudo-2D field (as I suggested in the issue), I just modified the logic in PAMELA field import to treat 1D fields as normal, non-material data.

This fixes the import in fluid flow benchmarks (Egg and SPE10), although both of these problems eventually fail due to a floating point error in the linear solver. But that is worth of another investigation.