### PR TITLE
Implemented aquifer boundary condition

### DIFF
--- a/src/coreComponents/fieldSpecification/AquiferBoundaryCondition.cpp
+++ b/src/coreComponents/fieldSpecification/AquiferBoundaryCondition.cpp
@@ -1,0 +1,165 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 Total, S.A
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file AquiferBoundaryCondition.cpp
+ */
+
+#include "AquiferBoundaryCondition.hpp"
+
+#include "mesh/DomainPartition.hpp"
+
+namespace geosx
+{
+
+using namespace dataRepository;
+
+AquiferBoundaryCondition::AquiferBoundaryCondition( string const & name, Group * parent )
+  : FieldSpecificationBase( name, parent ),
+  m_cumulativeFlux( 0.0 )
+{
+  registerWrapper( viewKeyStruct::aquiferPorosityString(), &m_porosity ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "Aquifer porosity" );
+
+  registerWrapper( viewKeyStruct::aquiferPermeabilityString(), &m_permeability ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "Aquifer permeability [m^2]" );
+
+  registerWrapper( viewKeyStruct::aquiferInitialPressureString(), &m_initialPressure ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "Aquifer initial pressure [Pa]" );
+
+  registerWrapper( viewKeyStruct::aquiferWaterViscosityString(), &m_viscosity ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "Aquifer water viscosity [Pa.s]" );
+
+  registerWrapper( viewKeyStruct::aquiferWaterDensityString(), &m_density ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "Aquifer water density [kg.m^-3]" );
+
+  registerWrapper( viewKeyStruct::aquiferTotalCompressibilityString(), &m_totalCompressibility ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "Aquifer total compressibility (rock and fluid) [Pa^-1]" );
+
+  registerWrapper( viewKeyStruct::aquiferWaterPhaseComponentFractionString(), &m_phaseComponentFraction ).
+    setInputFlag( InputFlags::OPTIONAL ).
+    setSizedFromParent( 0 ).
+    setDescription( "Aquifer water phase component fraction" );
+
+  registerWrapper( viewKeyStruct::aquiferWaterPhaseComponentNamesString(), &m_phaseComponentNames ).
+    setInputFlag( InputFlags::OPTIONAL ).
+    setSizedFromParent( 0 ).
+    setDescription( "Aquifer water phase component names" );
+
+  registerWrapper( viewKeyStruct::aquiferElevationString(), &m_elevation ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "Aquifer elevation (positive going upward) [m]" );
+
+  registerWrapper( viewKeyStruct::aquiferThicknessString(), &m_thickness ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "Aquifer thickness [m]" );
+
+  registerWrapper( viewKeyStruct::aquiferInnerRadiusString(), &m_innerRadius ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "Aquifer inner radius [m]" );
+
+  registerWrapper( viewKeyStruct::aquiferAngleString(), &m_angle ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "Angle subtended by the aquifer boundary from the center of the reservoir [degress]" );
+
+  registerWrapper( viewKeyStruct::pressureInfluenceFunctionNameString(), &m_pressureInfluenceFunctionName ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "Name of the table describing the pressure influence function" );
+
+  registerWrapper( viewKeyStruct::cumulativeFluxString(), &m_cumulativeFlux ).
+    setInputFlag( InputFlags::FALSE );
+
+  getWrapper< string >( FieldSpecificationBase::viewKeyStruct::fieldNameString() ).
+    setInputFlag( InputFlags::FALSE );
+  setFieldName( catalogName() );
+
+  getWrapper< int >( FieldSpecificationBase::viewKeyStruct::componentString() ).
+    setInputFlag( InputFlags::FALSE );
+
+}
+
+void AquiferBoundaryCondition::postProcessInput()
+{
+  GEOSX_THROW_IF( m_permeability <= 0.0,
+                  getCatalogName() << " " << getName() << ": the aquifer permeability cannot be equal to zero or negative",
+                  InputError );
+
+  GEOSX_THROW_IF( m_pressureInfluenceFunctionName.empty(),
+                  getCatalogName() << " " << getName() << ": the pressure influence table name must be specified using the keyword " << viewKeyStruct::pressureInfluenceFunctionNameString(),
+                  InputError );
+
+  FunctionManager const & functionManager = FunctionManager::getInstance();
+  GEOSX_THROW_IF( !functionManager.hasGroup( m_pressureInfluenceFunctionName ),
+                  getCatalogName() << " " << getName() << ": the pressure influence table " << m_pressureInfluenceFunctionName << " could not be found",
+                  InputError );
+
+  computeTimeConstant();
+  computeInfluxConstant();
+
+  GEOSX_THROW_IF( m_timeConstant <= 0.0,
+                  getCatalogName() << " " << getName() << ": the aquifer time constant is equal to zero or negative, the simulation cannot procede",
+                  InputError );
+
+  GEOSX_THROW_IF( m_influxConstant <= 0.0,
+                  getCatalogName() << " " << getName() << ": the aquifer influx constant is equal to zero or negative, the simulation cannot procede",
+                  InputError );
+
+  GEOSX_THROW_IF( m_phaseComponentFraction.size() != m_phaseComponentNames.size(),
+                  getCatalogName() << " " << getName() << ": the sizes of "
+                                   << viewKeyStruct::aquiferWaterPhaseComponentFractionString() << " and " << viewKeyStruct::aquiferWaterPhaseComponentNamesString()
+                                   << " are inconsistent",
+                  InputError );
+
+}
+
+void AquiferBoundaryCondition::initializePreSubGroups()
+{}
+
+void AquiferBoundaryCondition::computeTimeConstant()
+{
+  // equation 5.3 of the Eclipse TD
+  m_timeConstant = m_viscosity * m_porosity * m_totalCompressibility * m_innerRadius * m_innerRadius;
+  m_timeConstant /= m_permeability;
+}
+
+void AquiferBoundaryCondition::computeInfluxConstant()
+{
+  // equation 5.4 of the Eclipse TD
+  m_influxConstant = m_thickness * m_angle * m_porosity * m_totalCompressibility * m_innerRadius * m_innerRadius;
+}
+
+AquiferBoundaryCondition::KernelWrapper AquiferBoundaryCondition::createKernelWrapper() const
+{
+  FunctionManager const & functionManager = FunctionManager::getInstance();
+  TableFunction const & pressureInfluenceFunction = functionManager.getGroup< TableFunction >( m_pressureInfluenceFunctionName );
+
+  return AquiferBoundaryCondition::KernelWrapper( m_initialPressure,
+                                                  m_density,
+                                                  m_elevation * m_gravityVector[2],
+                                                  m_timeConstant,
+                                                  m_influxConstant,
+                                                  m_cumulativeFlux,
+                                                  pressureInfluenceFunction.createKernelWrapper() );
+}
+
+REGISTER_CATALOG_ENTRY( FieldSpecificationBase, AquiferBoundaryCondition, string const &, Group * const )
+
+
+} /* namespace geosx */

--- a/src/coreComponents/fieldSpecification/AquiferBoundaryCondition.hpp
+++ b/src/coreComponents/fieldSpecification/AquiferBoundaryCondition.hpp
@@ -1,0 +1,349 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 Total, S.A
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file AquiferBoundaryCondition.hpp
+ */
+
+
+#ifndef GEOSX_FIELDSPECIFICATION_AQUIFERBOUNDARYCONDITION_HPP
+#define GEOSX_FIELDSPECIFICATION_AQUIFERBOUNDARYCONDITION_HPP
+
+#include "FieldSpecificationBase.hpp"
+#include "finiteVolume/BoundaryStencil.hpp"
+#include "functions/TableFunction.hpp"
+#include "mesh/FaceManager.hpp"
+
+namespace geosx
+{
+
+/**
+ * @class AquiferBoundaryCondition
+ * Holds data and methods to apply a traction boundary condition
+ */
+class AquiferBoundaryCondition : public FieldSpecificationBase
+{
+public:
+
+  /**
+   * @class KernelWrapper
+   *
+   * A nested class encapsulating the kernel function doing the computing the average influx rate
+   */
+  class KernelWrapper
+  {
+public:
+
+    /**
+     * @brief Constructor of the kernel wrapper
+     * @param[in] initialPressure the initial pressure in the aquifer
+     * @param[in] density the water density in the aquifer
+     * @param[in] gravCoef the elevation * gravVector in the aquifer
+     * @param[in] timeConstant the time constant of the aquifer
+     * @param[in] influxConstant the influx constant of the aquifer
+     * @param[in] cumulativeFlux the cumulative flux of the aquifer
+     * @param[in] pressureInfluenceFunction the pressure influence function of the aquifer
+     */
+    KernelWrapper( real64 initialPressure,
+                   real64 density,
+                   real64 gravCoef,
+                   real64 timeConstant,
+                   real64 influxConstant,
+                   real64 cumulativeFlux,
+                   TableFunction::KernelWrapper pressureInfluenceFunction )
+      : m_initialPressure( initialPressure ),
+      m_density( density ),
+      m_gravCoef( gravCoef ),
+      m_timeConstant( timeConstant ),
+      m_influxConstant( influxConstant ),
+      m_cumulativeFlux( cumulativeFlux ),
+      m_pressureInfluenceFunction( pressureInfluenceFunction )
+    {}
+
+    /**
+     * @brief Compute the aquifer-reservoir volumetric flux
+     * @param[in] timeAtEndOfStep the time at the end of the step
+     * @param[in] reservoirPressure the current reservoir pressure
+     * @param[in] reservoirGravCoef the elevation * gravVector in the aquifer
+     * @param[in] areaFraction the area fraction for the face
+     * @param[out] dAquiferVolFlux_dPres the derivative of the aquifer-reservoir volumetric flux
+     * @return the aquifer-reservoir volumetric flux
+     */
+    GEOSX_HOST_DEVICE
+    inline real64
+    compute( real64 const & timeAtEndOfStep,
+             real64 const & reservoirPressure,
+             real64 const & reservoirGravCoef,
+             real64 const & areaFraction,
+             real64 & dAquiferVolFlux_dPres ) const;
+
+private:
+
+    // Physical parameters
+
+    /// Aquifer initial pressure
+    real64 m_initialPressure;
+
+    /// Aquifer water density
+    real64 m_density;
+
+    /// Aquifer gravity coefficient
+    real64 m_gravCoef;
+
+    /// Aquifer time constant
+    real64 m_timeConstant;
+
+    /// Aquifer influx constant
+    real64 m_influxConstant;
+
+    /// Aquifer cumulative influx
+    real64 m_cumulativeFlux;
+
+    /// Pressure influence function
+    TableFunction::KernelWrapper m_pressureInfluenceFunction;
+
+  };
+
+  /// @copydoc FieldSpecificationBase(string const &, Group *)
+  AquiferBoundaryCondition( string const & name, Group * parent );
+
+  /// deleted default constructor
+  AquiferBoundaryCondition() = delete;
+
+  /// default destructor
+  virtual ~AquiferBoundaryCondition() = default;
+
+  /// deleted copy constructor
+  AquiferBoundaryCondition( AquiferBoundaryCondition const & ) = delete;
+
+  /// defaulted move constructor
+  AquiferBoundaryCondition( AquiferBoundaryCondition && ) = default;
+
+  /// deleted copy assignment operator
+  AquiferBoundaryCondition & operator=( AquiferBoundaryCondition const & ) = delete;
+
+  /// deleted move assignment operator
+  AquiferBoundaryCondition & operator=( AquiferBoundaryCondition && ) = delete;
+
+  /**
+   * @brief Static Factory Catalog Functions
+   * @return the catalog name
+   */
+  static string catalogName() { return "Aquifer"; }
+
+  /**
+   * @brief Create the wrapper performing in-kernel aquifer flow rate computation
+   * @return the kernel wrapper
+   */
+  KernelWrapper createKernelWrapper() const;
+
+  /**
+   * @brief Setter for the R1Tensor storing the gravity vector
+   * @param[in] gravityVector the gravity vector
+   */
+  void setGravityVector( R1Tensor const & gravityVector ) { m_gravityVector = gravityVector; }
+
+  /**
+   * @brief Increment the cumulative flux for this aquifer
+   * @param[in] fluxIncrement the new fluxes multiplied by dt
+   */
+  void saveConvergedState( real64 const fluxIncrement ) { m_cumulativeFlux += fluxIncrement; }
+
+  /**
+   * @brief Getter for the aquifer water phase density
+   * @return the value of the water phase density
+   */
+  real64 const & getWaterPhaseDensity() const { return m_density; }
+
+  /**
+   * @brief Getter for the aquifer water phase composition
+   * @return an array storing the water phase component fractions
+   */
+  arrayView1d< real64 const > getWaterPhaseComponentFraction() const { return m_phaseComponentFraction.toViewConst(); }
+
+  /**
+   * @brief Getter for the aquifer water phase component names
+   * @return an array storing the water phase component names
+   */
+  arrayView1d< string const > getWaterPhaseComponentNames() const { return m_phaseComponentNames.toViewConst(); }
+
+
+  /**
+   * @brief View keys
+   */
+  struct viewKeyStruct : public FieldSpecificationBase::viewKeyStruct
+  {
+
+    // aquifer geological properties
+
+    /// @return The key for porosity
+    constexpr static char const * aquiferPorosityString() { return "aquiferPorosity"; }
+
+    /// @return The key for permeability
+    constexpr static char const * aquiferPermeabilityString() { return "aquiferPermeability"; }
+
+    // aquifer fluid properties
+
+    /// @return The key for initial pressure
+    constexpr static char const * aquiferInitialPressureString() { return "aquiferInitialPressure"; }
+
+    /// @return The key for viscosity
+    constexpr static char const * aquiferWaterViscosityString() { return "aquiferWaterViscosity"; }
+
+    /// @return The key for density
+    constexpr static char const * aquiferWaterDensityString() { return "aquiferWaterDensity"; }
+
+    /// @return The key for phase component fraction
+    constexpr static char const * aquiferWaterPhaseComponentFractionString() { return "aquiferWaterPhaseComponentFraction"; }
+
+    /// @return The key for phase component names
+    constexpr static char const * aquiferWaterPhaseComponentNamesString() { return "aquiferWaterPhaseComponentNames"; }
+
+    /// @return The key for total compressibility
+    constexpr static char const * aquiferTotalCompressibilityString() { return "aquiferTotalCompressibility"; }
+
+    // aquifer geometry
+
+    /// @return The key for elevation
+    constexpr static char const * aquiferElevationString() { return "aquiferElevation"; }
+
+    /// @return The key for thickness
+    constexpr static char const * aquiferThicknessString() { return "aquiferThickness"; }
+
+    /// @return The key for inner radius
+    constexpr static char const * aquiferInnerRadiusString() { return "aquiferInnerRadius"; }
+
+    /// @return The key for angle
+    constexpr static char const * aquiferAngleString() { return "aquiferAngle"; }
+
+    // table influence function
+
+    /// @return The key for the pressure influence function
+    constexpr static char const * pressureInfluenceFunctionNameString() { return "pressureInfluenceFunctionName"; }
+
+    // cumulative flux
+
+    /// @return The key for the cumulative aquifer flux
+    constexpr static char const * cumulativeFluxString() { return "cumulativeFlux"; }
+
+  };
+
+
+protected:
+
+  virtual void postProcessInput() override final;
+
+  virtual void initializePreSubGroups() override final;
+
+private:
+
+  /**
+   * @brief Compute the aquifer time constant as a function of water properties, and aquifer geology / geometry
+   */
+  void computeTimeConstant();
+
+  /**
+   * @brief Compute the aquifer influx constant as a function of aquifer geology and geometry
+   */
+  void computeInfluxConstant();
+
+
+  // Physical parameters
+
+  /// Gravity vector
+  R1Tensor m_gravityVector;
+
+  /// Porosity of the aquifer
+  real64 m_porosity;
+
+  /// Permeability of the aquifer
+  real64 m_permeability;
+
+  /// Initial pressure
+  real64 m_initialPressure;
+
+  /// Water viscosity
+  real64 m_viscosity;
+
+  /// Water density
+  real64 m_density;
+
+  /// Water phase component fraction
+  array1d< real64 > m_phaseComponentFraction;
+
+  /// Water phase component names
+  array1d< string > m_phaseComponentNames;
+
+  /// Total compressibility (rock + water)
+  real64 m_totalCompressibility;
+
+  /// Aquifer elevation
+  real64 m_elevation;
+
+  /// Aquifer thickness
+  real64 m_thickness;
+
+  /// Aquifer inner radius
+  real64 m_innerRadius;
+
+  /// Aquifer angle
+  real64 m_angle;
+
+  /// Aquifer time constant
+  real64 m_timeConstant;
+
+  /// Aquifer influx constant
+  real64 m_influxConstant;
+
+  /// Cumulative aquifer flux
+  real64 m_cumulativeFlux;
+
+  /// Name of the pressure influence table
+  string m_pressureInfluenceFunctionName;
+
+};
+
+GEOSX_HOST_DEVICE
+real64
+AquiferBoundaryCondition::KernelWrapper::
+  compute( real64 const & timeAtEndOfStep,
+           real64 const & reservoirPressure,
+           real64 const & reservoirGravCoef,
+           real64 const & areaFraction,
+           real64 & dAquiferVolFlux_dPres ) const
+{
+  // compute the dimensionless time (equation 5.5 of the Eclipse TD)
+  real64 const dimensionlessTime = timeAtEndOfStep / m_timeConstant;
+
+  // compute the pressure influence and its derivative wrt to dimensionless time
+  real64 dPresInfluence_dTime = 0;
+  real64 const presInfluence = m_pressureInfluenceFunction.compute( &timeAtEndOfStep, &dPresInfluence_dTime );
+
+  // compute the potential difference between the reservoir and the aquifer
+  real64 const potDiff = m_initialPressure - reservoirPressure - m_density * ( m_gravCoef - reservoirGravCoef );
+  real64 const dPotDiff_dPres = -1;
+
+  // compute the average inflow rate (equation 2.266 of the Intersect TD)
+  real64 const coef = areaFraction / m_timeConstant;
+  real64 const denom = presInfluence - dimensionlessTime * dPresInfluence_dTime;
+  real64 const aquiferVolFlux = coef * ( m_influxConstant * potDiff - m_cumulativeFlux * dPresInfluence_dTime ) / denom;
+  dAquiferVolFlux_dPres = coef * m_influxConstant * dPotDiff_dPres / denom;
+
+  return aquiferVolFlux;
+}
+
+
+} /* namespace geosx */
+
+#endif /* GEOSX_FIELDSPECIFICATION_AQUIFERBOUNDARYCONDITION_HPP */

--- a/src/coreComponents/fieldSpecification/CMakeLists.txt
+++ b/src/coreComponents/fieldSpecification/CMakeLists.txt
@@ -7,6 +7,7 @@ set( fieldSpecification_headers
      FieldSpecificationManager.hpp
      SourceFluxBoundaryCondition.hpp
      TractionBoundaryCondition.hpp
+     AquiferBoundaryCondition.hpp
    )
 
 #
@@ -18,6 +19,7 @@ set( fieldSpecification_sources
      FieldSpecificationManager.cpp
      SourceFluxBoundaryCondition.cpp
      TractionBoundaryCondition.cpp
+     AquiferBoundaryCondition.cpp
    )
 
 set( dependencyList functions linearAlgebra )

--- a/src/coreComponents/fieldSpecification/FieldSpecificationBase.hpp
+++ b/src/coreComponents/fieldSpecification/FieldSpecificationBase.hpp
@@ -502,9 +502,6 @@ private:
   /// The name of a function used to turn on and off the boundary condition.
   string m_bcApplicationFunctionName;
 
-  /// The factor used to normalize the boundary flux by the size of the set it is applied to
-  //real64 m_setSizeScalingFactor;
-
 };
 
 

--- a/src/coreComponents/finiteVolume/FluxApproximationBase.cpp
+++ b/src/coreComponents/finiteVolume/FluxApproximationBase.cpp
@@ -20,6 +20,8 @@
 #include "FluxApproximationBase.hpp"
 
 #include "fieldSpecification/FieldSpecificationManager.hpp"
+#include "fieldSpecification/DirichletBoundaryCondition.hpp"
+#include "fieldSpecification/AquiferBoundaryCondition.hpp"
 #include "mesh/mpiCommunications/CommunicationTools.hpp"
 
 namespace geosx
@@ -80,19 +82,36 @@ void FluxApproximationBase::registerDataOnMesh( Group & meshBodies )
                              stencilParentGroup.registerGroup( getName() );
 
       registerCellStencil( stencilGroup );
+
       registerFractureStencil( stencilGroup );
-      // For each face-based boundary condition on target field, create a boundary stencil
-      fsManager.apply( 0.0,
-                       dynamicCast< DomainPartition & >( meshBodies.getParent() ), // TODO: Apply() should take a MeshLevel directly
-                       "faceManager",
-                       m_fieldName,
-                       [&] ( FieldSpecificationBase const &,
-                             string const & setName,
-                             SortedArrayView< localIndex const > const &,
-                             Group const &,
-                             string const & )
+
+      // For each face-based Dirichlet boundary condition on target field, create a boundary stencil
+      // TODO: Apply() should take a MeshLevel directly
+      fsManager.apply< DirichletBoundaryCondition >( 0.0,
+                                                     dynamicCast< DomainPartition & >( meshBodies.getParent() ),
+                                                     "faceManager",
+                                                     m_fieldName,
+                                                     [&] ( DirichletBoundaryCondition const &,
+                                                           string const & setName,
+                                                           SortedArrayView< localIndex const > const &,
+                                                           Group const &,
+                                                           string const & )
       {
         registerBoundaryStencil( stencilGroup, setName );
+      } );
+
+      // For each aquifer boundary condition, create a boundary stencil
+      fsManager.apply< AquiferBoundaryCondition >( 0.0,
+                                                   dynamicCast< DomainPartition & >( meshBodies.getParent() ),
+                                                   "faceManager",
+                                                   AquiferBoundaryCondition::catalogName(),
+                                                   [&] ( AquiferBoundaryCondition const &,
+                                                         string const & setName,
+                                                         SortedArrayView< localIndex const > const &,
+                                                         Group const &,
+                                                         string const & )
+      {
+        registerAquiferStencil( stencilGroup, setName );
       } );
 
       FaceManager & faceManager = mesh.getFaceManager();
@@ -122,19 +141,23 @@ void FluxApproximationBase::initializePostInitialConditionsPreSubGroups()
       // Compute the main cell-based stencil
       computeCellStencil( mesh );
 
-      // For each face-based boundary condition on target field, create a boundary stencil
-      fsManager.apply( 0.0,
-                       domain,
-                       "faceManager",
-                       m_fieldName,
-                       [&] ( FieldSpecificationBase const &,
-                             string const & setName,
-                             SortedArrayView< localIndex const > const & faceSet,
-                             Group const &,
-                             string const & )
+      // For each face-based boundary condition on target field, compute the boundary stencil weights
+      fsManager.apply< DirichletBoundaryCondition >( 0.0,
+                                                     domain,
+                                                     "faceManager",
+                                                     m_fieldName,
+                                                     [&] ( DirichletBoundaryCondition const &,
+                                                           string const & setName,
+                                                           SortedArrayView< localIndex const > const & faceSet,
+                                                           Group const &,
+                                                           string const & )
       {
         computeBoundaryStencil( mesh, setName, faceSet );
       } );
+
+      // Compute the aquifer stencil weights
+      computeAquiferStencil( domain, mesh );
+
     } );
   } );
 }

--- a/src/coreComponents/finiteVolume/FluxApproximationBase.hpp
+++ b/src/coreComponents/finiteVolume/FluxApproximationBase.hpp
@@ -266,7 +266,7 @@ protected:
                                         string const & setName ) const = 0;
 
   /**
-   * @brief Allocate and populate a stencil to be used in boundary condition application
+   * @brief Allocate and populate a stencil to be used in dirichlet boundary condition application
    * @param mesh the target mesh level
    * @param setName name of the face set, to be used as wrapper name for the produced stencil
    * @param faceSet set of face indices to use
@@ -274,6 +274,23 @@ protected:
   virtual void computeBoundaryStencil( MeshLevel & mesh,
                                        string const & setName,
                                        SortedArrayView< localIndex const > const & faceSet ) const = 0;
+
+  /**
+   * @brief Register the wrapper for aquifer stencil on a mesh.
+   * @param stencilGroup the group holding the stencil objects
+   * @param setName the face set name (used as the wrapper name)
+   */
+  virtual void registerAquiferStencil( Group & stencilGroup,
+                                       string const & setName ) const = 0;
+
+  /**
+   * @brief Allocate and populate a stencil to be used in aquifer boundary condition application
+   * @param domain the domain partion
+   * @param mesh the target mesh level
+   */
+  virtual void computeAquiferStencil( DomainPartition & domain,
+                                      MeshLevel & mesh ) const = 0;
+
 
   /// name of the primary solution field
   string m_fieldName;

--- a/src/coreComponents/finiteVolume/TwoPointFluxApproximation.cpp
+++ b/src/coreComponents/finiteVolume/TwoPointFluxApproximation.cpp
@@ -19,6 +19,9 @@
 #include "TwoPointFluxApproximation.hpp"
 
 #include "codingUtilities/Utilities.hpp"
+#include "common/MpiWrapper.hpp"
+#include "fieldSpecification/FieldSpecificationManager.hpp"
+#include "fieldSpecification/AquiferBoundaryCondition.hpp"
 #include "finiteVolume/BoundaryStencil.hpp"
 #include "finiteVolume/CellElementStencilTPFA.hpp"
 #include "finiteVolume/SurfaceElementStencil.hpp"
@@ -897,6 +900,188 @@ void TwoPointFluxApproximation::computeBoundaryStencil( MeshLevel & mesh,
                    kf );
     }
   }
+}
+
+void TwoPointFluxApproximation::registerAquiferStencil( Group & stencilGroup, string const & setName ) const
+{
+  registerBoundaryStencil( stencilGroup, setName );
+}
+
+
+void TwoPointFluxApproximation::computeAquiferStencil( DomainPartition & domain, MeshLevel & mesh ) const
+{
+  // The computation of the aquifer stencil weights requires three passes:
+  //  - In the first pass, we count the number of individual aquifers
+  //  - In the second pass, we compute the sum of the face areas for each aquifer
+  //  - In the third pass, we compute the area fraction for each face
+
+  FieldSpecificationManager & fsManager = FieldSpecificationManager::getInstance();
+  FaceManager const & faceManager = mesh.getFaceManager();
+  ElementRegionManager const & elemManager = mesh.getElemManager();
+
+  ElementRegionManager::ElementViewAccessor< arrayView1d< integer const > > const elemGhostRank =
+    elemManager.constructArrayViewAccessor< integer, 1 >( ObjectManagerBase::viewKeyStruct::ghostRankString() );
+
+  arrayView1d< real64 const > const & faceArea              = faceManager.faceArea();
+  arrayView2d< localIndex const > const & elemRegionList    = faceManager.elementRegionList();
+  arrayView2d< localIndex const > const & elemSubRegionList = faceManager.elementSubRegionList();
+  arrayView2d< localIndex const > const & elemList          = faceManager.elementList();
+
+  constexpr localIndex numPts = BoundaryStencil::NUM_POINT_IN_FLUX;
+
+  // make a list of region indices to be included
+  SortedArray< localIndex > regionFilter;
+  for( string const & regionName : m_targetRegions )
+  {
+    regionFilter.insert( elemManager.getRegions().getIndex( regionName ) );
+  }
+
+  // Step 1: count individual aquifers
+
+  std::map< string, localIndex > aquiferNameToAquiferId;
+  localIndex aquiferCounter = 0;
+
+  fsManager.forSubGroups< AquiferBoundaryCondition >( [&] ( AquiferBoundaryCondition const & bc )
+  {
+    if( aquiferNameToAquiferId.count( bc.getName() ) == 0 )
+    {
+      aquiferNameToAquiferId[bc.getName()] = aquiferCounter;
+      aquiferCounter++;
+    }
+  } );
+
+  // Step 2: sum the face areas for each individual aquifer
+
+  array1d< real64 > globalSumFaceAreas( aquiferNameToAquiferId.size() );
+  array1d< real64 > localSumFaceAreas( aquiferNameToAquiferId.size() );
+  arrayView1d< real64 > const localSumFaceAreasView = localSumFaceAreas.toView();
+
+  fsManager.apply< AquiferBoundaryCondition >( 0.0,
+                                               domain,
+                                               "faceManager",
+                                               AquiferBoundaryCondition::catalogName(),
+                                               [&] ( AquiferBoundaryCondition const & bc,
+                                                     string const &,
+                                                     SortedArrayView< localIndex const > const & targetSet,
+                                                     Group const &,
+                                                     string const & )
+  {
+    RAJA::ReduceSum< parallelHostReduce, real64 > targetSetSumFaceAreas( 0.0 );
+    forAll< parallelHostPolicy >( targetSet.size(), [=] ( localIndex const i )
+    {
+      localIndex const iface = targetSet[i];
+
+      bool isOwnedAquiferFaceInTarget = false;
+      for( localIndex ke = 0; ke < numPts; ++ke )
+      {
+        // Filter out elements not locally present
+        if( elemRegionList[iface][ke] < 0 )
+        {
+          continue;
+        }
+
+        // Filter out elements not in target regions
+        if( !regionFilter.contains( elemRegionList[iface][ke] ))
+        {
+          continue;
+        }
+
+        localIndex const er  = elemRegionList[iface][ke];
+        localIndex const esr = elemSubRegionList[iface][ke];
+        localIndex const ei  = elemList[iface][ke];
+
+        // Filter out ghosted elements
+        if( elemGhostRank[er][esr][ei] >= 0 )
+        {
+          continue;
+        }
+
+        isOwnedAquiferFaceInTarget = true;
+      }
+
+      if( isOwnedAquiferFaceInTarget )
+      {
+        targetSetSumFaceAreas += faceArea[iface];
+      }
+    } );
+    localIndex const aquiferIndex = aquiferNameToAquiferId.at( bc.getName() );
+    localSumFaceAreasView[aquiferIndex] += targetSetSumFaceAreas.get();
+  } );
+
+  MpiWrapper::allReduce( localSumFaceAreas.data(),
+                         globalSumFaceAreas.data(),
+                         localSumFaceAreas.size(),
+                         MpiWrapper::getMpiOp( MpiWrapper::Reduction::Sum ),
+                         MPI_COMM_GEOSX );
+
+  // Step 3: compute the face area fraction for each connection, and insert into boundary stencil
+
+  fsManager.apply< AquiferBoundaryCondition >( 0.0,
+                                               domain,
+                                               "faceManager",
+                                               AquiferBoundaryCondition::catalogName(),
+                                               [&] ( AquiferBoundaryCondition const & bc,
+                                                     string const & setName,
+                                                     SortedArrayView< localIndex const > const & targetSet,
+                                                     Group const &,
+                                                     string const & )
+  {
+    BoundaryStencil & stencil = getStencil< BoundaryStencil >( mesh, setName );
+
+    stackArray1d< localIndex, numPts > stencilRegionIndices( numPts );
+    stackArray1d< localIndex, numPts > stencilSubRegionIndices( numPts );
+    stackArray1d< localIndex, numPts > stencilElemOrFaceIndices( numPts );
+    stackArray1d< real64, numPts > stencilWeights( numPts );
+
+    localIndex const aquiferIndex = aquiferNameToAquiferId.at( bc.getName() );
+
+    stencil.reserve( targetSet.size() );
+    for( localIndex iface : targetSet )
+    {
+
+      for( localIndex ke = 0; ke < numPts; ++ke )
+      {
+        // Filter out elements not locally present
+        if( elemRegionList[iface][ke] < 0 )
+        {
+          continue;
+        }
+
+        // Filter out elements not in target regions
+        if( !regionFilter.contains( elemRegionList[iface][ke] ))
+        {
+          continue;
+        }
+
+        localIndex const er  = elemRegionList[iface][ke];
+        localIndex const esr = elemSubRegionList[iface][ke];
+        localIndex const ei  = elemList[iface][ke];
+
+        // Filter out ghosted elements
+        if( elemGhostRank[er][esr][ei] >= 0 )
+        {
+          continue;
+        }
+
+        stencilRegionIndices[BoundaryStencil::Order::ELEM] = er;
+        stencilSubRegionIndices[BoundaryStencil::Order::ELEM] = esr;
+        stencilElemOrFaceIndices[BoundaryStencil::Order::ELEM] = ei;
+        stencilWeights[BoundaryStencil::Order::ELEM] = faceArea[iface] / globalSumFaceAreas[aquiferIndex];
+
+        stencilRegionIndices[BoundaryStencil::Order::FACE] = -1;
+        stencilSubRegionIndices[BoundaryStencil::Order::FACE] = -1;
+        stencilElemOrFaceIndices[BoundaryStencil::Order::FACE] = iface;
+        stencilWeights[BoundaryStencil::Order::FACE] = -faceArea[iface] / globalSumFaceAreas[aquiferIndex]; // likely unused for aquifers
+
+        stencil.add( stencilRegionIndices.size(),
+                     stencilRegionIndices.data(),
+                     stencilSubRegionIndices.data(),
+                     stencilElemOrFaceIndices.data(),
+                     stencilWeights.data(),
+                     iface );
+      }
+    }
+  } );
 }
 
 

--- a/src/coreComponents/finiteVolume/TwoPointFluxApproximation.hpp
+++ b/src/coreComponents/finiteVolume/TwoPointFluxApproximation.hpp
@@ -80,6 +80,13 @@ protected:
                                        string const & setName,
                                        SortedArrayView< localIndex const > const & faceSet ) const override;
 
+  virtual void registerAquiferStencil( Group & stencilGroup,
+                                       string const & setName ) const override;
+
+  virtual void computeAquiferStencil( DomainPartition & domain,
+                                      MeshLevel & mesh ) const override;
+
+
   virtual void addEDFracToFractureStencil( MeshLevel & mesh,
                                            string const & embeddedSurfaceRegionName ) const override;
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.hpp
@@ -342,6 +342,21 @@ public:
                           CRSMatrixView< real64, globalIndex const > const & localMatrix,
                           arrayView1d< real64 > const & localRhs ) const;
 
+  /**
+   * @brief Apply aquifer boundary conditions to the system
+   * @param time current time
+   * @param dt time step
+   * @param dofManager degree-of-freedom manager associated with the linear system
+   * @param domain the domain
+   * @param localMatrix local system matrix
+   * @param localRhs local system right-hand side vector
+   */
+  virtual void applyAquiferBC( real64 const time,
+                               real64 const dt,
+                               DofManager const & dofManager,
+                               DomainPartition & domain,
+                               CRSMatrixView< real64, globalIndex const > const & localMatrix,
+                               arrayView1d< real64 > const & localRhs ) const = 0;
 
   /**
    * @brief Sets all the negative component densities (if any) to zero.
@@ -359,9 +374,25 @@ protected:
 
   /**
    * @brief Checks constitutive models for consistency
-   * @param cm        reference to the global constitutive model manager
+   * @param[in] cm reference to the global constitutive model manager
    */
   void validateConstitutiveModels( constitutive::ConstitutiveManager const & cm ) const;
+
+  /**
+   * @brief Checks aquifer boundary condition for consistency
+   * @param[in] cm reference to the global constitutive model manager
+   */
+  void validateAquiferBC( constitutive::ConstitutiveManager const & cm ) const;
+
+  /**
+   * @brief Increment the cumulative flux from each aquifer
+   * @param[in] time the time at the beginning of the time step
+   * @param[in] dt the time step size
+   * @param[in] domain the domain partition
+   */
+  virtual void saveAquiferConvergedState( real64 const & time,
+                                          real64 const & dt,
+                                          DomainPartition & domain ) = 0;
 
   /**
    * @brief Setup stored views into domain data for the current step

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFVM.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFVM.hpp
@@ -114,15 +114,6 @@ public:
 
   /**@}*/
 
-  /**
-   * @brief assembles the flux terms for all cells
-   * @param time_n previous time value
-   * @param dt time step
-   * @param domain the physical domain object
-   * @param dofManager degree-of-freedom manager associated with the linear system
-   * @param matrix the system matrix
-   * @param rhs the system right-hand side vector
-   */
   virtual void
   assembleFluxTerms( real64 const dt,
                      DomainPartition const & domain,
@@ -131,12 +122,22 @@ public:
                      arrayView1d< real64 > const & localRhs ) const override;
 
 
-  /**
-   * @brief Recompute phase mobility from constitutive and primary variables
-   * @param domain the domain containing the mesh and fields
-   */
   virtual void
   updatePhaseMobility( Group & dataGroup, localIndex const targetIndex ) const override;
+
+  virtual void
+  applyAquiferBC( real64 const time,
+                  real64 const dt,
+                  DofManager const & dofManager,
+                  DomainPartition & domain,
+                  CRSMatrixView< real64, globalIndex const > const & localMatrix,
+                  arrayView1d< real64 > const & localRhs ) const override;
+
+  virtual void
+  saveAquiferConvergedState( real64 const & time,
+                             real64 const & dt,
+                             DomainPartition & domain ) override;
+
 
   /**
    * @brief Compute the largest CFL number in the domain

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFVMKernels.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFVMKernels.cpp
@@ -1117,6 +1117,249 @@ INST_CFLKernel( 5, 3 );
 
 #undef INST_CFLKernel
 
+/******************************** AquiferBCKernel ********************************/
+
+template< localIndex NC >
+GEOSX_HOST_DEVICE
+void
+AquiferBCKernel::
+  compute( localIndex numPhases,
+           real64 const & aquiferVolFlux,
+           real64 const & dAquiferVolFlux_dPres,
+           real64 const & aquiferWaterPhaseDens,
+           arrayView1d< real64 const > const & aquiferWaterPhaseCompFrac,
+           arraySlice1d< real64 const, multifluid::USD_PHASE - 2 > phaseDens,
+           arraySlice1d< real64 const, multifluid::USD_PHASE - 2 > dPhaseDens_dPres,
+           arraySlice2d< real64 const, multifluid::USD_PHASE_DC - 2 > dPhaseDens_dCompFrac,
+           arraySlice2d< real64 const, multifluid::USD_PHASE_COMP - 2 > phaseCompFrac,
+           arraySlice2d< real64 const, multifluid::USD_PHASE_COMP - 2 > dPhaseCompFrac_dPres,
+           arraySlice3d< real64 const, multifluid::USD_PHASE_COMP_DC - 2 > dPhaseCompFrac_dCompFrac,
+           arraySlice2d< real64 const, compflow::USD_COMP_DC - 1 > dCompFrac_dCompDens,
+           real64 (& localFlux)[NC],
+           real64 (& localFluxJacobian)[NC][NC+1] )
+{
+  real64 dProp_dC[NC]{};
+  real64 dPhaseFlux_dCompDens[NC]{};
+
+  // TODO: my understanding is that the flux does not need to be multiplied by the time step, but this needs to be confirmed
+
+  if( aquiferVolFlux > 0 ) // aquifer is upstream
+  {
+    // in this case, we assume that:
+    //    - only the water phase is present in the aquifer
+    //    - the aquifer water phase composition is constant
+
+    for( integer ic = 0; ic < NC; ++ic )
+    {
+      real64 const phaseFlux = aquiferVolFlux * aquiferWaterPhaseDens;
+      localFlux[ic] += phaseFlux * aquiferWaterPhaseCompFrac[ic];
+      localFluxJacobian[ic][0] += dAquiferVolFlux_dPres * aquiferWaterPhaseCompFrac[ic];
+    }
+  }
+  else // reservoir is upstream
+  {
+    for( integer ip = 0; ip < numPhases; ++ip )
+    {
+      real64 const phaseFlux = aquiferVolFlux * phaseDens[ip];
+      real64 const dPhaseFlux_dPres = dAquiferVolFlux_dPres * phaseDens[ip] + aquiferVolFlux * dPhaseDens_dPres[ip];
+
+      applyChainRule( NC, dCompFrac_dCompDens, dPhaseDens_dCompFrac[ip], dProp_dC );
+      for( integer ic = 0; ic < NC; ++ic )
+      {
+        dPhaseFlux_dCompDens[ic] = aquiferVolFlux * dProp_dC[ic];
+      }
+
+      for( integer ic = 0; ic < NC; ++ic )
+      {
+        localFlux[ic] += phaseFlux * phaseCompFrac[ip][ic];
+        localFluxJacobian[ic][0] += dPhaseFlux_dPres * phaseCompFrac[ip][ic] + phaseFlux * dPhaseCompFrac_dPres[ip][ic];
+
+        applyChainRule( NC, dCompFrac_dCompDens, dPhaseCompFrac_dCompFrac[ic][ip], dProp_dC );
+        for( integer jc = 0; jc < NC; ++jc )
+        {
+          localFluxJacobian[ic][jc+1] += dPhaseFlux_dCompDens[ic] * phaseCompFrac[ip][ic] + phaseFlux * dProp_dC[jc];
+        }
+      }
+    }
+  }
+}
+
+template< localIndex NC >
+void
+AquiferBCKernel::
+  launch( localIndex const numPhases,
+          BoundaryStencil const & stencil,
+          globalIndex const rankOffset,
+          ElementViewConst< arrayView1d< globalIndex const > > const & dofNumber,
+          ElementViewConst< arrayView1d< integer const > > const & ghostRank,
+          AquiferBoundaryCondition::KernelWrapper const & aquiferBCWrapper,
+          real64 const & aquiferWaterPhaseDens,
+          arrayView1d< real64 const > const & aquiferWaterPhaseCompFrac,
+          ElementViewConst< arrayView1d< real64 const > > const & pres,
+          ElementViewConst< arrayView1d< real64 const > > const & dPres,
+          ElementViewConst< arrayView1d< real64 const > > const & gravCoef,
+          ElementViewConst< arrayView3d< real64 const, multifluid::USD_PHASE > > const & phaseDens,
+          ElementViewConst< arrayView3d< real64 const, multifluid::USD_PHASE > > const & dPhaseDens_dPres,
+          ElementViewConst< arrayView4d< real64 const, multifluid::USD_PHASE_DC > > const & dPhaseDens_dCompFrac,
+          ElementViewConst< arrayView4d< real64 const, multifluid::USD_PHASE_COMP > > const & phaseCompFrac,
+          ElementViewConst< arrayView4d< real64 const, multifluid::USD_PHASE_COMP > > const & dPhaseCompFrac_dPres,
+          ElementViewConst< arrayView5d< real64 const, multifluid::USD_PHASE_COMP_DC > > const & dPhaseCompFrac_dCompFrac,
+          ElementViewConst< arrayView3d< real64 const, compflow::USD_COMP_DC > > const & dCompFrac_dCompDens,
+          real64 const timeAtEndOfStep,
+          CRSMatrixView< real64, globalIndex const > const & localMatrix,
+          arrayView1d< real64 > const & localRhs )
+{
+  using Order = BoundaryStencil::Order;
+
+  BoundaryStencil::IndexContainerViewConstType const & seri = stencil.getElementRegionIndices();
+  BoundaryStencil::IndexContainerViewConstType const & sesri = stencil.getElementSubRegionIndices();
+  BoundaryStencil::IndexContainerViewConstType const & sefi = stencil.getElementIndices();
+  BoundaryStencil::WeightContainerViewConstType const & weight = stencil.getWeights();
+
+  forAll< parallelDevicePolicy<> >( stencil.size(), [=] GEOSX_HOST_DEVICE ( localIndex const iconn )
+  {
+    constexpr localIndex NDOF = NC + 1;
+
+    // working arrays
+    globalIndex dofColIndices[NDOF]{};
+    real64 localFlux[NC]{};
+    real64 localFluxJacobian[NC][NDOF]{};
+
+    localIndex const er  = seri( iconn, Order::ELEM );
+    localIndex const esr = sesri( iconn, Order::ELEM );
+    localIndex const ei  = sefi( iconn, Order::ELEM );
+    real64 const areaFraction = weight( iconn, Order::ELEM );
+
+    // compute the aquifer influx rate using the pressure influence function and the aquifer props
+    real64 const resPres = pres[er][esr][ei] + dPres[er][esr][ei];
+    real64 const resGravCoef = gravCoef[er][esr][ei];
+    real64 dAquiferVolFlux_dPres = 0.0;
+    real64 const aquiferVolFlux = aquiferBCWrapper.compute( timeAtEndOfStep,
+                                                            resPres,
+                                                            resGravCoef,
+                                                            areaFraction,
+                                                            dAquiferVolFlux_dPres );
+
+    // compute the phase/component aquifer flux
+    AquiferBCKernel::compute< NC >( numPhases,
+                                    aquiferVolFlux,
+                                    dAquiferVolFlux_dPres,
+                                    aquiferWaterPhaseDens,
+                                    aquiferWaterPhaseCompFrac,
+                                    phaseDens[er][esr][ei][0],
+                                    dPhaseDens_dPres[er][esr][ei][0],
+                                    dPhaseDens_dCompFrac[er][esr][ei][0],
+                                    phaseCompFrac[er][esr][ei][0],
+                                    dPhaseCompFrac_dPres[er][esr][ei][0],
+                                    dPhaseCompFrac_dCompFrac[er][esr][ei][0],
+                                    dCompFrac_dCompDens[er][esr][ei],
+                                    localFlux,
+                                    localFluxJacobian );
+
+    // populate dof indices
+    globalIndex const offset = dofNumber[er][esr][ei];
+    for( localIndex jdof = 0; jdof < NDOF; ++jdof )
+    {
+      dofColIndices[jdof] = offset + jdof;
+    }
+
+    // Add to residual/jacobian
+    if( ghostRank[er][esr][ei] < 0 )
+    {
+      globalIndex const globalRow = dofNumber[er][esr][ei];
+      localIndex const localRow = LvArray::integerConversion< localIndex >( globalRow - rankOffset );
+      GEOSX_ASSERT_GE( localRow, 0 );
+      GEOSX_ASSERT_GT( localMatrix.numRows(), localRow + NC );
+
+      for( localIndex ic = 0; ic < NC; ++ic )
+      {
+        RAJA::atomicAdd( parallelDeviceAtomic{}, &localRhs[localRow + ic], localFlux[ic] );
+        localMatrix.addToRowBinarySearchUnsorted< parallelDeviceAtomic >( localRow + ic,
+                                                                          dofColIndices,
+                                                                          localFluxJacobian[ic],
+                                                                          NDOF );
+      }
+    }
+  } );
+}
+
+real64
+AquiferBCKernel::
+  sumFluxes( BoundaryStencil const & stencil,
+             AquiferBoundaryCondition::KernelWrapper const & aquiferBCWrapper,
+             ElementViewConst< arrayView1d< real64 const > > const & pres,
+             ElementViewConst< arrayView1d< real64 const > > const & dPres,
+             ElementViewConst< arrayView1d< real64 const > > const & gravCoef,
+             real64 const & timeAtEndOfStep )
+{
+  // TODO: move this so it can be used by single-phase flow
+
+  using Order = BoundaryStencil::Order;
+
+  BoundaryStencil::IndexContainerViewConstType const & seri = stencil.getElementRegionIndices();
+  BoundaryStencil::IndexContainerViewConstType const & sesri = stencil.getElementSubRegionIndices();
+  BoundaryStencil::IndexContainerViewConstType const & sefi = stencil.getElementIndices();
+  BoundaryStencil::WeightContainerViewConstType const & weight = stencil.getWeights();
+
+  RAJA::ReduceSum< parallelDeviceReduce, real64 > targetSetSumFluxes( 0.0 );
+
+  forAll< parallelDevicePolicy<> >( stencil.size(), [=] GEOSX_HOST_DEVICE ( localIndex const iconn )
+  {
+    localIndex const er  = seri( iconn, Order::ELEM );
+    localIndex const esr = sesri( iconn, Order::ELEM );
+    localIndex const ei  = sefi( iconn, Order::ELEM );
+    real64 const areaFraction = weight( iconn, Order::ELEM );
+
+    // compute the aquifer influx rate using the pressure influence function and the aquifer props
+    real64 const resPres = pres[er][esr][ei] + dPres[er][esr][ei];
+    real64 const resGravCoef = gravCoef[er][esr][ei];
+    real64 dAquiferVolFlux_dPres = 0.0;
+    real64 const aquiferVolFlux = aquiferBCWrapper.compute( timeAtEndOfStep,
+                                                            resPres,
+                                                            resGravCoef,
+                                                            areaFraction,
+                                                            dAquiferVolFlux_dPres );
+    targetSetSumFluxes += aquiferVolFlux;
+  } );
+
+  return targetSetSumFluxes.get();
+}
+
+
+#define INST_AquiferBCKernel( NC ) \
+  template \
+  void AquiferBCKernel:: \
+    launch< NC >( localIndex const numPhases, \
+                  BoundaryStencil const & stencil, \
+                  globalIndex const rankOffset, \
+                  ElementViewConst< arrayView1d< globalIndex const > > const & dofNumber, \
+                  ElementViewConst< arrayView1d< integer const > > const & ghostRank, \
+                  AquiferBoundaryCondition::KernelWrapper const & aquiferBCWrapper, \
+                  real64 const & aquiferWaterPhaseDens, \
+                  arrayView1d< real64 const > const & aquiferWaterPhaseCompFrac, \
+                  ElementViewConst< arrayView1d< real64 const > > const & pres, \
+                  ElementViewConst< arrayView1d< real64 const > > const & dPres, \
+                  ElementViewConst< arrayView1d< real64 const > > const & gravCoef, \
+                  ElementViewConst< arrayView3d< real64 const, multifluid::USD_PHASE > > const & phaseDens, \
+                  ElementViewConst< arrayView3d< real64 const, multifluid::USD_PHASE > > const & dPhaseDens_dPres, \
+                  ElementViewConst< arrayView4d< real64 const, multifluid::USD_PHASE_DC > > const & dPhaseDens_dCompFrac, \
+                  ElementViewConst< arrayView4d< real64 const, multifluid::USD_PHASE_COMP > > const & phaseCompFrac, \
+                  ElementViewConst< arrayView4d< real64 const, multifluid::USD_PHASE_COMP > > const & dPhaseCompFrac_dPres, \
+                  ElementViewConst< arrayView5d< real64 const, multifluid::USD_PHASE_COMP_DC > > const & dPhaseCompFrac_dCompFrac, \
+                  ElementViewConst< arrayView3d< real64 const, compflow::USD_COMP_DC > > const & dCompFrac_dCompDens, \
+                  real64 const timeAtEndOfStep, \
+                  CRSMatrixView< real64, globalIndex const > const & localMatrix, \
+                  arrayView1d< real64 > const & localRhs )
+
+INST_AquiferBCKernel( 1 );
+INST_AquiferBCKernel( 2 );
+INST_AquiferBCKernel( 3 );
+INST_AquiferBCKernel( 4 );
+INST_AquiferBCKernel( 5 );
+
+#undef INST_AquiferBCKernel
+
+
 } // namespace CompositionalMultiphaseFVMKernels
 
 } // namespace geosx

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseHybridFVM.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseHybridFVM.cpp
@@ -689,6 +689,31 @@ void CompositionalMultiphaseHybridFVM::applyBoundaryConditions( real64 const tim
   // TODO: implement face boundary conditions here
 }
 
+void CompositionalMultiphaseHybridFVM::applyAquiferBC( real64 const time,
+                                                       real64 const dt,
+                                                       DofManager const & dofManager,
+                                                       DomainPartition & domain,
+                                                       CRSMatrixView< real64, globalIndex const > const & localMatrix,
+                                                       arrayView1d< real64 > const & localRhs ) const
+{
+  GEOSX_MARK_FUNCTION;
+
+  GEOSX_UNUSED_VAR( time, dt, dofManager, domain, localMatrix, localRhs );
+
+  GEOSX_ERROR( "In progress" );
+}
+
+void CompositionalMultiphaseHybridFVM::saveAquiferConvergedState( real64 const & time,
+                                                                  real64 const & dt,
+                                                                  DomainPartition & domain )
+{
+  GEOSX_MARK_FUNCTION;
+
+  GEOSX_UNUSED_VAR( time, dt, domain );
+
+  GEOSX_ERROR( "In progress" );
+}
+
 real64 CompositionalMultiphaseHybridFVM::calculateResidualNorm( DomainPartition const & domain,
                                                                 DofManager const & dofManager,
                                                                 arrayView1d< real64 const > const & localRhs )

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseHybridFVM.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseHybridFVM.hpp
@@ -125,15 +125,6 @@ public:
                         real64 const & dt,
                         DomainPartition & domain ) override;
 
-  /**
-   * @brief assembles the flux terms for all cells
-   * @param time_n previous time value
-   * @param dt time step
-   * @param domain the physical domain object
-   * @param dofManager degree-of-freedom manager associated with the linear system
-   * @param localMatrix the system matrix
-   * @param localRhs the system right-hand side vector
-   */
   virtual void
   assembleFluxTerms( real64 const dt,
                      DomainPartition const & domain,
@@ -141,12 +132,21 @@ public:
                      CRSMatrixView< real64, globalIndex const > const & localMatrix,
                      arrayView1d< real64 > const & localRhs ) const override;
 
-  /**
-   * @brief Recompute phase mobility from constitutive and primary variables
-   * @param domain the domain containing the mesh and fields
-   */
   virtual void
   updatePhaseMobility( Group & dataGroup, localIndex const targetIndex ) const override;
+
+  virtual void
+  applyAquiferBC( real64 const time,
+                  real64 const dt,
+                  DofManager const & dofManager,
+                  DomainPartition & domain,
+                  CRSMatrixView< real64, globalIndex const > const & localMatrix,
+                  arrayView1d< real64 > const & localRhs ) const override;
+
+  virtual void
+  saveAquiferConvergedState( real64 const & time,
+                             real64 const & dt,
+                             DomainPartition & domain ) override;
 
   /**@}*/
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/integratedTests/compositionalMultiphaseFlow/co2_flux_3d.xml
+++ b/src/coreComponents/physicsSolvers/fluidFlow/integratedTests/compositionalMultiphaseFlow/co2_flux_3d.xml
@@ -6,14 +6,14 @@
       name="compflow"
       logLevel="1"
       discretization="fluidTPFA"
-      fluidNames="{ fluid1 }"
+      fluidNames="{ fluid }"
       solidNames="{ rock }"
       permeabilityNames="{ rockPerm }"
       relPermNames="{ relperm }"
       temperature="368.15"
       useMass="1"
       computeCFLNumbers="1"
-      targetRegions="{ Region1 }">
+      targetRegions="{ region }">
       <NonlinearSolverParameters
         newtonTol="1.0e-5"
         newtonMaxIter="100"
@@ -34,7 +34,7 @@
       nx="{ 10 }"
       ny="{ 10 }"
       nz="{ 10 }"
-      cellBlockNames="{ cb1 }"/>
+      cellBlockNames="{ cellBlock }"/>
   </Mesh>
 
   <Geometry>
@@ -57,6 +57,28 @@
       name="barrier"
       xMin="{ -0.01, 20.99, 20.99 }"
       xMax="{ 12.01, 30.01, 21.01 }"/>
+
+    <Box
+      name="aquifer1Part1"
+      xMin="{ 14.99, -0.01, 14.99 }"
+      xMax="{ 18.01,  0.01, 18.01 }"/> 
+
+    <Box
+      name="aquifer1Part2"
+      xMin="{ 17.99, -0.01, 17.99 }"
+      xMax="{ 21.01,  0.01, 24.01 }"/> 
+
+    <Box
+      name="aquifer2Part1"
+      xMin="{ 14.99, 29.99, 14.99 }"
+      xMax="{ 18.01, 30.01, 18.01 }"/> 
+
+    <Box
+      name="aquifer2Part2"
+      xMin="{ 17.99, 29.99, 17.99 }"
+      xMax="{ 21.01, 30.01, 24.01 }"/> 
+
+    
   </Geometry>
 
   <Events
@@ -89,14 +111,14 @@
 
   <ElementRegions>
     <CellElementRegion
-      name="Region1"
-      cellBlocks="{ cb1 }"
-      materialList="{ fluid1, rock, relperm, rockPerm, rockPorosity, nullSolid }"/>
+      name="region"
+      cellBlocks="{ cellBlock }"
+      materialList="{ fluid, rock, relperm, rockPerm, rockPorosity, nullSolid }"/>
   </ElementRegions>
 
   <Constitutive>
     <CO2BrineFluid
-      name="fluid1"
+      name="fluid"
       phaseNames="{ gas, water }"
       componentNames="{ co2, water }"
       componentMolarWeight="{ 44e-3, 18e-3 }"
@@ -143,7 +165,7 @@
       name="initialPressure"
       initialCondition="1"
       setNames="{ all }"
-      objectPath="ElementRegions/Region1/cb1"
+      objectPath="ElementRegions/region/cellBlock"
       fieldName="pressure"
       scale="9e6"/>
 
@@ -152,7 +174,7 @@
       name="initialComposition_co2"
       initialCondition="1"
       setNames="{ all }"
-      objectPath="ElementRegions/Region1/cb1"
+      objectPath="ElementRegions/region/cellBlock"
       fieldName="globalCompFraction"
       component="0"
       scale="0.005"/>
@@ -161,7 +183,7 @@
       name="initialComposition_water"
       initialCondition="1"
       setNames="{ all }"
-      objectPath="ElementRegions/Region1/cb1"
+      objectPath="ElementRegions/region/cellBlock"
       fieldName="globalCompFraction"
       component="1"
       scale="0.995"/>
@@ -169,7 +191,7 @@
     <!-- Injection rate: 0.03 kg/s -->
     <SourceFlux
       name="sourceTerm"
-      objectPath="ElementRegions/Region1/cb1"
+      objectPath="ElementRegions/region/cellBlock"
       component="0"
       scale="-0.03"
       setNames="{ source }"/>
@@ -177,7 +199,7 @@
     <!-- Production stream: same as initial (should not matter due to upwinding) -->
     <FieldSpecification
       name="sinkTerm1"
-      objectPath="ElementRegions/Region1/cb1"
+      objectPath="ElementRegions/region/cellBlock"
       fieldName="pressure"
       scale="9e6"
       setNames="{ sink1 }"/>
@@ -185,7 +207,7 @@
     <FieldSpecification
       name="sinkTermComposition1_co2"
       setNames="{ sink1 }"
-      objectPath="ElementRegions/Region1/elementSubRegions/cb1"
+      objectPath="ElementRegions/region/cellBlock"
       fieldName="globalCompFraction"
       component="0"
       scale="0.005"/>
@@ -193,14 +215,14 @@
     <FieldSpecification
       name="sinkTermComposition1_water"
       setNames="{ sink1 }"
-      objectPath="ElementRegions/Region1/cb1"
+      objectPath="ElementRegions/region/cellBlock"
       fieldName="globalCompFraction"
       component="1"
       scale="0.995"/>
 
     <FieldSpecification
       name="sinkTerm2"
-      objectPath="ElementRegions/Region1/cb1"
+      objectPath="ElementRegions/region/cellBlock"
       fieldName="pressure"
       scale="9e6"
       setNames="{ sink2 }"/>
@@ -209,7 +231,7 @@
     <FieldSpecification
       name="sinkTermComposition2_co2"
       setNames="{ sink2 }"
-      objectPath="ElementRegions/Region1/cb1"
+      objectPath="ElementRegions/region/cellBlock"
       fieldName="globalCompFraction"
       component="0"
       scale="0.005"/>
@@ -217,10 +239,47 @@
     <FieldSpecification
       name="sinkTermComposition2_water"
       setNames="{ sink2 }"
-      objectPath="ElementRegions/Region1/cb1"
+      objectPath="ElementRegions/region/cellBlock"
       fieldName="globalCompFraction"
       component="1"
       scale="0.995"/>
+
+    <Aquifer
+      name="aquiferBC1"
+      aquiferPorosity="1e-1"
+      aquiferPermeability="1e-13"
+      aquiferInitialPressure="1e7"
+      aquiferWaterViscosity="1e-3"
+      aquiferWaterDensity="1000"
+      aquiferWaterPhaseComponentFraction="{ 0.0, 1.0 }"
+      aquiferWaterPhaseComponentNames="{ co2, water }"       
+      aquiferTotalCompressibility="1e-10"
+      aquiferElevation="20"
+      aquiferThickness="10"
+      aquiferInnerRadius="10"
+      aquiferAngle="0.1"
+      setNames="{ aquifer1Part1, aquifer1Part2 }"
+      objectPath="faceManager"
+      pressureInfluenceFunctionName="pressureInfluenceFunction"/>
+
+    <Aquifer
+      name="aquiferBC2"
+      aquiferPorosity="1e-1"
+      aquiferPermeability="1e-13"
+      aquiferInitialPressure="1e7"
+      aquiferWaterViscosity="1e-3"
+      aquiferWaterDensity="1000"
+      aquiferWaterPhaseComponentFraction="{ 0.0, 1.0 }"
+      aquiferWaterPhaseComponentNames="{ co2, water }"
+      aquiferTotalCompressibility="1e-10"
+      aquiferElevation="20"
+      aquiferThickness="10"
+      aquiferInnerRadius="10"
+      aquiferAngle="0.1"
+      setNames="{ aquifer2Part1, aquifer2Part2 }"
+      objectPath="faceManager"
+      pressureInfluenceFunctionName="pressureInfluenceFunction"/>
+    
   </FieldSpecifications>
 
   <Outputs>
@@ -230,4 +289,14 @@
     <Restart
       name="sidreRestart"/>
   </Outputs>
+
+  <Functions>
+    <TableFunction
+      name="pressureInfluenceFunction"
+      inputVarNames="{ time }"
+      coordinates="{ 0.0, 1.0, 10.0, 100.0 }"
+      values="{ 0.0, 2.0, 15.0, 1000.0 }"/>
+  </Functions>
+
+  
 </Problem>

--- a/src/coreComponents/schema/docs/Aquifer.rst
+++ b/src/coreComponents/schema/docs/Aquifer.rst
@@ -1,0 +1,31 @@
+
+
+================================== ============ ======== ================================================================================== 
+Name                               Type         Default  Description                                                                        
+================================== ============ ======== ================================================================================== 
+aquiferAngle                       real64       required Angle subtended by the aquifer boundary from the center of the reservoir [degress] 
+aquiferElevation                   real64       required Aquifer elevation (positive going upward) [m]                                      
+aquiferInitialPressure             real64       required Aquifer initial pressure [Pa]                                                      
+aquiferInnerRadius                 real64       required Aquifer inner radius [m]                                                           
+aquiferPermeability                real64       required Aquifer permeability [m^2]                                                         
+aquiferPorosity                    real64       required Aquifer porosity                                                                   
+aquiferThickness                   real64       required Aquifer thickness [m]                                                              
+aquiferTotalCompressibility        real64       required Aquifer total compressibility (rock and fluid) [Pa^-1]                             
+aquiferWaterDensity                real64       required Aquifer water density [kg.m^-3]                                                    
+aquiferWaterPhaseComponentFraction real64_array {0}      Aquifer water phase component fraction                                             
+aquiferWaterPhaseComponentNames    string_array {}       Aquifer water phase component names                                                
+aquiferWaterViscosity              real64       required Aquifer water viscosity [Pa.s]                                                     
+bcApplicationTableName             string                Name of table that specifies the on/off application of the bc.                     
+beginTime                          real64       -1e+99   time at which BC will start being applied.                                         
+direction                          R1Tensor     {0,0,0}  Direction to apply boundary condition to                                           
+endTime                            real64       1e+99    time at which bc will stop being applied                                           
+functionName                       string                Name of function that specifies variation of the BC                                
+initialCondition                   integer      0        BC is applied as an initial condition.                                             
+name                               string       required A name is required for any non-unique nodes                                        
+objectPath                         string                Path to the target field                                                           
+pressureInfluenceFunctionName      string       required Name of the table describing the pressure influence function                       
+scale                              real64       0        Scale factor for value of BC.                                                      
+setNames                           string_array required Name of sets that boundary condition is applied to.                                
+================================== ============ ======== ================================================================================== 
+
+

--- a/src/coreComponents/schema/docs/Aquifer_other.rst
+++ b/src/coreComponents/schema/docs/Aquifer_other.rst
@@ -1,0 +1,11 @@
+
+
+============== ======= ============================================================= 
+Name           Type    Description                                                   
+============== ======= ============================================================= 
+component      integer Component of field (if tensor) to apply boundary condition to 
+cumulativeFlux real64  (no description available)                                    
+fieldName      string  Name of field that boundary condition is applied to.          
+============== ======= ============================================================= 
+
+

--- a/src/coreComponents/schema/docs/FieldSpecifications.rst
+++ b/src/coreComponents/schema/docs/FieldSpecifications.rst
@@ -3,6 +3,7 @@
 ================== ==== ======= ============================= 
 Name               Type Default Description                   
 ================== ==== ======= ============================= 
+Aquifer            node         :ref:`XML_Aquifer`            
 Dirichlet          node         :ref:`XML_Dirichlet`          
 FieldSpecification node         :ref:`XML_FieldSpecification` 
 SourceFlux         node         :ref:`XML_SourceFlux`         

--- a/src/coreComponents/schema/docs/FieldSpecifications_other.rst
+++ b/src/coreComponents/schema/docs/FieldSpecifications_other.rst
@@ -3,6 +3,7 @@
 ================== ==== ======================================= 
 Name               Type Description                             
 ================== ==== ======================================= 
+Aquifer            node :ref:`DATASTRUCTURE_Aquifer`            
 Dirichlet          node :ref:`DATASTRUCTURE_Dirichlet`          
 FieldSpecification node :ref:`DATASTRUCTURE_FieldSpecification` 
 SourceFlux         node :ref:`DATASTRUCTURE_SourceFlux`         

--- a/src/coreComponents/schema/schema.xsd
+++ b/src/coreComponents/schema/schema.xsd
@@ -281,11 +281,60 @@
 	</xsd:complexType>
 	<xsd:complexType name="FieldSpecificationsType">
 		<xsd:choice minOccurs="0" maxOccurs="unbounded">
+			<xsd:element name="Aquifer" type="AquiferType" />
 			<xsd:element name="Dirichlet" type="DirichletType" />
 			<xsd:element name="FieldSpecification" type="FieldSpecificationType" />
 			<xsd:element name="SourceFlux" type="SourceFluxType" />
 			<xsd:element name="Traction" type="TractionType" />
 		</xsd:choice>
+	</xsd:complexType>
+	<xsd:complexType name="AquiferType">
+		<!--aquiferAngle => Angle subtended by the aquifer boundary from the center of the reservoir [degress]-->
+		<xsd:attribute name="aquiferAngle" type="real64" use="required" />
+		<!--aquiferElevation => Aquifer elevation (positive going upward) [m]-->
+		<xsd:attribute name="aquiferElevation" type="real64" use="required" />
+		<!--aquiferInitialPressure => Aquifer initial pressure [Pa]-->
+		<xsd:attribute name="aquiferInitialPressure" type="real64" use="required" />
+		<!--aquiferInnerRadius => Aquifer inner radius [m]-->
+		<xsd:attribute name="aquiferInnerRadius" type="real64" use="required" />
+		<!--aquiferPermeability => Aquifer permeability [m^2]-->
+		<xsd:attribute name="aquiferPermeability" type="real64" use="required" />
+		<!--aquiferPorosity => Aquifer porosity-->
+		<xsd:attribute name="aquiferPorosity" type="real64" use="required" />
+		<!--aquiferThickness => Aquifer thickness [m]-->
+		<xsd:attribute name="aquiferThickness" type="real64" use="required" />
+		<!--aquiferTotalCompressibility => Aquifer total compressibility (rock and fluid) [Pa^-1]-->
+		<xsd:attribute name="aquiferTotalCompressibility" type="real64" use="required" />
+		<!--aquiferWaterDensity => Aquifer water density [kg.m^-3]-->
+		<xsd:attribute name="aquiferWaterDensity" type="real64" use="required" />
+		<!--aquiferWaterPhaseComponentFraction => Aquifer water phase component fraction-->
+		<xsd:attribute name="aquiferWaterPhaseComponentFraction" type="real64_array" default="{0}" />
+		<!--aquiferWaterPhaseComponentNames => Aquifer water phase component names-->
+		<xsd:attribute name="aquiferWaterPhaseComponentNames" type="string_array" default="{}" />
+		<!--aquiferWaterViscosity => Aquifer water viscosity [Pa.s]-->
+		<xsd:attribute name="aquiferWaterViscosity" type="real64" use="required" />
+		<!--bcApplicationTableName => Name of table that specifies the on/off application of the bc.-->
+		<xsd:attribute name="bcApplicationTableName" type="string" default="" />
+		<!--beginTime => time at which BC will start being applied.-->
+		<xsd:attribute name="beginTime" type="real64" default="-1e+99" />
+		<!--direction => Direction to apply boundary condition to-->
+		<xsd:attribute name="direction" type="R1Tensor" default="{0,0,0}" />
+		<!--endTime => time at which bc will stop being applied-->
+		<xsd:attribute name="endTime" type="real64" default="1e+99" />
+		<!--functionName => Name of function that specifies variation of the BC-->
+		<xsd:attribute name="functionName" type="string" default="" />
+		<!--initialCondition => BC is applied as an initial condition.-->
+		<xsd:attribute name="initialCondition" type="integer" default="0" />
+		<!--objectPath => Path to the target field-->
+		<xsd:attribute name="objectPath" type="string" default="" />
+		<!--pressureInfluenceFunctionName => Name of the table describing the pressure influence function-->
+		<xsd:attribute name="pressureInfluenceFunctionName" type="string" use="required" />
+		<!--scale => Scale factor for value of BC.-->
+		<xsd:attribute name="scale" type="real64" default="0" />
+		<!--setNames => Name of sets that boundary condition is applied to.-->
+		<xsd:attribute name="setNames" type="string_array" use="required" />
+		<!--name => A name is required for any non-unique nodes-->
+		<xsd:attribute name="name" type="string" use="required" />
 	</xsd:complexType>
 	<xsd:complexType name="DirichletType">
 		<!--bcApplicationTableName => Name of table that specifies the on/off application of the bc.-->

--- a/src/coreComponents/schema/schema.xsd.other
+++ b/src/coreComponents/schema/schema.xsd.other
@@ -254,11 +254,20 @@
 	</xsd:complexType>
 	<xsd:complexType name="FieldSpecificationsType">
 		<xsd:choice minOccurs="0" maxOccurs="unbounded">
+			<xsd:element name="Aquifer" type="AquiferType" />
 			<xsd:element name="Dirichlet" type="DirichletType" />
 			<xsd:element name="FieldSpecification" type="FieldSpecificationType" />
 			<xsd:element name="SourceFlux" type="SourceFluxType" />
 			<xsd:element name="Traction" type="TractionType" />
 		</xsd:choice>
+	</xsd:complexType>
+	<xsd:complexType name="AquiferType">
+		<!--component => Component of field (if tensor) to apply boundary condition to-->
+		<xsd:attribute name="component" type="integer" />
+		<!--cumulativeFlux => (no description available)-->
+		<xsd:attribute name="cumulativeFlux" type="real64" />
+		<!--fieldName => Name of field that boundary condition is applied to.-->
+		<xsd:attribute name="fieldName" type="string" />
 	</xsd:complexType>
 	<xsd:complexType name="DirichletType" />
 	<xsd:complexType name="FieldSpecificationType" />

--- a/src/docs/sphinx/CompleteXMLSchema.rst
+++ b/src/docs/sphinx/CompleteXMLSchema.rst
@@ -15,6 +15,13 @@ Element: AcousticSEM
 .. include:: ../../coreComponents/schema/docs/AcousticSEM.rst
 
 
+.. _XML_Aquifer:
+
+Element: Aquifer
+================
+.. include:: ../../coreComponents/schema/docs/Aquifer.rst
+
+
 .. _XML_Benchmarks:
 
 Element: Benchmarks
@@ -885,6 +892,13 @@ Datastructure Definitions
 Datastructure: AcousticSEM
 ==========================
 .. include:: ../../coreComponents/schema/docs/AcousticSEM_other.rst
+
+
+.. _DATASTRUCTURE_Aquifer:
+
+Datastructure: Aquifer
+======================
+.. include:: ../../coreComponents/schema/docs/Aquifer_other.rst
 
 
 .. _DATASTRUCTURE_Benchmarks:


### PR DESCRIPTION
This PR implements an aquifer face boundary condition based on the Carter-Tracy model. The implementation reuses the `BoundaryStencil` already in place for the standard face boundary condition in `SinglePhaseFVM`.

For now, the implementation is limited to `CompositionalMultiphaseFVM` and is in a working state. Before propagating it to the compositional mimetic solver (and potentially single-phase flow solvers as well), there is a little bit of validation work that I need to do to make sure that my implementation is correct (it is hard to tell by just looking at the results).