### PR TITLE
restructure relationship between tests, examples, benchmarks

### DIFF
--- a/src/coreComponents/physicsSolvers/fluidFlow/benchmarks/SPE10/dead_oil_spe10_layers_84_85.xml
+++ b/src/coreComponents/physicsSolvers/fluidFlow/benchmarks/SPE10/dead_oil_spe10_layers_84_85.xml
@@ -33,48 +33,6 @@
   </Solvers>
   <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_SOLVERS_END -->  
 
-  <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_MESH -->
-  <Mesh>
-    <InternalMesh
-      name="mesh"
-      elementTypes="{ C3D8 }"
-      xCoords="{ 0, 365.76 }"
-      yCoords="{ 0, 670.56 }"
-      zCoords="{ 0, 1.22 }"
-      nx="{ 60 }"
-      ny="{ 220 }"
-      nz="{ 2 }"
-      cellBlockNames="{ block }"/>
-  </Mesh>
-  <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_MESH_END -->
-
-  <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_GEOMETRY -->  
-  <Geometry>
-
-    <Box
-      name="source"
-      xMin="{ 182.85, 335.25, -0.01 }"
-      xMax="{ 189.00, 338.35, 2.00 }"/>
-    <Box
-      name="sink1"
-      xMin="{ -0.01, -0.01, -0.01 }"
-      xMax="{ 6.126, 3.078, 2.00 }"/>
-    <Box
-      name="sink2"
-      xMin="{ -0.01, 667.482, -0.01 }"
-      xMax="{ 6.126, 670.60, 2.00 }"/>
-    <Box
-      name="sink3"
-      xMin="{ 359.634, -0.01, -0.01 }"
-      xMax="{ 365.8, 3.048, 2.00 }"/>
-    <Box
-      name="sink4"
-      xMin="{ 359.634, 667.482, -0.01 }"
-      xMax="{ 365.8, 670.60, 2.00 }"/>
-    
-  </Geometry>
-  <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_GEOMETRY_END -->  
-
   <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_EVENTS -->  
   <Events
     maxTime="8e7">
@@ -92,6 +50,7 @@
     
   </Events>
   <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_EVENTS_END -->  
+
 
   <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_NUMERICAL_METHODS -->  
   <NumericalMethods>

--- a/src/coreComponents/physicsSolvers/fluidFlow/benchmarks/SPE10/dead_oil_spe10_layers_84_85_benchmark.xml
+++ b/src/coreComponents/physicsSolvers/fluidFlow/benchmarks/SPE10/dead_oil_spe10_layers_84_85_benchmark.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" ?>
+
+<Problem>
+
+  <Included>
+    <File
+      name="./dead_oil_spe10_layers_84_85.xml"/>
+  </Included>
+
+
+  <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_MESH -->
+  <Mesh>
+    <InternalMesh
+      name="mesh"
+      elementTypes="{ C3D8 }"
+      xCoords="{ 0, 365.76 }"
+      yCoords="{ 0, 670.56 }"
+      zCoords="{ 0, 1.22 }"
+      nx="{ 60 }"
+      ny="{ 220 }"
+      nz="{ 2 }"
+      cellBlockNames="{ block }"/>
+  </Mesh>
+  <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_MESH_END -->
+
+  <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_GEOMETRY -->  
+  <Geometry>
+
+    <Box
+      name="source"
+      xMin="{ 182.85, 335.25, -0.01 }"
+      xMax="{ 189.00, 338.35, 2.00 }"/>
+    <Box
+      name="sink1"
+      xMin="{ -0.01, -0.01, -0.01 }"
+      xMax="{ 6.126, 3.078, 2.00 }"/>
+    <Box
+      name="sink2"
+      xMin="{ -0.01, 667.482, -0.01 }"
+      xMax="{ 6.126, 670.60, 2.00 }"/>
+    <Box
+      name="sink3"
+      xMin="{ 359.634, -0.01, -0.01 }"
+      xMax="{ 365.8, 3.048, 2.00 }"/>
+    <Box
+      name="sink4"
+      xMin="{ 359.634, 667.482, -0.01 }"
+      xMax="{ 365.8, 670.60, 2.00 }"/>
+    
+  </Geometry>
+  <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_GEOMETRY_END -->  
+
+  
+</Problem>

--- a/src/coreComponents/physicsSolvers/fluidFlow/benchmarks/SPE10/dead_oil_spe10_layers_84_85_benchmark2.xml
+++ b/src/coreComponents/physicsSolvers/fluidFlow/benchmarks/SPE10/dead_oil_spe10_layers_84_85_benchmark2.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" ?>
+
+<Problem>
+
+  <Included>
+    <File
+      name="./dead_oil_spe10_layers_84_85.xml"/>
+  </Included>
+
+
+  <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_MESH -->
+  <Mesh>
+    <InternalMesh
+      name="mesh"
+      elementTypes="{ C3D8 }"
+      xCoords="{ 0, 365.76 }"
+      yCoords="{ 0, 670.56 }"
+      zCoords="{ 0, 1.22 }"
+      nx="{ 120 }"
+      ny="{ 440 }"
+      nz="{ 4 }"
+      cellBlockNames="{ block }"/>
+  </Mesh>
+  <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_MESH_END -->
+
+  <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_GEOMETRY -->  
+  <Geometry>
+
+    <Box
+      name="source"
+      xMin="{ 182.85, 335.25, -0.01 }"
+      xMax="{ 189.00, 338.35, 2.00 }"/>
+    <Box
+      name="sink1"
+      xMin="{ -0.01, -0.01, -0.01 }"
+      xMax="{ 6.126, 3.078, 2.00 }"/>
+    <Box
+      name="sink2"
+      xMin="{ -0.01, 667.482, -0.01 }"
+      xMax="{ 6.126, 670.60, 2.00 }"/>
+    <Box
+      name="sink3"
+      xMin="{ 359.634, -0.01, -0.01 }"
+      xMax="{ 365.8, 3.048, 2.00 }"/>
+    <Box
+      name="sink4"
+      xMin="{ 359.634, 667.482, -0.01 }"
+      xMax="{ 365.8, 670.60, 2.00 }"/>
+    
+  </Geometry>
+  <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_GEOMETRY_END -->  
+  
+</Problem>

--- a/src/coreComponents/physicsSolvers/fluidFlow/benchmarks/SPE10/dead_oil_spe10_layers_84_85_smoke.xml
+++ b/src/coreComponents/physicsSolvers/fluidFlow/benchmarks/SPE10/dead_oil_spe10_layers_84_85_smoke.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" ?>
+
+<Problem>
+
+  <Included>
+    <File
+      name="./dead_oil_spe10_layers_84_85.xml"/>
+  </Included>
+
+
+  <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_MESH -->
+  <Mesh>
+    <InternalMesh
+      name="mesh"
+      elementTypes="{ C3D8 }"
+      xCoords="{ 0, 365.76 }"
+      yCoords="{ 0, 670.56 }"
+      zCoords="{ 0, 1.22 }"
+      nx="{ 30 }"
+      ny="{ 110 }"
+      nz="{ 2 }"
+      cellBlockNames="{ block }"/>
+  </Mesh>
+  <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_MESH_END -->
+
+  <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_GEOMETRY -->  
+  <Geometry>
+
+    <Box
+      name="source"
+      xMin="{ 182.00, 335.00, -0.01 }"
+      xMax="{ 196.00, 342.00, 2.00 }"/>
+    <Box
+      name="sink1"
+      xMin="{ -0.01, -0.01, -0.01 }"
+      xMax="{ 13.00,  7.00, 2.00 }"/>
+    <Box
+      name="sink2"
+      xMin="{ -0.01, 663.00, -0.01 }"
+      xMax="{ 13.0,  670.60, 2.00 }"/>
+    <Box
+      name="sink3"
+      xMin="{ 353.0, -0.01, -0.01 }"
+      xMax="{ 365.8, 7.0, 2.00 }"/>
+    <Box
+      name="sink4"
+      xMin="{ 353.0, 663.0, -0.01 }"
+      xMax="{ 365.8, 670.60, 2.00 }"/>
+    
+  </Geometry>
+  <!-- SPHINX_TUT_DEAD_OIL_BOTTOM_SPE10_GEOMETRY_END -->  
+  
+</Problem>


### PR DESCRIPTION
We would like to have strong links between smoke tests, examples, benchmarks. This PR splits up xml files s.t. tests at different levels include the same input files, but have deviations specified in the top level xml file.