### PR TITLE
Added calls to reserve in transmissibilities precomputation

### DIFF
--- a/src/coreComponents/finiteVolume/CellElementStencilTPFA.cpp
+++ b/src/coreComponents/finiteVolume/CellElementStencilTPFA.cpp
@@ -30,6 +30,14 @@ CellElementStencilTPFA::CellElementStencilTPFA():
   m_cellToFaceVec.resize( 0, 2, 3 );
 }
 
+void CellElementStencilTPFA::reserve( localIndex const size )
+{
+  StencilBase::reserve( size );
+
+  m_faceNormal.reserve( 3 * size );
+  m_cellToFaceVec.reserve( 6 * size );
+  m_transMultiplier.reserve( size );
+}
 
 void CellElementStencilTPFA::add( localIndex const numPts,
                                   localIndex const * const elementRegionIndices,

--- a/src/coreComponents/finiteVolume/CellElementStencilTPFA.hpp
+++ b/src/coreComponents/finiteVolume/CellElementStencilTPFA.hpp
@@ -197,6 +197,12 @@ public:
   { return m_elementRegionIndices.size( 0 ); }
 
   /**
+   * @brief Reserve the size of the stencil
+   * @param[in] size the size of the stencil to reserve
+   */
+  virtual void reserve( localIndex const size ) override final;
+
+  /**
    * @brief Give the number of points in a stencil entry.
    * @param[in] index of the stencil entry for which to query the size
    * @return the size of a stencil entry

--- a/src/coreComponents/finiteVolume/FaceElementToCellStencil.cpp
+++ b/src/coreComponents/finiteVolume/FaceElementToCellStencil.cpp
@@ -28,6 +28,15 @@ FaceElementToCellStencil::FaceElementToCellStencil():
   m_cellToFaceVec.resize( 0, 3 );
 }
 
+void FaceElementToCellStencil::reserve( localIndex const size )
+{
+  StencilBase::reserve( size );
+
+  m_faceNormal.reserve( 3 * size );
+  m_cellToFaceVec.reserve( 3 * size );
+  m_transMultiplier.reserve( size );
+}
+
 void FaceElementToCellStencil::move( LvArray::MemorySpace const space )
 {
   StencilBase< FaceElementToCellStencil_Traits, FaceElementToCellStencil >::move( space );

--- a/src/coreComponents/finiteVolume/FaceElementToCellStencil.hpp
+++ b/src/coreComponents/finiteVolume/FaceElementToCellStencil.hpp
@@ -236,6 +236,12 @@ public:
   { return m_elementRegionIndices.size( 0 ); }
 
   /**
+   * @brief Reserve the size of the stencil
+   * @param[in] size the size of the stencil to reserve
+   */
+  virtual void reserve( localIndex const size ) override final;
+
+  /**
    * @brief Give the number of points in a stencil entry.
    * @param[in] index of the stencil entry for which to query the size
    * @return the size of a stencil entry

--- a/src/coreComponents/finiteVolume/TwoPointFluxApproximation.cpp
+++ b/src/coreComponents/finiteVolume/TwoPointFluxApproximation.cpp
@@ -306,6 +306,9 @@ void TwoPointFluxApproximation::addToFractureStencil( MeshLevel & mesh,
   SortedArrayView< localIndex const > const
   recalculateFractureConnectorEdges = edgeManager.m_recalculateFractureConnectorEdges.toViewConst();
 
+  // reserve memory for the connections of this fracture
+  fractureStencil.reserve( fractureStencil.size() + recalculateFractureConnectorEdges.size() );
+
   // add new connectors/connections between face elements to the fracture stencil
   forAll< serialPolicy >( recalculateFractureConnectorEdges.size(),
                           [ &allNewElems,
@@ -542,6 +545,11 @@ void TwoPointFluxApproximation::addToFractureStencil( MeshLevel & mesh,
     arrayView2d< localIndex const > elemSubRegionList = faceElementsToCells.m_toElementSubRegion;
     arrayView2d< localIndex const > elemList = faceElementsToCells.m_toElementIndex;
 
+    // reserve memory for the connections of this region
+    if( cellStencil.size() != 0 )
+    {
+      faceToCellStencil.reserve( faceToCellStencil.size() + faceElementsToCells.size() );
+    }
 
     forAll< serialPolicy >( newFaceElements.size(),
                             [ newFaceElements,
@@ -659,6 +667,9 @@ void TwoPointFluxApproximation::addEDFracToFractureStencil( MeshLevel & mesh,
 
   localIndex connectorIndex = 0;
 
+  // reserve memory for the connections of this fracture
+  fractureStencil.reserve( fractureStencil.size() + embSurfEdgeManager.size() );
+
   // add new connectors/connections between embedded elements to the fracture stencil
   for( localIndex ke = 0; ke <  embSurfEdgeManager.size(); ke++ )
   {
@@ -725,6 +736,9 @@ void TwoPointFluxApproximation::addEDFracToFractureStencil( MeshLevel & mesh,
   FixedToManyElementRelation const & surfaceElementsToCells = fractureSubRegion.getToCellRelation();
 
   arrayView1d< real64 const > const connectivityIndex = fractureSubRegion.getConnectivityIndex();
+
+  // reserve memory for the connections of this fracture
+  edfmStencil.reserve( edfmStencil.size() + fractureSubRegion.size() );
 
   // start from last connectorIndex from cell-To-cell connections
   connectorIndex = edfmStencil.size();


### PR DESCRIPTION
This small PR adds three calls to `reserve` for the arrays stored in the stencil classes. 

This is to make sure that we are able run large one-rank models without stalling in the precomputation of the transmissibilities. The PR solves the problem and does not seem to break anything else.