### PR TITLE
Add version output

### DIFF
--- a/src/VERSION
+++ b/src/VERSION
@@ -1,1 +1,1 @@
-VERSION_ID = v0.0.31
+VERSION_ID = v0.2.0

--- a/src/cmake/GeosxConfig.cmake
+++ b/src/cmake/GeosxConfig.cmake
@@ -8,8 +8,18 @@ string( REPLACE "." ";" GEOSX_VERSION_LIST ${GEOSX_VERSION_FULL} )
 list( GET GEOSX_VERSION_LIST  0 GEOSX_VERSION_MAJOR )
 list( GET GEOSX_VERSION_LIST  1 GEOSX_VERSION_MINOR )
 list( GET GEOSX_VERSION_LIST  2 GEOSX_VERSION_PATCH )
-message( STATUS "Configuring GEOSX version ${GEOSX_VERSION_FULL}" )
 
+if( GIT_FOUND )
+    blt_is_git_repo( OUTPUT_STATE is_git_repo )
+    if( is_git_repo )
+        # the other option is to use blt_git_tag() but we want branch info too
+        blt_git_branch( BRANCH_NAME git_branch RETURN_CODE git_branch_rc )
+        blt_git_hashcode( HASHCODE git_hash RETURN_CODE git_hash_rc )
+        set( GEOSX_VERSION_DEV "${git_branch}-${git_hash}" )
+    endif()
+endif()
+
+message( STATUS "Configuring GEOSX version ${GEOSX_VERSION_FULL} ${GEOSX_VERSION_DEV}" )
 
 set( PREPROCESSOR_DEFINES ARRAY_BOUNDS_CHECK
                           CALIPER
@@ -72,6 +82,7 @@ function( make_full_config_file
     set( GEOSX_LA_INTERFACE_HYPRE ON )
     set( GEOSX_LA_INTERFACE_TRILINOS OFF )
     set( GEOSX_LA_INTERFACE_PETSC OFF )
+    unset( GEOSX_VERSION_DEV )
 
     configure_file( ${CMAKE_SOURCE_DIR}/coreComponents/common/GeosxConfig.hpp.in
                     ${CMAKE_SOURCE_DIR}/docs/doxygen/GeosxConfig.hpp )

--- a/src/coreComponents/common/GeosxConfig.hpp.in
+++ b/src/coreComponents/common/GeosxConfig.hpp.in
@@ -16,8 +16,10 @@
 #define GEOSX_VERSION_PATCH @GEOSX_VERSION_PATCH@
 /// GEOSX full version number string
 #define GEOSX_VERSION_FULL  "@GEOSX_VERSION_FULL@"
+/// GEOSX development version string
+#cmakedefine GEOSX_VERSION_DEV "@GEOSX_VERSION_DEV@"
 
-/// Enables floating point execptions
+/// Enables floating point exceptions
 #cmakedefine GEOSX_USE_FPE
 
 /// Enables bounds check in LvArray classes (CMake option ARRAY_BOUNDS_CHECK)

--- a/src/coreComponents/common/initializeEnvironment.cpp
+++ b/src/coreComponents/common/initializeEnvironment.cpp
@@ -41,7 +41,7 @@
 #include <cuda.h>
 #endif
 
-#include <fenv.h>
+#include <cfenv>
 
 namespace geosx
 {

--- a/src/coreComponents/mainInterface/GeosxState.hpp
+++ b/src/coreComponents/mainInterface/GeosxState.hpp
@@ -99,7 +99,7 @@ public:
    * @details Loads in the restart file if applicable, and allocates the ProblemManager.
    * @post After this call @c getState() is @c State::UNINITIALIZED.
    */
-  GeosxState( std::unique_ptr< CommandLineOptions > && commandLineOptions );
+  explicit GeosxState( std::unique_ptr< CommandLineOptions > && commandLineOptions );
 
   /**
    * @brief Destructor.

--- a/src/coreComponents/mainInterface/initialization.cpp
+++ b/src/coreComponents/mainInterface/initialization.cpp
@@ -15,33 +15,12 @@
 #include "initialization.hpp"
 
 #include "common/DataTypes.hpp"
-#include "common/TimingMacros.hpp"
 #include "common/Path.hpp"
 #include "LvArray/src/system.hpp"
 #include "linearAlgebra/interfaces/InterfaceTypes.hpp"
-#include "common/MpiWrapper.hpp"
 
 // TPL includes
 #include <optionparser.h>
-#include <umpire/ResourceManager.hpp>
-
-#if defined( GEOSX_USE_CALIPER )
-#include <caliper/cali-manager.h>
-#include <adiak.hpp>
-#endif
-
-// System includes
-#include <iomanip>
-
-#if defined( GEOSX_USE_OPENMP )
-#include <omp.h>
-#endif
-
-#if defined( GEOSX_USE_CUDA )
-#include <cuda.h>
-#endif
-
-#include <fenv.h>
 
 namespace geosx
 {
@@ -182,7 +161,7 @@ std::unique_ptr< CommandLineOptions > parseCommandLineOptions( int argc, char * 
       case RESTART:
       {
         commandLineOptions->restartFileName = opt.arg;
-        commandLineOptions->beginFromRestart = 1;
+        commandLineOptions->beginFromRestart = true;
       }
       break;
       case XPAR:
@@ -241,7 +220,7 @@ std::unique_ptr< CommandLineOptions > parseCommandLineOptions( int argc, char * 
     }
   }
 
-  if( commandLineOptions->problemName == "" && options[INPUT].count() > 0 )
+  if( commandLineOptions->problemName.empty() && options[INPUT].count() > 0 )
   {
     string & inputFileName = commandLineOptions->inputFileNames[0];
     if( inputFileName.length() > 4 && inputFileName.substr( inputFileName.length() - 4, 4 ) == ".xml" )
@@ -284,6 +263,16 @@ void basicCleanup()
 {
   finalizeLAI();
   cleanupEnvironment();
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+string getVersion()
+{
+#ifdef GEOSX_VERSION_DEV
+  return GEOSX_VERSION_FULL " (" GEOSX_VERSION_DEV ")";
+#else
+  return GEOSX_VERSION_FULL;
+#endif
 }
 
 

--- a/src/coreComponents/mainInterface/initialization.hpp
+++ b/src/coreComponents/mainInterface/initialization.hpp
@@ -21,8 +21,6 @@
 namespace geosx
 {
 
-
-
 /**
  * @brief Parse the command line options and populate @p commandLineOptions with the results.
  * @param argc The number of command line arguments.
@@ -45,6 +43,12 @@ std::unique_ptr< CommandLineOptions > basicSetup( int argc, char * argv[], bool 
  * @brief Perform the basic GEOSX cleanup.
  */
 void basicCleanup();
+
+/**
+ * @brief Get GEOSX version.
+ * @return The full version string.
+ */
+string getVersion();
 
 } // namespace geosx
 

--- a/src/docs/doxygen/GeosxConfig.hpp
+++ b/src/docs/doxygen/GeosxConfig.hpp
@@ -11,13 +11,15 @@
 /// GEOSX major version number
 #define GEOSX_VERSION_MAJOR 0
 /// GEOSX minor version number
-#define GEOSX_VERSION_MINOR 0
+#define GEOSX_VERSION_MINOR 2
 /// GEOSX patch version number
-#define GEOSX_VERSION_PATCH 31
+#define GEOSX_VERSION_PATCH 0
 /// GEOSX full version number string
-#define GEOSX_VERSION_FULL  "0.0.31"
+#define GEOSX_VERSION_FULL  "0.2.0"
+/// GEOSX development version string
+/* #undef GEOSX_VERSION_DEV */
 
-/// Enables floating point execptions
+/// Enables floating point exceptions
 #define GEOSX_USE_FPE
 
 /// Enables bounds check in LvArray classes (CMake option ARRAY_BOUNDS_CHECK)

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -37,6 +37,8 @@ int main( int argc, char *argv[] )
 
     std::unique_ptr< CommandLineOptions > commandLineOptions = basicSetup( argc, argv, true );
 
+    GEOSX_LOG_RANK_0( "GEOSX version " << getVersion() );
+
     std::chrono::system_clock::duration initTime;
     std::chrono::system_clock::duration runTime;
     {


### PR DESCRIPTION
This PR adds printing of GEOSX version at the beginning of each run (including git branch and commit hash, if applicable, i.e. when building from git clone as opposed to a tarball). This is helpful for resolving user-reported issues.

An alternative would be to add a command-line option for printing version. While it's a bit nicer, it potentially adds an additional communication round-trip (asking the user to run with `--version`). I can implement that if desired. Any other suggestions are welcome too.