### PR TITLE
Improve version header generation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,14 @@ endif()
 ################################
 install( DIRECTORY ${PROJECT_BINARY_DIR}/include DESTINATION . )
 
+
+################################
+# Generate version information
+################################
+include( cmake/GeosxVersion.cmake )
+message( STATUS "Configuring GEOSX version ${GEOSX_VERSION_FULL}" )
+
+
 ################################
 # Create header of configuration options
 ################################

--- a/src/cmake/GeosxConfig.cmake
+++ b/src/cmake/GeosxConfig.cmake
@@ -1,26 +1,3 @@
-#
-# Get GEOSX Version
-#
-file ( STRINGS "VERSION" GEOSX_VERSION_FULL )
-string( REGEX REPLACE "VERSION_ID = v" "" GEOSX_VERSION_FULL "${GEOSX_VERSION_FULL}" )
-string( REPLACE "." ";" GEOSX_VERSION_LIST ${GEOSX_VERSION_FULL} )
-
-list( GET GEOSX_VERSION_LIST  0 GEOSX_VERSION_MAJOR )
-list( GET GEOSX_VERSION_LIST  1 GEOSX_VERSION_MINOR )
-list( GET GEOSX_VERSION_LIST  2 GEOSX_VERSION_PATCH )
-
-if( GIT_FOUND )
-    blt_is_git_repo( OUTPUT_STATE is_git_repo )
-    if( is_git_repo )
-        # the other option is to use blt_git_tag() but we want branch info too
-        blt_git_branch( BRANCH_NAME git_branch RETURN_CODE git_branch_rc )
-        blt_git_hashcode( HASHCODE git_hash RETURN_CODE git_hash_rc )
-        set( GEOSX_VERSION_DEV "${git_branch}-${git_hash}" )
-    endif()
-endif()
-
-message( STATUS "Configuring GEOSX version ${GEOSX_VERSION_FULL} ${GEOSX_VERSION_DEV}" )
-
 set( PREPROCESSOR_DEFINES ARRAY_BOUNDS_CHECK
                           CALIPER
                           CHAI
@@ -82,7 +59,6 @@ function( make_full_config_file
     set( GEOSX_LA_INTERFACE_HYPRE ON )
     set( GEOSX_LA_INTERFACE_TRILINOS OFF )
     set( GEOSX_LA_INTERFACE_PETSC OFF )
-    unset( GEOSX_VERSION_DEV )
 
     configure_file( ${CMAKE_SOURCE_DIR}/coreComponents/common/GeosxConfig.hpp.in
                     ${CMAKE_SOURCE_DIR}/docs/doxygen/GeosxConfig.hpp )

--- a/src/cmake/GeosxVersion.cmake
+++ b/src/cmake/GeosxVersion.cmake
@@ -1,0 +1,101 @@
+# This script generates version info for GEOSX from VERSION file and git.
+# At config time, it sets various version variables and generates a build
+# target named 'generate_version', that the code must set a dependency on.
+# The target invokes this script again at build time, where it generates a
+# version header with the most up-to-date version info. Thus any change to
+# VERSION file or git state (in particular, branch name or HEAD commit sha)
+# will trigger a partial rebuild (anything that includes version header).
+#
+# This self-referential approach inspired in part by:
+# https://github.com/andrew-hardin/cmake-git-version-tracking
+
+# In script mode CMAKE_SOURCE_DIR is set to the build directory,
+# therefore the script uses SOURCE_DIR as the CMake root path.
+if( NOT DEFINED CMAKE_SCRIPT_MODE_FILE )
+  set( SOURCE_DIR ${CMAKE_SOURCE_DIR} )
+endif()
+
+# Get GEOSX version from a file
+# Inputs:
+#   -- SOURCE_DIR
+# Outputs:
+#   -- GEOSX_VERSION_FULL
+#   -- GEOSX_VERSION_LIST
+#   -- GEOSX_VERSION_MAJOR
+#   -- GEOSX_VERSION_MINOR
+#   -- GEOSX_VERSION_PATCH
+macro(geosx_get_file_version)
+  file ( STRINGS "${SOURCE_DIR}/VERSION" GEOSX_VERSION_FULL )
+  string( REGEX REPLACE "VERSION_ID = v" "" GEOSX_VERSION_FULL "${GEOSX_VERSION_FULL}" )
+  string( REPLACE "." ";" GEOSX_VERSION_LIST ${GEOSX_VERSION_FULL} )
+  list( GET GEOSX_VERSION_LIST  0 GEOSX_VERSION_MAJOR )
+  list( GET GEOSX_VERSION_LIST  1 GEOSX_VERSION_MINOR )
+  list( GET GEOSX_VERSION_LIST  2 GEOSX_VERSION_PATCH )
+endmacro()
+
+# Get GEOSX development version from git
+# Inputs:
+#   -- SOURCE_DIR
+#   -- GIT_FOUND
+#   -- GIT_EXECUTABLE (only when GIT_FOUND=TRUE )
+# Outputs (if GIT_FOUND=TRUE and inside git repo):
+#   -- GEOSX_GIT_BRANCH
+#   -- GEOSX_GIT_HASH
+#   -- GEOSX_GIT_TAG
+macro(geosx_get_git_version)
+  if( GIT_FOUND )
+    # Use BLT Git macros for convenience
+    include( ${SOURCE_DIR}/cmake/blt/cmake/BLTGitMacros.cmake )
+    blt_is_git_repo( OUTPUT_STATE is_git_repo
+                     SOURCE_DIR ${SOURCE_DIR} )
+    if( is_git_repo )
+      blt_git_branch( BRANCH_NAME GEOSX_GIT_BRANCH
+                      RETURN_CODE _git_rc
+                      SOURCE_DIR ${SOURCE_DIR} )
+      blt_git_hashcode( HASHCODE GEOSX_GIT_HASH
+                        RETURN_CODE _git_rc
+                        SOURCE_DIR ${SOURCE_DIR} )
+      blt_git_tag( OUTPUT_TAG GEOSX_GIT_TAG
+                   RETURN_CODE _git_rc
+                   SOURCE_DIR ${SOURCE_DIR} )
+    endif()
+  endif()
+endmacro()
+
+# Both at config time and build time, we generate updated version info
+geosx_get_file_version()
+geosx_get_git_version()
+
+# Set paths for version header
+set( ver_component mainInterface )
+set( ver_filename GeosxVersion.hpp )
+set( ver_in_file ${SOURCE_DIR}/coreComponents/${ver_component}/${ver_filename}.in )
+set( ver_tmp_file ${CMAKE_BINARY_DIR}/${ver_filename} )
+set( ver_out_path ${CMAKE_BINARY_DIR}/include/${ver_component} )
+set( ver_out_file ${ver_out_path}/${ver_filename} )
+
+# Generate version header, but in a temporary location to avoid rebuilds every time
+configure_file( ${ver_in_file} ${ver_tmp_file} )
+
+if( NOT DEFINED CMAKE_SCRIPT_MODE_FILE )
+  # At config time copy version header into place so it can be picked up by IDEs, etc.
+  # Also make it installable in case another project wants to include it.
+  file( COPY ${ver_tmp_file} DESTINATION ${ver_out_path} )
+  install( FILES ${ver_out_file}
+           DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${ver_component} )
+
+  # Define a build-time target that will call this script again and:
+  # - Regenerate the temporary version header
+  # - Copy the header into place whenever it changes, to trigger partial rebuild
+  add_custom_target( generate_version
+                     ALL
+                     DEPENDS ${ver_in_file}
+                     BYPRODUCTS ${ver_out_file} ${ver_tmp_file}
+                     COMMENT "Generating version information"
+                     COMMAND ${CMAKE_COMMAND}
+                     -D SOURCE_DIR=${SOURCE_DIR}
+                     -D GIT_FOUND=${GIT_FOUND}
+                     -D GIT_EXECUTABLE=${GIT_EXECUTABLE}
+                     -P "${CMAKE_CURRENT_LIST_FILE}"
+                     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ver_tmp_file} ${ver_out_file} )
+endif()

--- a/src/coreComponents/common/GeosxConfig.hpp.in
+++ b/src/coreComponents/common/GeosxConfig.hpp.in
@@ -8,17 +8,6 @@
 #ifndef GEOSX_COMMON_CONFIG_HPP
 #define GEOSX_COMMON_CONFIG_HPP
 
-/// GEOSX major version number
-#define GEOSX_VERSION_MAJOR @GEOSX_VERSION_MAJOR@
-/// GEOSX minor version number
-#define GEOSX_VERSION_MINOR @GEOSX_VERSION_MINOR@
-/// GEOSX patch version number
-#define GEOSX_VERSION_PATCH @GEOSX_VERSION_PATCH@
-/// GEOSX full version number string
-#define GEOSX_VERSION_FULL  "@GEOSX_VERSION_FULL@"
-/// GEOSX development version string
-#cmakedefine GEOSX_VERSION_DEV "@GEOSX_VERSION_DEV@"
-
 /// Enables floating point exceptions
 #cmakedefine GEOSX_USE_FPE
 

--- a/src/coreComponents/mainInterface/CMakeLists.txt
+++ b/src/coreComponents/mainInterface/CMakeLists.txt
@@ -29,6 +29,8 @@ blt_add_library( NAME       mainInterface
                  OBJECT     ${GEOSX_BUILD_OBJ_LIBS}
                )
 
+add_dependencies( mainInterface generate_version )
+
 target_include_directories( mainInterface PUBLIC ${CMAKE_SOURCE_DIR}/coreComponents )
 
 geosx_add_code_checks( PREFIX mainInterface )

--- a/src/coreComponents/mainInterface/GeosxVersion.hpp.in
+++ b/src/coreComponents/mainInterface/GeosxVersion.hpp.in
@@ -1,0 +1,28 @@
+/**
+ * @file GeosxVersion.hpp
+ *
+ * GEOSX version file.
+ * Contains a CMake-generated list of macros that define a particular software version.
+ */
+
+#ifndef GEOSX_MAININTERFACE_VERSION_HPP_
+#define GEOSX_MAININTERFACE_VERSION_HPP_
+
+/// GEOSX major version number
+#define GEOSX_VERSION_MAJOR @GEOSX_VERSION_MAJOR@
+/// GEOSX minor version number
+#define GEOSX_VERSION_MINOR @GEOSX_VERSION_MINOR@
+/// GEOSX patch version number
+#define GEOSX_VERSION_PATCH @GEOSX_VERSION_PATCH@
+/// GEOSX full version number string
+#define GEOSX_VERSION_FULL  "@GEOSX_VERSION_FULL@"
+
+/// GEOSX development branch string
+#cmakedefine GEOSX_GIT_BRANCH "@GEOSX_GIT_BRANCH@"
+/// GEOSX development branch string
+#cmakedefine GEOSX_GIT_HASH "@GEOSX_GIT_HASH@"
+/// GEOSX development branch string
+#cmakedefine GEOSX_GIT_TAG "@GEOSX_GIT_TAG@"
+
+#endif  /* GEOSX_MAININTERFACE_VERSION_HPP_ */
+

--- a/src/coreComponents/mainInterface/initialization.cpp
+++ b/src/coreComponents/mainInterface/initialization.cpp
@@ -18,6 +18,7 @@
 #include "common/Path.hpp"
 #include "LvArray/src/system.hpp"
 #include "linearAlgebra/interfaces/InterfaceTypes.hpp"
+#include "mainInterface/GeosxVersion.hpp"
 
 // TPL includes
 #include <optionparser.h>
@@ -268,8 +269,8 @@ void basicCleanup()
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 string getVersion()
 {
-#ifdef GEOSX_VERSION_DEV
-  return GEOSX_VERSION_FULL " (" GEOSX_VERSION_DEV ")";
+#if defined(GEOSX_GIT_BRANCH) && defined(GEOSX_GIT_HASH)
+  return GEOSX_VERSION_FULL " (" GEOSX_GIT_BRANCH ", sha1: " GEOSX_GIT_HASH ")";
 #else
   return GEOSX_VERSION_FULL;
 #endif

--- a/src/docs/doxygen/GeosxConfig.hpp
+++ b/src/docs/doxygen/GeosxConfig.hpp
@@ -8,17 +8,6 @@
 #ifndef GEOSX_COMMON_CONFIG_HPP
 #define GEOSX_COMMON_CONFIG_HPP
 
-/// GEOSX major version number
-#define GEOSX_VERSION_MAJOR 0
-/// GEOSX minor version number
-#define GEOSX_VERSION_MINOR 2
-/// GEOSX patch version number
-#define GEOSX_VERSION_PATCH 0
-/// GEOSX full version number string
-#define GEOSX_VERSION_FULL  "0.2.0"
-/// GEOSX development version string
-/* #undef GEOSX_VERSION_DEV */
-
 /// Enables floating point exceptions
 #define GEOSX_USE_FPE
 


### PR DESCRIPTION
This PR addresses two issues noticed by @TotoGaz in https://github.com/GEOSX/GEOSX/pull/1581 :
1. Each time the development version changed, an almost-full rebuild would ensue as a result of changes to `GeosxConfig.hpp`. The solution is to put all version information macros into a separate header, `GeosxVersion.hpp`, that is only included in a single translation unit that is fast to rebuild. The header is placed as low as possible in the dependency tree - in `coreComponents/mainInterface` (however not in `main`, so that it remains accessible also through python in the future).
2. Version would only be updated upon re-configure, meaning that if one pulled new commits and did not rerun `cmake`, they could end up with stale version data baked into the binary. The solution is to generate version header at build time (instead of or in addition to config time). This is now done via new CMake script, `GeosxVersion.cmake` that runs both at config time (and generates a new build-time target) and then later at build time. There are some small tricks to avoid triggering partial rebuild if nothing has changed (using a temporary header and CMake's `copy_if_different` command), but all in all the end solution is fairly neat. 

I've tested it on both "dirty" and "clean" in-repo builds, as well as a non-repo build (deleting `.git` from a repository, which is more or less equivalent to a release tarball) and did not observe any problems.