### PR TITLE
Fixed negative cell volume with reverseZ on CPG

### DIFF
--- a/src/coreComponents/mesh/CellBlock.hpp
+++ b/src/coreComponents/mesh/CellBlock.hpp
@@ -265,22 +265,22 @@ private:
     {
       case ElementType::Hexahedron:
       {
-        m_elementVolume[k] = computationalGeometry::HexVolume( Xlocal );
+        m_elementVolume[k] = computationalGeometry::hexVolume( Xlocal );
         break;
       }
       case ElementType::Tetrahedron:
       {
-        m_elementVolume[k] = computationalGeometry::TetVolume( Xlocal );
+        m_elementVolume[k] = computationalGeometry::tetVolume( Xlocal );
         break;
       }
       case ElementType::Prism:
       {
-        m_elementVolume[k] = computationalGeometry::WedgeVolume( Xlocal );
+        m_elementVolume[k] = computationalGeometry::wedgeVolume( Xlocal );
         break;
       }
       case ElementType::Pyramid:
       {
-        m_elementVolume[k] = computationalGeometry::PyramidVolume( Xlocal );
+        m_elementVolume[k] = computationalGeometry::pyramidVolume( Xlocal );
         break;
       }
       default:

--- a/src/coreComponents/mesh/utilities/ComputationalGeometry.hpp
+++ b/src/coreComponents/mesh/utilities/ComputationalGeometry.hpp
@@ -433,7 +433,7 @@ void getBoundingBox( localIndex const elemIndex,
  */
 GEOSX_HOST_DEVICE
 inline
-real64 HexVolume( real64 const X[][3] )
+real64 hexVolume( real64 const X[][3] )
 {
   real64 X7_X1[ 3 ] = LVARRAY_TENSOROPS_INIT_LOCAL_3( X[7] );
   LvArray::tensorOps::subtract< 3 >( X7_X1, X[1] );
@@ -483,7 +483,7 @@ real64 HexVolume( real64 const X[][3] )
  */
 GEOSX_HOST_DEVICE
 inline
-real64 TetVolume( real64 const X[][3] )
+real64 tetVolume( real64 const X[][3] )
 {
   real64 X1_X0[ 3 ] = LVARRAY_TENSOROPS_INIT_LOCAL_3( X[1] );
   LvArray::tensorOps::subtract< 3 >( X1_X0, X[0] );
@@ -497,7 +497,7 @@ real64 TetVolume( real64 const X[][3] )
   real64 X2_X0crossX3_X0[ 3 ];
   LvArray::tensorOps::crossProduct( X2_X0crossX3_X0, X2_X0, X3_X0 );
 
-  return std::fabs( LvArray::tensorOps::AiBi< 3 >( X1_X0, X2_X0crossX3_X0 ) / 6.0 );
+  return LvArray::math::abs( LvArray::tensorOps::AiBi< 3 >( X1_X0, X2_X0crossX3_X0 ) / 6.0 );
 }
 
 /**
@@ -507,7 +507,7 @@ real64 TetVolume( real64 const X[][3] )
  */
 GEOSX_HOST_DEVICE
 inline
-real64 WedgeVolume( real64 const X[][3] )
+real64 wedgeVolume( real64 const X[][3] )
 {
   real64 const tet1[4][3] = { LVARRAY_TENSOROPS_INIT_LOCAL_3( X[0] ),
                               LVARRAY_TENSOROPS_INIT_LOCAL_3( X[1] ),
@@ -524,7 +524,7 @@ real64 WedgeVolume( real64 const X[][3] )
                               LVARRAY_TENSOROPS_INIT_LOCAL_3( X[4] ),
                               LVARRAY_TENSOROPS_INIT_LOCAL_3( X[5] ) };
 
-  return TetVolume( tet1 ) + TetVolume( tet2 ) + TetVolume( tet3 );
+  return tetVolume( tet1 ) + tetVolume( tet2 ) + tetVolume( tet3 );
 }
 
 /**
@@ -534,7 +534,7 @@ real64 WedgeVolume( real64 const X[][3] )
  */
 GEOSX_HOST_DEVICE
 inline
-real64 PyramidVolume( real64 const X[][3] )
+real64 pyramidVolume( real64 const X[][3] )
 {
   real64 const tet1[4][3] = { LVARRAY_TENSOROPS_INIT_LOCAL_3( X[0] ),
                               LVARRAY_TENSOROPS_INIT_LOCAL_3( X[1] ),
@@ -546,7 +546,7 @@ real64 PyramidVolume( real64 const X[][3] )
                               LVARRAY_TENSOROPS_INIT_LOCAL_3( X[3] ),
                               LVARRAY_TENSOROPS_INIT_LOCAL_3( X[4] ) };
 
-  return TetVolume( tet1 ) + TetVolume( tet2 );
+  return tetVolume( tet1 ) + tetVolume( tet2 );
 }
 
 } /* namespace computationalGeometry */

--- a/src/coreComponents/physicsSolvers/fluidFlow/integratedTests/singlePhaseFlow/pamela_test/3D_10x10x10_compressible_pamela_pyramid_gravity.xml
+++ b/src/coreComponents/physicsSolvers/fluidFlow/integratedTests/singlePhaseFlow/pamela_test/3D_10x10x10_compressible_pamela_pyramid_gravity.xml
@@ -107,7 +107,7 @@
       name="Porosity"
       initialCondition="1"
       setNames="{ all }"
-      objectPath="ElementRegions/Domain/DEFAULT_HEX"
+      objectPath="ElementRegions/Domain/DEFAULT_PYRAMID"
       fieldName="rockPorosity_referencePorosity"
       scale="0.05"/>
 

--- a/src/coreComponents/unitTests/finiteVolumeTests/testMimeticInnerProducts.cpp
+++ b/src/coreComponents/unitTests/finiteVolumeTests/testMimeticInnerProducts.cpp
@@ -79,11 +79,11 @@ void computeVolumeAndCenter( array2d< real64, nodes::REFERENCE_POSITION_PERM > c
 
   if( numNodes == 8 )
   {
-    elemVolume = computationalGeometry::HexVolume( Xlocal );
+    elemVolume = computationalGeometry::hexVolume( Xlocal );
   }
   else if( numNodes == 4 )
   {
-    elemVolume = computationalGeometry::TetVolume( Xlocal );
+    elemVolume = computationalGeometry::tetVolume( Xlocal );
   }
 }
 


### PR DESCRIPTION
In the `PAMELAMeshGenerator`, we have an option called `reverseZ` that can be used to convert depth (typically used in the GRDECL format) to elevation (that we use internally in GEOSX). However, I noticed with @wdmhouston 's case that using `reverseZ` to go from depth to elevation leads to negative cell volumes because of our node ordering assumption:
```
*                  6                   7                       ____________________
 *                   o-----------------o                       |Node   xi0  xi1  xi2|
 *                  /.                /|                       |=====  ===  ===  ===|
 *                 / .               / |                       | 0     -1   -1   -1 |
 *              4 o-----------------o 5|                       | 1      1   -1   -1 |
 *                |  .              |  |                       | 2     -1    1   -1 |
 *                |  .              |  |                       | 3      1    1   -1 |
 *                |  .              |  |                       | 4     -1   -1    1 |
 *                |  .              |  |                       | 5      1   -1    1 |
 *                |2 o..............|..o 3       xi2           | 6     -1    1    1 |
 *                | ,               | /          |             | 7      1    1    1 |
 *                |,                |/           | / xi1       |____________________|
 *                o-----------------o            |/
 *               0                   1           ------ xi0
```
This PR fixes that by switching the nodes {0,1,2,3} and {4,5,6,7} if `reverseZ` is equal to 1.

The other option would be to just add an absolute value [here](https://github.com/GEOSX/GEOSX/blob/a8711cad373dd1328ece6a51713a81732714a01d/src/coreComponents/mesh/utilities/ComputationalGeometry.hpp#L474). But, given that negative volumes have been a very good indicator for meshing issues over the past years, I would prefer not to add the absolute value. Let me know what you think.

This PR does not require a rebaseline.