### PR TITLE
Add Ninja job pool limit options

### DIFF
--- a/src/cmake/GeosxOptions.cmake
+++ b/src/cmake/GeosxOptions.cmake
@@ -78,6 +78,18 @@ option( GEOSX_BUILD_OBJ_LIBS "Builds coreComponent modules as object libraries" 
 
 option( GEOSX_BUILD_SHARED_LIBS "Builds geosx_core as a shared library " OFF )
 
+set( GEOSX_PARALLEL_COMPILE_JOBS "" CACHE STRING "Maximum number of concurrent compilation jobs" )
+if( GEOSX_PARALLEL_COMPILE_JOBS )
+    set_property( GLOBAL APPEND PROPERTY JOB_POOLS compile_job_pool=${GEOSX_PARALLEL_COMPILE_JOBS} )
+    set( CMAKE_JOB_POOL_COMPILE compile_job_pool )
+endif()
+
+set( GEOSX_PARALLEL_LINK_JOBS "" CACHE STRING "Maximum number of concurrent link jobs" )
+if( GEOSX_PARALLEL_LINK_JOBS )
+    set_property( GLOBAL APPEND PROPERTY JOB_POOLS link_job_pool=${GEOSX_PARALLEL_LINK_JOBS} )
+    set( CMAKE_JOB_POOL_LINK link_job_pool )
+endif()
+
 #set(CMAKE_POSITION_INDEPENDENT_CODE ON  CACHE BOOL "" FORCE)
 #blt_append_custom_compiler_flag(FLAGS_VAR CMAKE_CXX_FLAGS DEFAULT -rdynamic)
 #set(CMAKE_EXE_LINKER_FLAGS "-rdynamic")

--- a/src/docs/sphinx/buildGuide/BuildProcess.rst
+++ b/src/docs/sphinx/buildGuide/BuildProcess.rst
@@ -55,17 +55,21 @@ Below is a list of CMake configuration options, in addition to TPL options above
 Some options, when enabled, require additional settings (e.g. ``ENABLE_CUDA``).
 Please see `host-config examples <https://github.com/GEOSX/GEOSX/blob/develop/host-configs>`_.
 
-============================= ========= ================================================================================
-Option                        Default   Explanation
-============================= ========= ================================================================================
-``ENABLE_MPI``                ``ON``    Build with MPI (also applies to TPLs)
-``ENABLE_OPENMP``             ``OFF``   Build with OpenMP (also applies to TPLs)
-``ENABLE_CUDA``               ``OFF``   Build with CUDA (also applies to TPLs)
-``ENABLE_DOCS``               ``ON``    Build documentation (Sphinx and Doxygen)
-``ENABLE_WARNINGS_AS_ERRORS`` ``ON``    Treat all warnings as errors
-``ENABLE_PAMELA``             ``ON``    Enable PAMELA library (required for external mesh import)
-``ENABLE_PVTPackage``         ``ON``    Enable PVTPackage library (required for compositional flow runs)
-``ENABLE_TOTALVIEW_OUTPUT``   ``OFF``   Enables TotalView debugger custom view of GEOSX data structures
-``GEOSX_ENABLE_FPE``          ``ON``    Enable floating point exception trapping
-``GEOSX_LA_INTERFACE``        ``Hypre`` Choiсe of Linear Algebra backend (Hypre/Petsc/Trilinos)
-============================= ========= ================================================================================
+=============================== ========= ==============================================================================
+Option                          Default   Explanation
+=============================== ========= ==============================================================================
+``ENABLE_MPI``                  ``ON``    Build with MPI (also applies to TPLs)
+``ENABLE_OPENMP``               ``OFF``   Build with OpenMP (also applies to TPLs)
+``ENABLE_CUDA``                 ``OFF``   Build with CUDA (also applies to TPLs)
+``ENABLE_DOCS``                 ``ON``    Build documentation (Sphinx and Doxygen)
+``ENABLE_WARNINGS_AS_ERRORS``   ``ON``    Treat all warnings as errors
+``ENABLE_PAMELA``               ``ON``    Enable PAMELA library (required for external mesh import)
+``ENABLE_PVTPackage``           ``ON``    Enable PVTPackage library (required for compositional flow runs)
+``ENABLE_TOTALVIEW_OUTPUT``     ``OFF``   Enables TotalView debugger custom view of GEOSX data structures
+``GEOSX_ENABLE_FPE``            ``ON``    Enable floating point exception trapping
+``GEOSX_LA_INTERFACE``          ``Hypre`` Choiсe of Linear Algebra backend (Hypre/Petsc/Trilinos)
+``GEOSX_BUILD_OBJ_LIBS``        ``ON``    Use CMake Object Libraries build
+``GEOSX_BUILD_SHARED_LIBS``     ``OFF``   Build ``geosx_core`` as a shared library instead of static
+``GEOSX_PARALLEL_COMPILE_JOBS``           Max. number of compile jobs (when using Ninja), in addition to ``-j`` flag
+``GEOSX_PARALLEL_LINK_JOBS``              Max. number of link jobs (when using Ninja), in addition to ``-j`` flag
+=============================== ========= ==============================================================================


### PR DESCRIPTION
This PR adds CMake-level compile/link job pool options.

This is useful when building on a machine with limited resources. Currently, for example, on a machine with 8 cores and 16 Gb RAM, building all targets in debug via `ninja -j8` passes through compilation just fine, but completely hangs the system and crashes while linking unit tests due to exhausting RAM.

It is thus useful to be able to set separate limits via host-config. These are supported for Ninja generator and place further restrictions over the global `-j` flag. This requires a small change to our CMake scripting as it is not possible to add job pools to global project properties via host-config file only. Nothing changes for users that don't specify the new options.

https://cmake.org/cmake/help/latest/prop_gbl/JOB_POOLS.html