### PR TITLE
Fix porosity initialization for advanced poromechanics wellbore problem

### DIFF
--- a/src/coreComponents/physicsSolvers/multiphysics/benchmarks/WellboreProblem_Base.xml
+++ b/src/coreComponents/physicsSolvers/multiphysics/benchmarks/WellboreProblem_Base.xml
@@ -124,6 +124,15 @@
     scale="10e6"
     functionName="timeFunction"   
   />
+
+  <FieldSpecification 
+    name="initialPorosity"
+    initialCondition="1"
+    setNames="{all}"
+    objectPath="ElementRegions/Omega/cb1"
+    fieldName="rockPorosity_porosity"
+    scale="0.3"
+  />
 </FieldSpecifications>
 <!-- SPHINX_WELLBORE_BC_END -->
 

--- a/src/coreComponents/physicsSolvers/multiphysics/integratedTests/WellboreProblem_Base.xml
+++ b/src/coreComponents/physicsSolvers/multiphysics/integratedTests/WellboreProblem_Base.xml
@@ -124,6 +124,15 @@
     scale="10e6"
     functionName="timeFunction"   
   />
+
+  <FieldSpecification 
+    name="initialPorosity"
+    initialCondition="1"
+    setNames="{all}"
+    objectPath="ElementRegions/Omega/cb1"
+    fieldName="rockPorosity_porosity"
+    scale="0.3"
+  />
 </FieldSpecifications>
 <!-- SPHINX_WELLBORE_BC_END -->
 

--- a/src/docs/sphinx/advancedExamples/validationStudies/poromechanicsWellbore/Example.rst
+++ b/src/docs/sphinx/advancedExamples/validationStudies/poromechanicsWellbore/Example.rst
@@ -124,12 +124,12 @@ As demonstrated in this example, to setup a poromechanical coupling, we need to 
   :end-before: <!-- SPHINX_WELLBORE_SINGLEPHASEFVM_END -->
 
 
-- the coupling solver (``SinglePhasePoromechanics``) that will bind the two single-physics solvers above, which is named as ``PoromechanicsSolver`` (more information at :ref:`SinglePhasePoromechanics`).
+- the coupling solver (``SinglePhasePoromechanics``) that will bind the two single-physics solvers above, which is named as ``PoromechanicsSolver`` (more information at :ref:`PoroelasticSolver`).
 
 .. literalinclude:: ../../../../../../src/coreComponents/physicsSolvers/multiphysics/benchmarks/WellboreProblem_Base.xml
   :language: xml
-  :start-after: <!-- SPHINX_WELLBORE_POROELASTICSOLVER -->
-  :end-before: <!-- SPHINX_WELLBORE_POROELASTICSOLVER_END -->
+  :start-after: <!-- SPHINX_WELLBORE_POROMECHANICSSOLVER -->
+  :end-before: <!-- SPHINX_WELLBORE_POROMECHANICSSOLVER_END -->
 
 
 The two single-physics solvers are parameterized as explained


### PR DESCRIPTION
If using `BiotPorosity` model, porosity should be initialized; otherwise, inaccurate results will be obtained (#1587). 

In this PR, porosity initialization is added to the poroelastic and proplastic wellbore examples (including xml files for both the benchmark and integrated test).

To avoid similar issue, following three cases should be added to the integrated tests :

`src/coreComponents/physicsSolvers/multiphysics/integratedTests/WellboreProblem_PoroElastic.xml`

`src/coreComponents/physicsSolvers/multiphysics/integratedTests/WellboreProblem_PoroDruckerPrager.xml`

`src/coreComponents/physicsSolvers/solidMechanics/integratedTests/ExtendedDruckerPrager_Wellbore.xml`

