### PR TITLE
Poromechanics kernels refactoring

### DIFF
--- a/src/coreComponents/constitutive/solid/PorousSolid.hpp
+++ b/src/coreComponents/constitutive/solid/PorousSolid.hpp
@@ -80,12 +80,12 @@ public:
     dTotalStress_dPressure[4] = 0;
     dTotalStress_dPressure[5] = 0;
 
-    m_porosityUpdate.updatePorosity( k,
-                                     q,
-                                     deltaPressure,
-                                     strainIncrement,
-                                     dPorosity_dPressure,
-                                     dPorosity_dVolStrain );
+    m_porosityUpdate.updateFromPressureAndStrain( k,
+                                                  q,
+                                                  deltaPressure,
+                                                  strainIncrement,
+                                                  dPorosity_dPressure,
+                                                  dPorosity_dVolStrain );
 
 // TODO uncomment once we start using permeability model in flow.
 //    m_permUpdate.updateFromPressureStrain( k,

--- a/src/coreComponents/constitutive/solid/PorousSolid.hpp
+++ b/src/coreComponents/constitutive/solid/PorousSolid.hpp
@@ -61,7 +61,7 @@ public:
                           real64 ( & totalStress )[6],
                           real64 & dPorosity_dPressure,
                           real64 & dPorosity_dVolStrain,
-                          real64 ( &dTotalStress_dPressure )[6],
+                          real64 ( & dTotalStress_dPressure )[6],
                           DiscretizationOps & stiffness ) const
   {
     // Compute effective stress and store in totalStress
@@ -69,24 +69,23 @@ public:
 
     updateBiotCoefficient( k );
 
-   // Compute  total stress
-   real64 const biotCoefficient = m_porosityUpdate.getBiotCoefficient( k );
-   LvArray::tensorOps::symAddIdentity< 3 >( totalStress, - biotCoefficient * ( pressure + deltaPressure ) );
+    // Compute  total stress
+    real64 const biotCoefficient = m_porosityUpdate.getBiotCoefficient( k );
+    LvArray::tensorOps::symAddIdentity< 3 >( totalStress, -biotCoefficient * ( pressure + deltaPressure ) );
 
-   dTotalStress_dPressure[0] = biotCoefficient;
-   dTotalStress_dPressure[1] = biotCoefficient;
-   dTotalStress_dPressure[2] = biotCoefficient;
-   dTotalStress_dPressure[3] = 0;
-   dTotalStress_dPressure[4] = 0;
-   dTotalStress_dPressure[5] = 0;
+    dTotalStress_dPressure[0] = biotCoefficient;
+    dTotalStress_dPressure[1] = biotCoefficient;
+    dTotalStress_dPressure[2] = biotCoefficient;
+    dTotalStress_dPressure[3] = 0;
+    dTotalStress_dPressure[4] = 0;
+    dTotalStress_dPressure[5] = 0;
 
-   m_porosityUpdate.updatePorosity( k,
-                                    q,
-				    pressure,
-                                    deltaPressure,
-                                    strainIncrement,
-                                    dPorosity_dPressure,
-                                    dPorosity_dVolStrain );
+    m_porosityUpdate.updatePorosity( k,
+                                     q,
+                                     deltaPressure,
+                                     strainIncrement,
+                                     dPorosity_dPressure,
+                                     dPorosity_dVolStrain );
 
 // TODO uncomment once we start using permeability model in flow.
 //    m_permUpdate.updateFromPressureStrain( k,

--- a/src/coreComponents/constitutive/solid/PorousSolid.hpp
+++ b/src/coreComponents/constitutive/solid/PorousSolid.hpp
@@ -55,25 +55,38 @@ public:
   GEOSX_HOST_DEVICE
   void smallStrainUpdate( localIndex const k,
                           localIndex const q,
+                          real64 const & pressure,
                           real64 const & deltaPressure,
                           real64 const ( &strainIncrement )[6],
-                          real64 ( & stress )[6],
+                          real64 ( & totalStress )[6],
                           real64 & dPorosity_dPressure,
                           real64 & dPorosity_dVolStrain,
-                          real64 & dTotalStress_dPressure,
+                          real64 ( &dTotalStress_dPressure )[6],
                           DiscretizationOps & stiffness ) const
   {
-    m_solidUpdate.smallStrainUpdate( k, q, strainIncrement, stress, stiffness );
+    // Compute effective stress and store in totalStress
+    m_solidUpdate.smallStrainUpdate( k, q, strainIncrement, totalStress, stiffness );
 
     updateBiotCoefficient( k );
 
-    m_porosityUpdate.updatePorosity( k,
-                                     q,
-                                     deltaPressure,
-                                     strainIncrement,
-                                     dPorosity_dPressure,
-                                     dPorosity_dVolStrain,
-                                     dTotalStress_dPressure );
+   // Compute  total stress
+   real64 const biotCoefficient = m_porosityUpdate.getBiotCoefficient( k );
+   LvArray::tensorOps::symAddIdentity< 3 >( totalStress, - biotCoefficient * ( pressure + deltaPressure ) );
+
+   dTotalStress_dPressure[0] = biotCoefficient;
+   dTotalStress_dPressure[1] = biotCoefficient;
+   dTotalStress_dPressure[2] = biotCoefficient;
+   dTotalStress_dPressure[3] = 0;
+   dTotalStress_dPressure[4] = 0;
+   dTotalStress_dPressure[5] = 0;
+
+   m_porosityUpdate.updatePorosity( k,
+                                    q,
+				    pressure,
+                                    deltaPressure,
+                                    strainIncrement,
+                                    dPorosity_dPressure,
+                                    dPorosity_dVolStrain );
 
 // TODO uncomment once we start using permeability model in flow.
 //    m_permUpdate.updateFromPressureStrain( k,

--- a/src/coreComponents/constitutive/solid/PorousSolid.hpp
+++ b/src/coreComponents/constitutive/solid/PorousSolid.hpp
@@ -73,9 +73,9 @@ public:
     real64 const biotCoefficient = m_porosityUpdate.getBiotCoefficient( k );
     LvArray::tensorOps::symAddIdentity< 3 >( totalStress, -biotCoefficient * ( pressure + deltaPressure ) );
 
-    dTotalStress_dPressure[0] = biotCoefficient;
-    dTotalStress_dPressure[1] = biotCoefficient;
-    dTotalStress_dPressure[2] = biotCoefficient;
+    dTotalStress_dPressure[0] = -biotCoefficient;
+    dTotalStress_dPressure[1] = -biotCoefficient;
+    dTotalStress_dPressure[2] = -biotCoefficient;
     dTotalStress_dPressure[3] = 0;
     dTotalStress_dPressure[4] = 0;
     dTotalStress_dPressure[5] = 0;

--- a/src/coreComponents/constitutive/solid/porosity/BiotPorosity.hpp
+++ b/src/coreComponents/constitutive/solid/porosity/BiotPorosity.hpp
@@ -65,7 +65,6 @@ public:
   GEOSX_HOST_DEVICE
   void updatePorosity( localIndex const k,
                        localIndex const q,
-                       real64 const & pressure,
                        real64 const & deltaPressure,
                        real64 const ( &strainIncrement )[6],
                        real64 & dPorosity_dPressure,

--- a/src/coreComponents/constitutive/solid/porosity/BiotPorosity.hpp
+++ b/src/coreComponents/constitutive/solid/porosity/BiotPorosity.hpp
@@ -63,12 +63,12 @@ public:
   real64 getBiotCoefficient( localIndex const k ) const { return m_biotCoefficient[k]; }
 
   GEOSX_HOST_DEVICE
-  void updatePorosity( localIndex const k,
-                       localIndex const q,
-                       real64 const & deltaPressure,
-                       real64 const ( &strainIncrement )[6],
-                       real64 & dPorosity_dPressure,
-                       real64 & dPorosity_dVolStrain ) const
+  void updateFromPressureAndStrain( localIndex const k,
+                                    localIndex const q,
+                                    real64 const & deltaPressure,
+                                    real64 const ( &strainIncrement )[6],
+                                    real64 & dPorosity_dPressure,
+                                    real64 & dPorosity_dVolStrain ) const
   {
     real64 const biotSkeletonModulusInverse = ( m_biotCoefficient[k] - m_referencePorosity[k] ) / m_grainBulkModulus;
 

--- a/src/coreComponents/constitutive/solid/porosity/BiotPorosity.hpp
+++ b/src/coreComponents/constitutive/solid/porosity/BiotPorosity.hpp
@@ -59,15 +59,17 @@ public:
     m_grainBulkModulus( grainBulkModulus )
   {}
 
+  GEOSX_HOST_DEVICE
+  real64 getBiotCoefficient( localIndex const k ) const { return m_biotCoefficient[k]; }
 
   GEOSX_HOST_DEVICE
   void updatePorosity( localIndex const k,
                        localIndex const q,
+                       real64 const & pressure,
                        real64 const & deltaPressure,
                        real64 const ( &strainIncrement )[6],
                        real64 & dPorosity_dPressure,
-                       real64 & dPorosity_dVolStrain,
-                       real64 & dTotalStress_dPressure ) const
+                       real64 & dPorosity_dVolStrain ) const
   {
     real64 const biotSkeletonModulusInverse = ( m_biotCoefficient[k] - m_referencePorosity[k] ) / m_grainBulkModulus;
 
@@ -80,8 +82,6 @@ public:
     dPorosity_dVolStrain = m_biotCoefficient[k];
 
     savePorosity( k, q, porosity, biotSkeletonModulusInverse );
-
-    dTotalStress_dPressure = m_biotCoefficient[k];
   }
 
 

--- a/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoromechanicsKernel.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoromechanicsKernel.hpp
@@ -278,11 +278,11 @@ public:
     real64 const detJxW = m_finiteElementSpace.template getGradN< FE_TYPE >( k, q, stack.xLocal, dNdX );
 
     // Evaluate total stress tensor
-    real64 strainIncrement[6] = {0};
+    real64 strainIncrement[6] = {0.0};
     real64 totalStress[6];
     real64 dPorosity_dPressure;
     real64 dPorosity_dVolStrainIncrement;
-    real64 dTotalStress_dPressure[6] = {0};
+    real64 dTotalStress_dPressure[6] = {0.0};
 
 
     // --- Update effective stress tensor (stored in totalStress)
@@ -341,17 +341,17 @@ public:
 
     for( integer a = 0; a < numNodesPerElem; ++a )
     {
-      stack.localDispFlowJacobian[a*3+0][0] += dNdX[a][0] * dTotalStress_dPressure[0] * detJxW;
-      stack.localDispFlowJacobian[a*3+0][0] += dNdX[a][2] * dTotalStress_dPressure[4] * detJxW;
-      stack.localDispFlowJacobian[a*3+0][0] += dNdX[a][1] * dTotalStress_dPressure[5] * detJxW;
+      stack.localDispFlowJacobian[a*3+0][0] -= dNdX[a][0] * dTotalStress_dPressure[0] * detJxW;
+      stack.localDispFlowJacobian[a*3+0][0] -= dNdX[a][2] * dTotalStress_dPressure[4] * detJxW;
+      stack.localDispFlowJacobian[a*3+0][0] -= dNdX[a][1] * dTotalStress_dPressure[5] * detJxW;
 
-      stack.localDispFlowJacobian[a*3+1][0] += dNdX[a][1] * dTotalStress_dPressure[1] * detJxW;
-      stack.localDispFlowJacobian[a*3+1][0] += dNdX[a][2] * dTotalStress_dPressure[3] * detJxW;
-      stack.localDispFlowJacobian[a*3+1][0] += dNdX[a][0] * dTotalStress_dPressure[5] * detJxW;
+      stack.localDispFlowJacobian[a*3+1][0] -= dNdX[a][1] * dTotalStress_dPressure[1] * detJxW;
+      stack.localDispFlowJacobian[a*3+1][0] -= dNdX[a][2] * dTotalStress_dPressure[3] * detJxW;
+      stack.localDispFlowJacobian[a*3+1][0] -= dNdX[a][0] * dTotalStress_dPressure[5] * detJxW;
 
-      stack.localDispFlowJacobian[a*3+2][0] += dNdX[a][2] * dTotalStress_dPressure[2] * detJxW;
-      stack.localDispFlowJacobian[a*3+2][0] += dNdX[a][1] * dTotalStress_dPressure[3] * detJxW;
-      stack.localDispFlowJacobian[a*3+2][0] += dNdX[a][0] * dTotalStress_dPressure[4] * detJxW;
+      stack.localDispFlowJacobian[a*3+2][0] -= dNdX[a][2] * dTotalStress_dPressure[2] * detJxW;
+      stack.localDispFlowJacobian[a*3+2][0] -= dNdX[a][1] * dTotalStress_dPressure[3] * detJxW;
+      stack.localDispFlowJacobian[a*3+2][0] -= dNdX[a][0] * dTotalStress_dPressure[4] * detJxW;
     }
 
     if( m_gravityAcceleration > 0.0 )

--- a/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoromechanicsKernel.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoromechanicsKernel.hpp
@@ -282,7 +282,7 @@ public:
     real64 totalStress[6];
     real64 dPorosity_dPressure;
     real64 dPorosity_dVolStrainIncrement;
-    real64 dTotalStress_dPressure;
+    real64 dTotalStress_dPressure[6] = {0};
 
 
     // --- Update effective stress tensor (stored in totalStress)
@@ -291,6 +291,7 @@ public:
 
     m_constitutiveUpdate.smallStrainUpdate( k,
                                             q,
+                                            m_fluidPressure[k],
                                             m_deltaFluidPressure[k],
                                             strainIncrement,
                                             totalStress,
@@ -301,10 +302,6 @@ public:
 
     real64 const porosityNew = m_constitutiveUpdate.getPorosity( k, q );
     real64 const porosityOld = m_constitutiveUpdate.getOldPorosity( k, q );
-
-    real64 const pressureStressTerm = -dTotalStress_dPressure * ( m_fluidPressure[k] + m_deltaFluidPressure[k] );
-
-    LvArray::tensorOps::symAddIdentity< 3 >( totalStress, pressureStressTerm );
 
     // Evaluate body force vector
     real64 bodyForce[3] = { m_gravityVector[0],
@@ -344,9 +341,17 @@ public:
 
     for( integer a = 0; a < numNodesPerElem; ++a )
     {
-      stack.localDispFlowJacobian[a*3+0][0] += dNdX[a][0] * dTotalStress_dPressure * detJxW;
-      stack.localDispFlowJacobian[a*3+1][0] += dNdX[a][1] * dTotalStress_dPressure * detJxW;
-      stack.localDispFlowJacobian[a*3+2][0] += dNdX[a][2] * dTotalStress_dPressure * detJxW;
+      stack.localDispFlowJacobian[a*3+0][0] += dNdX[a][0] * dTotalStress_dPressure[0] * detJxW;
+      stack.localDispFlowJacobian[a*3+0][0] += dNdX[a][2] * dTotalStress_dPressure[4] * detJxW;
+      stack.localDispFlowJacobian[a*3+0][0] += dNdX[a][1] * dTotalStress_dPressure[5] * detJxW;
+
+      stack.localDispFlowJacobian[a*3+1][0] += dNdX[a][1] * dTotalStress_dPressure[1] * detJxW;
+      stack.localDispFlowJacobian[a*3+1][0] += dNdX[a][2] * dTotalStress_dPressure[3] * detJxW;
+      stack.localDispFlowJacobian[a*3+1][0] += dNdX[a][0] * dTotalStress_dPressure[5] * detJxW;
+
+      stack.localDispFlowJacobian[a*3+2][0] += dNdX[a][2] * dTotalStress_dPressure[2] * detJxW;
+      stack.localDispFlowJacobian[a*3+2][0] += dNdX[a][1] * dTotalStress_dPressure[3] * detJxW;
+      stack.localDispFlowJacobian[a*3+2][0] += dNdX[a][0] * dTotalStress_dPressure[4] * detJxW;
     }
 
     if( m_gravityAcceleration > 0.0 )

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsKernel.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsKernel.hpp
@@ -223,11 +223,11 @@ public:
     real64 const detJxW = m_finiteElementSpace.template getGradN< FE_TYPE >( k, q, stack.xLocal, dNdX );
 
     // Evaluate total stress tensor
-    real64 strainIncrement[6] = {0};
+    real64 strainIncrement[6] = {0.0};
     real64 totalStress[6];
     real64 dPorosity_dPressure;
     real64 dPorosity_dVolStrainIncrement;
-    real64 dTotalStress_dPressure[6] = {0};
+    real64 dTotalStress_dPressure[6] = {0.0};
 
     // --- Update total stress tensor
     typename CONSTITUTIVE_TYPE::KernelWrapper::DiscretizationOps stiffness;
@@ -278,17 +278,17 @@ public:
 
     for( integer a = 0; a < numNodesPerElem; ++a )
     {
-      stack.localDispFlowJacobian[a*3+0][0] += dNdX[a][0] * dTotalStress_dPressure[0] * detJxW;
-      stack.localDispFlowJacobian[a*3+0][0] += dNdX[a][2] * dTotalStress_dPressure[4] * detJxW;
-      stack.localDispFlowJacobian[a*3+0][0] += dNdX[a][1] * dTotalStress_dPressure[5] * detJxW;
+      stack.localDispFlowJacobian[a*3+0][0] -= dNdX[a][0] * dTotalStress_dPressure[0] * detJxW;
+      stack.localDispFlowJacobian[a*3+0][0] -= dNdX[a][2] * dTotalStress_dPressure[4] * detJxW;
+      stack.localDispFlowJacobian[a*3+0][0] -= dNdX[a][1] * dTotalStress_dPressure[5] * detJxW;
 
-      stack.localDispFlowJacobian[a*3+1][0] += dNdX[a][1] * dTotalStress_dPressure[1] * detJxW;
-      stack.localDispFlowJacobian[a*3+1][0] += dNdX[a][2] * dTotalStress_dPressure[3] * detJxW;
-      stack.localDispFlowJacobian[a*3+1][0] += dNdX[a][0] * dTotalStress_dPressure[5] * detJxW;
+      stack.localDispFlowJacobian[a*3+1][0] -= dNdX[a][1] * dTotalStress_dPressure[1] * detJxW;
+      stack.localDispFlowJacobian[a*3+1][0] -= dNdX[a][2] * dTotalStress_dPressure[3] * detJxW;
+      stack.localDispFlowJacobian[a*3+1][0] -= dNdX[a][0] * dTotalStress_dPressure[5] * detJxW;
 
-      stack.localDispFlowJacobian[a*3+2][0] += dNdX[a][2] * dTotalStress_dPressure[2] * detJxW;
-      stack.localDispFlowJacobian[a*3+2][0] += dNdX[a][1] * dTotalStress_dPressure[3] * detJxW;
-      stack.localDispFlowJacobian[a*3+2][0] += dNdX[a][0] * dTotalStress_dPressure[4] * detJxW;
+      stack.localDispFlowJacobian[a*3+2][0] -= dNdX[a][2] * dTotalStress_dPressure[2] * detJxW;
+      stack.localDispFlowJacobian[a*3+2][0] -= dNdX[a][1] * dTotalStress_dPressure[3] * detJxW;
+      stack.localDispFlowJacobian[a*3+2][0] -= dNdX[a][0] * dTotalStress_dPressure[4] * detJxW;
     }
 
     if( m_gravityAcceleration > 0.0 )

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsKernel.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsKernel.hpp
@@ -227,7 +227,7 @@ public:
     real64 totalStress[6];
     real64 dPorosity_dPressure;
     real64 dPorosity_dVolStrainIncrement;
-    real64 dTotalStress_dPressure;
+    real64 dTotalStress_dPressure[6] = {0};
 
     // --- Update total stress tensor
     typename CONSTITUTIVE_TYPE::KernelWrapper::DiscretizationOps stiffness;
@@ -235,6 +235,7 @@ public:
 
     m_constitutiveUpdate.smallStrainUpdate( k,
                                             q,
+                                            m_fluidPressure[k],
                                             m_deltaFluidPressure[k],
                                             strainIncrement,
                                             totalStress,
@@ -245,10 +246,6 @@ public:
 
     real64 const porosityNew = m_constitutiveUpdate.getPorosity( k, q );
     real64 const porosityOld = m_constitutiveUpdate.getOldPorosity( k, q );
-
-    real64 const pressureStressTerm = -dTotalStress_dPressure * ( m_fluidPressure[k] + m_deltaFluidPressure[k] );
-
-    LvArray::tensorOps::symAddIdentity< 3 >( totalStress, pressureStressTerm );
 
     // Evaluate body force vector
     real64 bodyForce[3] = { m_gravityVector[0],
@@ -281,9 +278,17 @@ public:
 
     for( integer a = 0; a < numNodesPerElem; ++a )
     {
-      stack.localDispFlowJacobian[a*3+0][0] += dNdX[a][0] * dTotalStress_dPressure * detJxW;
-      stack.localDispFlowJacobian[a*3+1][0] += dNdX[a][1] * dTotalStress_dPressure * detJxW;
-      stack.localDispFlowJacobian[a*3+2][0] += dNdX[a][2] * dTotalStress_dPressure * detJxW;
+      stack.localDispFlowJacobian[a*3+0][0] += dNdX[a][0] * dTotalStress_dPressure[0] * detJxW;
+      stack.localDispFlowJacobian[a*3+0][0] += dNdX[a][2] * dTotalStress_dPressure[4] * detJxW;
+      stack.localDispFlowJacobian[a*3+0][0] += dNdX[a][1] * dTotalStress_dPressure[5] * detJxW;
+
+      stack.localDispFlowJacobian[a*3+1][0] += dNdX[a][1] * dTotalStress_dPressure[1] * detJxW;
+      stack.localDispFlowJacobian[a*3+1][0] += dNdX[a][2] * dTotalStress_dPressure[3] * detJxW;
+      stack.localDispFlowJacobian[a*3+1][0] += dNdX[a][0] * dTotalStress_dPressure[5] * detJxW;
+
+      stack.localDispFlowJacobian[a*3+2][0] += dNdX[a][2] * dTotalStress_dPressure[2] * detJxW;
+      stack.localDispFlowJacobian[a*3+2][0] += dNdX[a][1] * dTotalStress_dPressure[3] * detJxW;
+      stack.localDispFlowJacobian[a*3+2][0] += dNdX[a][0] * dTotalStress_dPressure[4] * detJxW;
     }
 
     if( m_gravityAcceleration > 0.0 )


### PR DESCRIPTION
This PR moves the computation of the total stress from the poromechanics solver kernels to the constitutive update. Note that the total stress derivative with respect to pressure (`dTotalStress_dPressure`) is now treated as a symmetric second order tensor, which removes the assumption of scalar Biot's coefficient. 

New baselines are not required. 