### PR TITLE
Keep neighbors with one-way ghost exchange

### DIFF
--- a/src/coreComponents/mesh/mpiCommunications/NeighborData.hpp
+++ b/src/coreComponents/mesh/mpiCommunications/NeighborData.hpp
@@ -56,7 +56,7 @@ public:
    * @brief @return True iff there is communication of the associated objects with the neighbor.
    */
   bool communicationExists() const
-  { return m_ghostsToSend.size() && m_ghostsToReceive.size(); }
+  { return !m_ghostsToSend.empty() || !m_ghostsToReceive.empty(); }
 
   /**
    * @brief @return An array containing the indices of the objects on the domain boundary with the neighbor.


### PR DESCRIPTION
This PR fixes a small issue in neighbor exchange shown in the image below. Here, rank 2 (rightmost) must receive data on ghosted nodes (highlighted) from rank 0 (leftmost) that owns them, but doesn't have anything to send in return. In current develop however, rank 0 is removed from rank 2's neighbor list because of the requirement for the 2-way exchange to exist, and data on ghosted nodes is never sync'ed.

![ghost_nodes](https://user-images.githubusercontent.com/1550292/134758205-73170051-1243-45ea-a828-f90893ff9c45.png)

Rebaseline PR: https://github.com/GEOSX/integratedTests/pull/154