### PR TITLE
Adding a Pecan CPU target alongside the GPU one.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: minimal
 
 env:
   global:
-  - GEOSX_TPL_TAG=161-674
+  - GEOSX_TPL_TAG=165-679
   - secure: CGs2uH6efq1Me6xJWRr0BnwtwxoujzlowC4FHXHdWbNOkPsXf7nCgdaW5vthfD3bhnOeEUQSrfxdhTRtyU/NfcKLmKgGBnZOdUG4/JJK4gDSJ2Wp8LZ/mB0QEoODKVxbh+YtoAiHe3y4M9PGCs+wkNDw/3eEU00cK12DZ6gad0RbLjI3xkhEr/ZEZDZkcYg9yHAhl5bmpqoh/6QGnIg8mxIqdAtGDw+6tT0EgUqjeqc5bG5WwsamKzJItHSXD5zx8IJAlgDk4EzEGjZe0m56YnNfb9iwqqUsmL3Cuwgs7ByVDYw78JC5Kv42YqoxA5BxMT2mFsEe37TpYNXlzofU7ma2Duw9DGXWQd4IkTCcBxlyR0I0bfo0TmgO+y7PYG9lIyHPUkENemdozsZcWamqqkqegiEdRhDVYlSRo3mu7iCwTS6ZTALliVyEYjYxYb7oAnR3cNywXjblTCI8oKfgLSY+8WijM9SRl57JruIHLkLMCjmRI+cZBfv5tS2tYQTBPkygGrigrrN77ZiC7/TGyfggSN0+y0oYtOAgqEnBcKcreiibMW7tKcV2Z1RFD9ZvIkSc1EXLUPDP8FX1oyhmqBMqVo8LksrYLDJHQ05+F3YNgl2taSt7uMjQ4e8iZ3/IjFeMnbylDw+cj/RbS520HXsFPbWFm2Pb9pceA9n6GnY=
 
 # The integrated test repository contains large data (using git lfs) and we do not use them here.
@@ -178,14 +178,23 @@ jobs:
     - CMAKE_BUILD_TYPE=Release
     - BUILD_AND_TEST_ARGS=--disable-unit-tests
   - stage: builds
-    name: Pecan_gcc8.2.0_cuda10.2.89p2_release
+    name: Pecan GPU
     <<: *geosx_totalenergies_cluster_build
     env:
-    - DOCKER_REPOSITORY=geosx/pecan-gcc8.2.0-openmpi4.0.1-mkl2019.5-cuda10.2.89p2
+    - DOCKER_REPOSITORY=geosx/pecan-gpu-gcc8.2.0-openmpi4.0.1-mkl2019.5-cuda10.2.89p2
     - CMAKE_BUILD_TYPE=Release
     - BUILD_AND_TEST_ARGS=--disable-unit-tests
-    - HOST_CONFIG=host-configs/TOTAL/pecan.cmake
-    - GCP_BUCKET=geosx/Pecan
+    - HOST_CONFIG=host-configs/TOTAL/pecan-GPU.cmake
+    - GCP_BUCKET=geosx/Pecan-GPU
+  - stage: builds
+    name: Pecan CPU
+    <<: *geosx_totalenergies_cluster_build
+    env:
+    - DOCKER_REPOSITORY=geosx/pecan-cpu-gcc8.2.0-openmpi4.0.1-mkl2019.5
+    - CMAKE_BUILD_TYPE=Release
+    - BUILD_AND_TEST_ARGS=--disable-unit-tests
+    - HOST_CONFIG=host-configs/TOTAL/pecan-CPU.cmake
+    - GCP_BUCKET=geosx/Pecan-CPU
   - stage: builds
     name: Ubuntu18.04_clang8.0.0_cuda10.1.243_release_hypreGPU
     <<: *geosx_linux_build
@@ -212,7 +221,7 @@ jobs:
     - CMAKE_BUILD_TYPE=Release
     - BUILD_AND_TEST_ARGS=--disable-unit-tests
   - stage: builds
-    name: Pangea2_gcc8.3.0_release
+    name: Pangea 2
     <<: *geosx_totalenergies_cluster_build
     env:
     - DOCKER_REPOSITORY=geosx/pangea2-gcc8.3.0-openmpi2.1.5-mkl2019.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -171,10 +171,35 @@ jobs:
     name: check_submodules
     script: scripts/test_submodule_updated.sh
   - stage: builds
+    name: Ubuntu18.04_clang8.0.0_cuda10.1.243_debug
+    <<: *geosx_linux_build
+    # Builds only the geosx executable (timeout when building tests)
+    env:
+    - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
+    - CMAKE_BUILD_TYPE=Debug
+    - BUILD_AND_TEST_ARGS="--disable-unit-tests --build-exe-only"
+  - stage: builds
     name: Ubuntu18.04_clang8.0.0_cuda10.1.243_release
     <<: *geosx_linux_build
     env:
     - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
+    - CMAKE_BUILD_TYPE=Release
+    - BUILD_AND_TEST_ARGS=--disable-unit-tests
+  - stage: builds
+    name: Ubuntu18.04_clang8.0.0_cuda10.1.243_release_hypreGPU
+    <<: *geosx_linux_build
+    env:
+    - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
+    - CMAKE_BUILD_TYPE=Release
+    - BUILD_AND_TEST_ARGS=--disable-unit-tests
+    - ENABLE_HYPRE=ON
+    - ENABLE_HYPRE_CUDA=ON
+    - ENABLE_TRILINOS=OFF
+  - stage: builds
+    name: Centos7.6_gcc8.3.1_cuda10.1.243_release
+    <<: *geosx_linux_build
+    env:
+    - DOCKER_REPOSITORY=geosx/centos7.6.1810-gcc8.3.1-cuda10.1.243
     - CMAKE_BUILD_TYPE=Release
     - BUILD_AND_TEST_ARGS=--disable-unit-tests
   - stage: builds
@@ -195,31 +220,6 @@ jobs:
     - BUILD_AND_TEST_ARGS=--disable-unit-tests
     - HOST_CONFIG=host-configs/TOTAL/pecan-CPU.cmake
     - GCP_BUCKET=geosx/Pecan-CPU
-  - stage: builds
-    name: Ubuntu18.04_clang8.0.0_cuda10.1.243_release_hypreGPU
-    <<: *geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
-    - CMAKE_BUILD_TYPE=Release
-    - BUILD_AND_TEST_ARGS=--disable-unit-tests
-    - ENABLE_HYPRE=ON
-    - ENABLE_HYPRE_CUDA=ON
-    - ENABLE_TRILINOS=OFF
-  # Builds only the geosx executable (timeout when building tests)
-  - stage: builds
-    name: Ubuntu18.04_clang8.0.0_cuda10.1.243_debug
-    <<: *geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
-    - CMAKE_BUILD_TYPE=Debug
-    - BUILD_AND_TEST_ARGS="--disable-unit-tests --build-exe-only"
-  - stage: builds
-    name: Centos7.6_gcc8.3.1_cuda10.1.243_release
-    <<: *geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/centos7.6.1810-gcc8.3.1-cuda10.1.243
-    - CMAKE_BUILD_TYPE=Release
-    - BUILD_AND_TEST_ARGS=--disable-unit-tests
   - stage: builds
     name: Pangea 2
     <<: *geosx_totalenergies_cluster_build

--- a/host-configs/TOTAL/pecan-CPU.cmake
+++ b/host-configs/TOTAL/pecan-CPU.cmake
@@ -14,25 +14,9 @@ set(MPIEXEC_EXECUTABLE "${MPI_HOME}/bin/mpirun" CACHE PATH "" FORCE)
 #set(MPIEXEC_NUMPROC_FLAG   "-p pecan -n" CACHE STRING "")
 set(ENABLE_WRAP_ALL_TESTS_WITH_MPIEXEC ON CACHE BOOL "")
 
-set(ENABLE_CUDA ON CACHE PATH "" FORCE)
-set(CUDA_TOOLKIT_ROOT_DIR /hrtc/apps/cuda/10.2.89/x86_64 CACHE PATH "")
-set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER} CACHE STRING "")
-set(CMAKE_CUDA_COMPILER ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc CACHE STRING "")
-
-set(CUDA_ARCH sm_75 CACHE STRING "")
-set(CMAKE_CUDA_STANDARD 14 CACHE STRING "")
-### The inclusion of -std=c++14 is a workaround for a cuda10/gcc8 bug ###
-set(CMAKE_CUDA_FLAGS "-restrict -arch ${CUDA_ARCH} --expt-relaxed-constexpr --expt-extended-lambda -Werror cross-execution-space-call,reorder,deprecated-declarations -Xcompiler -std=c++14" CACHE STRING "")
-set(CMAKE_CUDA_FLAGS_RELEASE "-O3 -DNDEBUG -Xcompiler -DNDEBUG -Xcompiler -O3" CACHE STRING "")
-set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-g -lineinfo ${CMAKE_CUDA_FLAGS_RELEASE}" CACHE STRING "")
-set(CMAKE_CUDA_FLAGS_DEBUG "-g -G -O0 -Xcompiler -O0" CACHE STRING "")
-
 set(ENABLE_PETSC OFF CACHE BOOL "" FORCE )
 set(ENABLE_TRILINOS OFF CACHE BOOL "" FORCE )
 set(ENABLE_HYPRE ON CACHE BOOL "" FORCE )
-# Current version of hypre does not build with GPU support.
-# Most recent version does build. Let's wait for an upgrade on our side.
-set(ENABLE_HYPRE_CUDA OFF CACHE BOOL "" FORCE)
 
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "" FORCE)
 set(ENABLE_CALIPER ON CACHE BOOL "")

--- a/host-configs/TOTAL/pecan-GPU.cmake
+++ b/host-configs/TOTAL/pecan-GPU.cmake
@@ -1,0 +1,20 @@
+# Retrieve the compilers, standard libraries... from the CPU configuration
+include(${CMAKE_CURRENT_LIST_DIR}/pecan-CPU.cmake)
+
+# Now let's add what's dedicated to GPU.
+set(ENABLE_CUDA ON CACHE PATH "" FORCE)
+set(CUDA_TOOLKIT_ROOT_DIR /hrtc/apps/cuda/10.2.89/x86_64 CACHE PATH "")
+set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER} CACHE STRING "")
+set(CMAKE_CUDA_COMPILER ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc CACHE STRING "")
+
+set(CUDA_ARCH sm_75 CACHE STRING "")
+set(CMAKE_CUDA_STANDARD 14 CACHE STRING "")
+### The inclusion of -std=c++14 is a workaround for a cuda10/gcc8 bug ###
+set(CMAKE_CUDA_FLAGS "-restrict -arch ${CUDA_ARCH} --expt-relaxed-constexpr --expt-extended-lambda -Werror cross-execution-space-call,reorder,deprecated-declarations -Xcompiler -std=c++14" CACHE STRING "")
+set(CMAKE_CUDA_FLAGS_RELEASE "-O3 -DNDEBUG -Xcompiler -DNDEBUG -Xcompiler -O3" CACHE STRING "")
+set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-g -lineinfo ${CMAKE_CUDA_FLAGS_RELEASE}" CACHE STRING "")
+set(CMAKE_CUDA_FLAGS_DEBUG "-g -G -O0 -Xcompiler -O0" CACHE STRING "")
+
+# Current version of hypre does not build with GPU support.
+# Most recent version does build. Let's wait for an upgrade on our side.
+set(ENABLE_HYPRE_CUDA OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
_Use case_: Some users are now developing on `Pecan` and not only launching computations.
They would greatly benefit from _both_ `CPU` _and_ `GPU` pre-compiled TPLs.

This PR (and https://github.com/GEOSX/thirdPartyLibs/pull/165) adds a target for `Pecan-CPU`.
Therefore, automatic deployments will be available for both `Pecan-GPU` and `Pecan-CPU`.

Note that
- As part of the refactoring process, the `Pecan` config files are split into `pecan-GPU.cmake` and `pecan-CPU.cmake`.
- We would have 11 builds on travis. The `Pecan-CPU` build lasts 54 minutes.
- If this PR gets accepted, I can reorder the builds such that the longest starts first (I do not want to do it now for code review purposes).