### PR TITLE
Fixed division by zero in getHistoryMetadata

### DIFF
--- a/src/coreComponents/dataRepository/HistoryDataSpec.hpp
+++ b/src/coreComponents/dataRepository/HistoryDataSpec.hpp
@@ -168,6 +168,7 @@ constexpr bool can_history_io_container = ( traits::is_array_type< T > || traits
  * @tparam T A type stored in an array that can be packed
  * @param name The name to give the metadata, usually dataRepository::Wrapper::getName by default.
  * @param arr The array to produce metadata about
+ * @param numComps Unused
  * @param sizeOverride Specified in order to overwrite the actual size of the array with the size specified (used when collecting only a
  * portion of the array data).
  * @return HistoryMetadata for the provided one-dimensional array.
@@ -175,8 +176,9 @@ constexpr bool can_history_io_container = ( traits::is_array_type< T > || traits
 template< typename T >
 inline
 typename std::enable_if< can_history_io< T >, HistoryMetadata >::type
-getHistoryMetadata( string const & name, ArrayView< T const, 1, 0 > const & arr, localIndex sizeOverride = -1 )
+getHistoryMetadata( string const & name, ArrayView< T const, 1, 0 > const & arr, localIndex const numComps, localIndex sizeOverride = -1 )
 {
+  GEOSX_UNUSED_VAR( numComps );
   localIndex size = sizeOverride < 0 ? arr.size( ) : sizeOverride;
   return HistoryMetadata( name, size, std::type_index( typeid( T )));
 }
@@ -186,6 +188,7 @@ getHistoryMetadata( string const & name, ArrayView< T const, 1, 0 > const & arr,
  * @tparam T A type stored in an array that can be packed
  * @param name The name to give the metadata, usually dataRepository::Wrapper::getName by default.
  * @param arr The array to produce metadata about
+ * @param numComps Unused
  * @param sizeOverride Specified in order to overwrite the actual size of the array with the size specified (used when collecting only a
  * portion of the array data).
  * @return HistoryMetadata for the provided one-dimensional array.
@@ -193,8 +196,9 @@ getHistoryMetadata( string const & name, ArrayView< T const, 1, 0 > const & arr,
 template< typename T >
 inline
 typename std::enable_if< can_history_io< T >, HistoryMetadata >::type
-getHistoryMetadata( string const & name, SortedArrayView< T const > const & arr, localIndex sizeOverride = -1 )
+getHistoryMetadata( string const & name, SortedArrayView< T const > const & arr, localIndex const numComps, localIndex sizeOverride = -1 )
 {
+  GEOSX_UNUSED_VAR( numComps );
   localIndex size = sizeOverride < 0 ? arr.size( ) : sizeOverride;
   return HistoryMetadata( name, size, std::type_index( typeid(T)));
 }
@@ -204,6 +208,7 @@ getHistoryMetadata( string const & name, SortedArrayView< T const > const & arr,
  * @tparam ARRAY_T An array type containing a packable type.
  * @param name The name to give the metadata, usually dataRepository::Wrapper::getName by default.
  * @param arr The array to produce metadata about
+ * @param numComps The number of components in the array
  * @param sizeOverride Specified in order to overwrite the actual size of the array with the size specified (used when collecting only a
  * portion of the array data).
  * @return HistoryMetadata for the provided multi-dimensional array.
@@ -211,12 +216,11 @@ getHistoryMetadata( string const & name, SortedArrayView< T const > const & arr,
 template< typename ARRAY_T >
 inline
 typename std::enable_if< ( traits::is_array_type< ARRAY_T >) && (ARRAY_T::NDIM > 1) && can_history_io< typename ARRAY_T::value_type >, HistoryMetadata >::type
-getHistoryMetadata( string const & name, ARRAY_T const & arr, localIndex sizeOverride = -1 )
+getHistoryMetadata( string const & name, ARRAY_T const & arr, localIndex const numComps, localIndex sizeOverride = -1 )
 {
-  // Array dim > 1 so this should be valid
-  localIndex const perIndexSize = arr.size( ) / arr.size( 0 );
-  localIndex const numIndices = sizeOverride >= 0 ? sizeOverride :  arr.size( ) / perIndexSize;
-  localIndex sizes[2] = { numIndices, perIndexSize };
+  // Array dim > 1 so this should be valid (i.e., no division by zero)
+  localIndex const numIndices = sizeOverride >= 0 ? sizeOverride :  arr.size( ) / numComps;
+  localIndex sizes[2] = { numIndices, numComps };
   return HistoryMetadata( name, 2, &sizes[0], std::type_index( typeid(typename ARRAY_T::value_type)));
 }
 
@@ -225,15 +229,16 @@ getHistoryMetadata( string const & name, ARRAY_T const & arr, localIndex sizeOve
  * @tparam T The type to produce HistoryMetadata for.
  * @param name The name to give the metadata, usually dataRepository::Wrapper::getName by default.
  * @param type The data of type T to being used for history collection/output.
+ * @param numComps Unused
  * @param sizeOverride Specified in order to overwrite the actual size of the data. Really only here to make the getHistoryMetadata
  * overloaded function consistent, but is still functional.
  * @return A HistoryMetadata describing a size-zero array with name "NULL" and type_index(typeid(NULL)), will never actually return.
  */
 template< typename T >
 inline typename std::enable_if< can_history_io< T >, HistoryMetadata >::type
-getHistoryMetadata( string const & name, const T & type, localIndex sizeOverride = -1 )
+getHistoryMetadata( string const & name, const T & type, localIndex const numComps, localIndex sizeOverride = -1 )
 {
-  GEOSX_UNUSED_VAR( type );
+  GEOSX_UNUSED_VAR( type, numComps );
   localIndex size = sizeOverride < 0 ? 0 : sizeOverride;
   return HistoryMetadata( name, size, std::type_index( typeid(T)));
 }
@@ -243,17 +248,16 @@ getHistoryMetadata( string const & name, const T & type, localIndex sizeOverride
  * @tparam T A history collection/output unsupported type.
  * @param name Unused
  * @param type Unused
+ * @param numComps Unused
  * @param sizeOverride Unused
  * @return A null HistoryMetadata, will never actually return.
  */
 template< typename T >
 inline typename std::enable_if< can_history_io_container< T > && !can_history_io< typename T::value_type >, HistoryMetadata >::type
-getHistoryMetadata( string const & name, const T & type, localIndex sizeOverride )
+getHistoryMetadata( string const & name, const T & type, localIndex const numComps, localIndex sizeOverride )
 {
   GEOSX_ERROR( "Trying to use time history output on an unsupported type." );
-  GEOSX_UNUSED_VAR( name );
-  GEOSX_UNUSED_VAR( type );
-  GEOSX_UNUSED_VAR( sizeOverride );
+  GEOSX_UNUSED_VAR( name, type, numComps, sizeOverride );
   return HistoryMetadata( );
 }
 
@@ -262,17 +266,16 @@ getHistoryMetadata( string const & name, const T & type, localIndex sizeOverride
  * @tparam T A history collection/output unsupported type.
  * @param name Unused
  * @param type Unused
+ * @param numComps Unused
  * @param sizeOverride Unused
  * @return A null HistoryMetadata, will never actually return.
  */
 template< typename T >
 inline typename std::enable_if< !can_history_io_container< T > && !can_history_io< T >, HistoryMetadata >::type
-getHistoryMetadata( string const & name, const T & type, localIndex sizeOverride )
+getHistoryMetadata( string const & name, const T & type, localIndex const numComps, localIndex sizeOverride )
 {
   GEOSX_ERROR( "Trying to use time history output on an unsupported type." );
-  GEOSX_UNUSED_VAR( name );
-  GEOSX_UNUSED_VAR( type );
-  GEOSX_UNUSED_VAR( sizeOverride );
+  GEOSX_UNUSED_VAR( name, type, numComps, sizeOverride );
   return HistoryMetadata( );
 }
 

--- a/src/coreComponents/dataRepository/Wrapper.hpp
+++ b/src/coreComponents/dataRepository/Wrapper.hpp
@@ -262,7 +262,7 @@ public:
   virtual
   HistoryMetadata getHistoryMetadata( localIndex const packCount = -1 ) const override final
   {
-    return geosx::getHistoryMetadata( getName(), referenceAsView( ), packCount );
+    return geosx::getHistoryMetadata( getName(), referenceAsView( ), numArrayComp(), packCount );
   }
 
   /**

--- a/src/coreComponents/unitTests/fileIOTests/testHDFFile.cpp
+++ b/src/coreComponents/unitTests/fileIOTests/testHDFFile.cpp
@@ -45,7 +45,7 @@ TEST( testHDFIO, ArrayHistory )
       value = count++;
     } );
 
-    HistoryMetadata spec = getHistoryMetadata( "Array1d History", arr.toViewConst( ) );
+    HistoryMetadata spec = getHistoryMetadata( "Array1d History", arr.toViewConst( ), 1 );
     HDFHistIO io( filename, spec );
     io.init( true );
 
@@ -68,7 +68,7 @@ TEST( testHDFIO, ArrayHistory )
       value = count++;
     } );
 
-    HistoryMetadata spec = getHistoryMetadata( "Array2d History", arr.toViewConst( ) );
+    HistoryMetadata spec = getHistoryMetadata( "Array2d History", arr.toViewConst( ), 4 );
     HDFHistIO io( filename, spec );
     io.init( true );
 
@@ -101,7 +101,7 @@ TEST( testHDFIO, IdxArrayHistory )
       value = rand() % 1024;
     } );
 
-    HistoryMetadata spec = getHistoryMetadata( "Array1d Idx History", arr.toViewConst( ), idx.size( ));
+    HistoryMetadata spec = getHistoryMetadata( "Array1d Idx History", arr.toViewConst( ), 4, idx.size( ));
     HDFHistIO io( filename, spec );
     io.init( true );
 


### PR DESCRIPTION
This PR fixes a division by zero in function `getHistoryMetadata` due to arrays that have a zero-size of their first dimension. This is solved by passing the result of `Wrapper::numArrayComp` to the function. 

Fixes #1673. 

This PR does not require a rebaseline. 