### PR TITLE
LAI vector refactor - zero copy assembly

### DIFF
--- a/src/coreComponents/common/FieldSpecificationOps.hpp
+++ b/src/coreComponents/common/FieldSpecificationOps.hpp
@@ -535,41 +535,6 @@ struct FieldSpecificationEqual : public FieldSpecificationOp< OpEqual >
    * @brief Function to apply a Dirichlet like boundary condition to a single dof in a system of
    *        equations.
    * @param[in] dof The degree of freedom that is to be set.
-   * @param[inout] matrix A ParallelMatrix object: the system matrix.
-   * @param[out] rhs The rhs contribution resulting from the application of the BC.
-   * @param[in] bcValue The target value of the Boundary Condition
-   * @param[in] fieldValue The current value of the variable to be set.
-   *
-   * This function clears the matrix row for the specified \p dof, sets the diagonal to some
-   * appropriately scaled value, and sets \p rhs to the negative product of the scaled value
-   * of the diagonal and the difference between \p bcValue and \p fieldValue.
-   *
-   * @note This function assumes the user is doing a Newton-type nonlinear solve and will
-   * negate the rhs vector upon assembly. Thus, it sets the value to negative of the desired
-   * update for the field. For a linear problem, this may lead to unexpected results.
-   */
-  template< typename LAI >
-  static inline void SpecifyFieldValue( globalIndex const dof,
-                                        typename LAI::ParallelMatrix & matrix,
-                                        real64 & rhs,
-                                        real64 const bcValue,
-                                        real64 const fieldValue )
-  {
-    if( matrix.getLocalRowID( dof ) >= 0 )
-    {
-      real64 const diag = matrix.clearRow( dof, true );
-      rhs = -diag * (bcValue - fieldValue);
-    }
-    else
-    {
-      rhs = 0.0;
-    }
-  }
-
-  /**
-   * @brief Function to apply a Dirichlet like boundary condition to a single dof in a system of
-   *        equations.
-   * @param[in] dof The degree of freedom that is to be set.
    * @param[in] dofRankOffset offset of dof indices on current rank
    * @param[in,out] matrix the local part of the system matrix
    * @param[out] rhs The rhs contribution resulting from the application of the BC.
@@ -626,28 +591,6 @@ struct FieldSpecificationEqual : public FieldSpecificationOp< OpEqual >
     else
     {
       rhs = 0.0;
-    }
-  }
-
-  /**
-   * @brief Function to add some values of a vector.
-   * @param rhs A ParallelVector object.
-   * @param num The number of values in \p rhs to replace
-   * @param dof A pointer to the global DOF to be replaced
-   * @param values A pointer to the values corresponding to \p dof that will be added to \p rhs.
-   */
-  template< typename LAI >
-  static inline void prescribeRhsValues( typename LAI::ParallelVector & rhs,
-                                         localIndex const num,
-                                         globalIndex * const dof,
-                                         real64 * const values )
-  {
-    for( localIndex a = 0; a < num; ++a )
-    {
-      if( rhs.getLocalRowID( dof[a] ) >= 0 )
-      {
-        rhs.set( dof[a], values[a] );
-      }
     }
   }
 
@@ -710,22 +653,6 @@ struct FieldSpecificationAdd : public FieldSpecificationOp< OpAdd >
     GEOSX_UNUSED_VAR( matrix );
     GEOSX_UNUSED_VAR( fieldValue );
     rhs += bcValue;
-  }
-
-  /**
-   * @brief Function to add some values of a vector.
-   * @param rhs A ParallelVector object.
-   * @param num The number of values in \p rhs to replace
-   * @param dof A pointer to the global DOF to be replaced
-   * @param values A pointer to the values corresponding to \p dof that will be added to \p rhs.
-   */
-  template< typename LAI >
-  static inline void prescribeRhsValues( typename LAI::ParallelVector & rhs,
-                                         localIndex const num,
-                                         globalIndex * const dof,
-                                         real64 * const values )
-  {
-    rhs.add( dof, values, num );
   }
 
   /**

--- a/src/coreComponents/linearAlgebra/DofManager.cpp
+++ b/src/coreComponents/linearAlgebra/DofManager.cpp
@@ -1036,8 +1036,8 @@ void DofManager::setSparsityPattern( SparsityPattern< globalIndex > & pattern ) 
 namespace
 {
 
-template< typename FIELD_OP, typename POLICY, typename LOCAL_VECTOR, typename FIELD_VIEW >
-void vectorToFieldKernel( LOCAL_VECTOR const localVector,
+template< typename FIELD_OP, typename POLICY, typename FIELD_VIEW >
+void vectorToFieldKernel( arrayView1d< real64 const > const & localVector,
                           FIELD_VIEW const & field,
                           arrayView1d< globalIndex const > const & dofNumber,
                           arrayView1d< integer const > const & ghostRank,
@@ -1064,8 +1064,8 @@ void vectorToFieldKernel( LOCAL_VECTOR const localVector,
   } );
 }
 
-template< typename FIELD_OP, typename POLICY, typename LOCAL_VECTOR >
-void vectorToFieldImpl( LOCAL_VECTOR const localVector,
+template< typename FIELD_OP, typename POLICY >
+void vectorToFieldImpl( arrayView1d< real64 const > const & localVector,
                         ObjectManagerBase & manager,
                         string const & dofKey,
                         string const & fieldName,
@@ -1095,8 +1095,8 @@ void vectorToFieldImpl( LOCAL_VECTOR const localVector,
   } );
 }
 
-template< typename FIELD_OP, typename POLICY, typename LOCAL_VECTOR, typename FIELD_VIEW >
-void fieldToVectorKernel( LOCAL_VECTOR localVector,
+template< typename FIELD_OP, typename POLICY, typename FIELD_VIEW >
+void fieldToVectorKernel( arrayView1d< real64 > const & localVector,
                           FIELD_VIEW const & field,
                           arrayView1d< globalIndex const > const & dofNumber,
                           arrayView1d< integer const > const & ghostRank,
@@ -1123,8 +1123,8 @@ void fieldToVectorKernel( LOCAL_VECTOR localVector,
   } );
 }
 
-template< typename FIELD_OP, typename POLICY, typename LOCAL_VECTOR >
-void fieldToVectorImpl( LOCAL_VECTOR localVector,
+template< typename FIELD_OP, typename POLICY >
+void fieldToVectorImpl( arrayView1d< real64 > const & localVector,
                         ObjectManagerBase const & manager,
                         string const & dofKey,
                         string const & fieldName,
@@ -1156,8 +1156,8 @@ void fieldToVectorImpl( LOCAL_VECTOR localVector,
 
 } // namespace
 
-template< typename FIELD_OP, typename POLICY, typename LOCAL_VECTOR >
-void DofManager::vectorToField( LOCAL_VECTOR const localVector,
+template< typename FIELD_OP, typename POLICY >
+void DofManager::vectorToField( arrayView1d< real64 const > const & localVector,
                                 string const & srcFieldName,
                                 string const & dstFieldName,
                                 real64 const scalingFactor,
@@ -1192,21 +1192,6 @@ void DofManager::vectorToField( LOCAL_VECTOR const localVector,
   }
 }
 
-// Copy values from DOFs to nodes
-template< typename VECTOR >
-void DofManager::copyVectorToField( VECTOR const & vector,
-                                    string const & srcFieldName,
-                                    string const & dstFieldName,
-                                    real64 const scalingFactor,
-                                    CompMask const mask ) const
-{
-  vectorToField< FieldSpecificationEqual, parallelHostPolicy >( vector.extractLocalVector(),
-                                                                srcFieldName,
-                                                                dstFieldName,
-                                                                scalingFactor,
-                                                                mask );
-}
-
 void DofManager::copyVectorToField( arrayView1d< real64 const > const & localVector,
                                     string const & srcFieldName,
                                     string const & dstFieldName,
@@ -1218,21 +1203,6 @@ void DofManager::copyVectorToField( arrayView1d< real64 const > const & localVec
                                                                     dstFieldName,
                                                                     scalingFactor,
                                                                     mask );
-}
-
-// Copy values from DOFs to nodes
-template< typename VECTOR >
-void DofManager::addVectorToField( VECTOR const & vector,
-                                   string const & srcFieldName,
-                                   string const & dstFieldName,
-                                   real64 const scalingFactor,
-                                   CompMask const mask ) const
-{
-  vectorToField< FieldSpecificationAdd, parallelHostPolicy >( vector.extractLocalVector(),
-                                                              srcFieldName,
-                                                              dstFieldName,
-                                                              scalingFactor,
-                                                              mask );
 }
 
 void DofManager::addVectorToField( arrayView1d< real64 const > const & localVector,
@@ -1248,8 +1218,8 @@ void DofManager::addVectorToField( arrayView1d< real64 const > const & localVect
                                                                   mask );
 }
 
-template< typename FIELD_OP, typename POLICY, typename LOCAL_VECTOR >
-void DofManager::fieldToVector( LOCAL_VECTOR localVector,
+template< typename FIELD_OP, typename POLICY >
+void DofManager::fieldToVector( arrayView1d< real64 > const & localVector,
                                 string const & srcFieldName,
                                 string const & dstFieldName,
                                 real64 const scalingFactor,
@@ -1284,21 +1254,6 @@ void DofManager::fieldToVector( LOCAL_VECTOR localVector,
   }
 }
 
-// Copy values from nodes to DOFs
-template< typename VECTOR >
-void DofManager::copyFieldToVector( VECTOR & vector,
-                                    string const & srcFieldName,
-                                    string const & dstFieldName,
-                                    real64 const scalingFactor,
-                                    CompMask const mask ) const
-{
-  fieldToVector< FieldSpecificationEqual, parallelHostPolicy >( vector.extractLocalVector(),
-                                                                srcFieldName,
-                                                                dstFieldName,
-                                                                scalingFactor,
-                                                                mask );
-}
-
 void DofManager::copyFieldToVector( arrayView1d< real64 > const & localVector,
                                     string const & srcFieldName,
                                     string const & dstFieldName,
@@ -1310,21 +1265,6 @@ void DofManager::copyFieldToVector( arrayView1d< real64 > const & localVector,
                                                                     dstFieldName,
                                                                     scalingFactor,
                                                                     mask );
-}
-
-// Copy values from nodes to DOFs
-template< typename VECTOR >
-void DofManager::addFieldToVector( VECTOR & vector,
-                                   string const & srcFieldName,
-                                   string const & dstFieldName,
-                                   real64 const scalingFactor,
-                                   CompMask const mask ) const
-{
-  fieldToVector< FieldSpecificationAdd, parallelHostPolicy >( vector.extractLocalVector(),
-                                                              srcFieldName,
-                                                              dstFieldName,
-                                                              scalingFactor,
-                                                              mask );
 }
 
 void DofManager::addFieldToVector( arrayView1d< real64 > const & localVector,
@@ -1617,26 +1557,6 @@ void DofManager::printFieldInfo( std::ostream & os ) const
 }
 
 #define MAKE_DOFMANAGER_METHOD_INST( LAI ) \
-  template void DofManager::copyVectorToField( LAI::ParallelVector const &, \
-                                               string const &, \
-                                               string const &, \
-                                               real64 const, \
-                                               CompMask const ) const; \
-  template void DofManager::addVectorToField( LAI::ParallelVector const &, \
-                                              string const &, \
-                                              string const &, \
-                                              real64 const, \
-                                              CompMask const ) const; \
-  template void DofManager::copyFieldToVector( LAI::ParallelVector &, \
-                                               string const &, \
-                                               string const &, \
-                                               real64 const, \
-                                               CompMask const ) const; \
-  template void DofManager::addFieldToVector( LAI::ParallelVector &, \
-                                              string const &, \
-                                              string const &, \
-                                              real64 const, \
-                                              CompMask const ) const; \
   template void DofManager::makeRestrictor( std::vector< SubComponent > const & selection, \
                                             MPI_Comm const & comm, \
                                             bool const transpose, \

--- a/src/coreComponents/linearAlgebra/DofManager.hpp
+++ b/src/coreComponents/linearAlgebra/DofManager.hpp
@@ -345,23 +345,6 @@ public:
   /**
    * @brief Copy values from LA vectors to simulation data arrays.
    *
-   * @tparam VECTOR type of LA vector
-   * @param vector source LA vector
-   * @param srcFieldName name of the source field (as defined in DofManager)
-   * @param dstFieldName name of the destination field (view wrapper key on the manager)
-   * @param scalingFactor a factor to scale vector values by
-   * @param mask component selection mask
-   */
-  template< typename VECTOR >
-  void copyVectorToField( VECTOR const & vector,
-                          string const & srcFieldName,
-                          string const & dstFieldName,
-                          real64 scalingFactor,
-                          CompMask mask = CompMask( MAX_COMP, true ) ) const;
-
-  /**
-   * @brief Copy values from LA vectors to simulation data arrays.
-   *
    * @param localVector source local vector
    * @param srcFieldName name of the source field (as defined in DofManager)
    * @param dstFieldName name of the destination field (view wrapper key on the manager)
@@ -373,23 +356,6 @@ public:
                           string const & dstFieldName,
                           real64 scalingFactor,
                           CompMask mask = CompMask( MAX_COMP, true ) ) const;
-
-  /**
-   * @brief Add values from LA vectors to simulation data arrays.
-   *
-   * @tparam VECTOR type of LA vector
-   * @param vector source LA vector
-   * @param srcFieldName name of the source field (as defined in DofManager)
-   * @param dstFieldName name of the destination field (view wrapper key on the manager)
-   * @param scalingFactor a factor to scale vector values by
-   * @param mask component selection mask
-   */
-  template< typename VECTOR >
-  void addVectorToField( VECTOR const & vector,
-                         string const & srcFieldName,
-                         string const & dstFieldName,
-                         real64 scalingFactor,
-                         CompMask mask = CompMask( MAX_COMP, true ) ) const;
 
   /**
    * @brief Add values from LA vectors to simulation data arrays.
@@ -407,23 +373,6 @@ public:
                          CompMask mask = CompMask( MAX_COMP, true ) ) const;
 
   /**
-   * @brief Copy values from nodes to DOFs.
-   *
-   * @tparam VECTOR type of LA vector
-   * @param vector target LA vector
-   * @param srcFieldName name of the source field (view wrapper key on the manager)
-   * @param dstFieldName name of the destination field (as defined in DofManager)
-   * @param scalingFactor a factor to scale vector values by
-   * @param mask component selection mask
-   */
-  template< typename VECTOR >
-  void copyFieldToVector( VECTOR & vector,
-                          string const & srcFieldName,
-                          string const & dstFieldName,
-                          real64 scalingFactor,
-                          CompMask mask = CompMask( MAX_COMP, true ) ) const;
-
-  /**
    * @brief Copy values from simulation data arrays to vectors.
    *
    * @param localVector target LA vector
@@ -437,23 +386,6 @@ public:
                           string const & dstFieldName,
                           real64 scalingFactor,
                           CompMask mask = CompMask( MAX_COMP, true ) ) const;
-
-  /**
-   * @brief Add values from a simulation data array to a DOF vector.
-   *
-   * @tparam VECTOR type of LA vector
-   * @param vector target LA vector
-   * @param srcFieldName name of the source field (view wrapper key on the manager)
-   * @param dstFieldName name of the destination field (as defined in DofManager)
-   * @param scalingFactor a factor to scale vector values by
-   * @param mask component selection mask
-   */
-  template< typename VECTOR >
-  void addFieldToVector( VECTOR & vector,
-                         string const & srcFieldName,
-                         string const & dstFieldName,
-                         real64 scalingFactor,
-                         CompMask mask = CompMask( MAX_COMP, true ) ) const;
 
   /**
    * @brief Add values from a simulation data array to a DOF vector.
@@ -605,19 +537,14 @@ private:
    * @brief Generic implementation for @ref copyVectorToField and @ref addVectorToField
    * @tparam FIELD_OP operation to perform (see FieldSpecificationOps.hpp)
    * @tparam POLICY execution policy for the kernel
-   * @param vector source LA vector
+   * @param localVector view of source vector
    * @param srcFieldName name of the source field (as defined in DofManager)
-   * @param scalingFactor a factor to scale vector values by
-   * @param manager mesh object manager that contains the target field (subregion for elements)
    * @param dstFieldName name of the destination field (view wrapper key on the manager)
-   * @param loCompIndex index of starting DoF component (for partial copy)
-   * @param hiCompIndex index past the ending DoF component (for partial copy)
-   *
-   * @note [@p loCompIndex , @p hiCompIndex) form a half-open interval.
-   *       Negative value of @p hiCompIndex means use full number of field components
+   * @param scalingFactor a factor to scale vector values by
+   * @param mask component selection mask (for partial copy)
    */
-  template< typename FIELD_OP, typename POLICY, typename LOCAL_VECTOR >
-  void vectorToField( LOCAL_VECTOR localVector,
+  template< typename FIELD_OP, typename POLICY >
+  void vectorToField( arrayView1d< real64 const > const & localVector,
                       string const & srcFieldName,
                       string const & dstFieldName,
                       real64 scalingFactor,
@@ -627,19 +554,14 @@ private:
    * @brief Generic implementation for @ref copyFieldToVector and @ref addFieldToVector
    * @tparam FIELD_OP operation to perform (see FieldSpecificationOps.hpp)
    * @tparam POLICY execution policy for the kernel
-   * @param manager mesh object manager that contains the target field (subregion for elements)
+   * @param localVector view of target vector local data
    * @param srcFieldName name of the source field (view wrapper key on the manager)
-   * @param scalingFactor a factor to scale vector values by
-   * @param vector ponter to target vector local data (host or device)
    * @param dstFieldName name of the destination field (as defined in DofManager)
-   * @param loCompIndex index of starting DoF component (for partial copy)
-   * @param hiCompIndex index past the ending DoF component (for partial copy)
-   *
-   * @note [@p loCompIndex , @p hiCompIndex) form a half-open interval.
-   *       Negative value of @p hiCompIndex means use full number of field components
+   * @param scalingFactor a factor to scale vector values by
+   * @param mask component selection mask (for partial copy)
    */
-  template< typename FIELD_OP, typename POLICY, typename LOCAL_VECTOR >
-  void fieldToVector( LOCAL_VECTOR localVector,
+  template< typename FIELD_OP, typename POLICY >
+  void fieldToVector( arrayView1d< real64 > const & localVector,
                       string const & srcFieldName,
                       string const & dstFieldName,
                       real64 scalingFactor,

--- a/src/coreComponents/linearAlgebra/common/LinearOperator.hpp
+++ b/src/coreComponents/linearAlgebra/common/LinearOperator.hpp
@@ -107,7 +107,7 @@ public:
    * @note when build without MPI, may return anything
    *       (MPI_Comm will be a mock type defined in MpiWrapper)
    */
-  virtual MPI_Comm getComm() const = 0;
+  virtual MPI_Comm comm() const = 0;
 };
 
 }

--- a/src/coreComponents/linearAlgebra/common/PreconditionerBase.hpp
+++ b/src/coreComponents/linearAlgebra/common/PreconditionerBase.hpp
@@ -115,9 +115,9 @@ public:
    * @note when build without MPI, may return anything
    *       (MPI_Comm will be a mock type defined in MpiWrapper)
    */
-  virtual MPI_Comm getComm() const override
+  virtual MPI_Comm comm() const override
   {
-    return m_mat->getComm();
+    return m_mat->comm();
   }
 
   /**

--- a/src/coreComponents/linearAlgebra/interfaces/VectorBase.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/VectorBase.hpp
@@ -52,13 +52,6 @@ protected:
   using Vector = VECTOR;
 
   /**
-   * @brief Constructs a vector in default state
-   */
-  VectorBase()
-    : m_closed( true )
-  {}
-
-  /**
    * @name Status query methods
    */
   ///@{
@@ -344,7 +337,7 @@ protected:
   }
 
   /// Flag indicating whether the vector is closed
-  bool m_closed;
+  bool m_closed = true;
 
   /// Actual storage for the local vector values
   array1d< real64 > m_data;

--- a/src/coreComponents/linearAlgebra/interfaces/VectorBase.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/VectorBase.hpp
@@ -142,8 +142,8 @@ protected:
   /**
    * @brief Notify the vector about external modification through direct data pointer.
    *
-   * This method must be called by the linear solver on the solution vector, so that the
-   * underlying Array object can be made aware of external changes in a specific memory space.
+   * This method MUST be called after any changes to vector values performed through direct pointer access,
+   * so that the underlying Array object can be made aware of external changes in a specific memory space.
    */
   virtual void touch() = 0;
 
@@ -311,7 +311,7 @@ protected:
    * @brief Get the communicator used by this vector
    * @return the MPI communicator
    */
-  virtual MPI_Comm getComm() const = 0;
+  virtual MPI_Comm comm() const = 0;
 
   ///@}
 

--- a/src/coreComponents/linearAlgebra/interfaces/VectorBase.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/VectorBase.hpp
@@ -95,7 +95,14 @@ protected:
     GEOSX_LAI_ASSERT( closed() );
     GEOSX_LAI_ASSERT_GE( localSize, 0 );
     reset();
-    m_data.resize( localSize );
+
+    // Ideally, resizing to the same size should be a no-op.
+    // But bufferManipulation::resize() always forces a touch in host memory.
+    // We want to avoid moving values to device again in that case.
+    if( m_values.size() != localSize )
+    {
+      m_values.resize( localSize );
+    }
   }
 
   /**
@@ -104,7 +111,7 @@ protected:
    */
   void setName( string const & name )
   {
-    m_data.setName( name );
+    m_values.setName( name );
   }
 
   ///@}
@@ -122,7 +129,7 @@ protected:
   {
     GEOSX_LAI_ASSERT( ready() );
     m_closed = false;
-    return m_data.toView();
+    return m_values.toView();
   }
 
   /**
@@ -150,7 +157,7 @@ protected:
     // moving the buffer to host, if a capacity increase does not occur, i.e. the new
     // array size is exactly the same as the one prior to clearing).
 
-    //m_data.clear();
+    //m_values.clear();
     m_closed = true;
   };
 
@@ -297,7 +304,7 @@ protected:
   arrayView1d< real64 const > values() const
   {
     GEOSX_LAI_ASSERT( ready() );
-    return m_data.toViewConst();
+    return m_values.toViewConst();
   }
 
   /**
@@ -345,7 +352,7 @@ protected:
   bool m_closed = true;
 
   /// Actual storage for the local vector values
-  array1d< real64 > m_data;
+  array1d< real64 > m_values;
 };
 
 } // namespace geosx

--- a/src/coreComponents/linearAlgebra/interfaces/VectorBase.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/VectorBase.hpp
@@ -145,7 +145,12 @@ protected:
    */
   virtual void reset()
   {
-    m_data.clear();
+    // Clearing the array causes issues on GPU when it is later resized again
+    // (the bug is in bufferManipulation::resize(), which calls buf.data() without
+    // moving the buffer to host, if a capacity increase does not occur, i.e. the new
+    // array size is exactly the same as the one prior to clearing).
+
+    //m_data.clear();
     m_closed = true;
   };
 

--- a/src/coreComponents/linearAlgebra/interfaces/direct/SuperLUDist.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/direct/SuperLUDist.cpp
@@ -179,7 +179,7 @@ void SuperLUDist< LAI >::setup( Matrix const & mat )
   int_t const numLR = LvArray::integerConversion< int_t >( mat.numLocalRows() );
   int_t const numNZ = LvArray::integerConversion< int_t >( mat.numLocalNonzeros() );
 
-  m_data = std::make_unique< SuperLUDistData >( numGR, numLR, numNZ, mat.getComm() );
+  m_data = std::make_unique< SuperLUDistData >( numGR, numLR, numNZ, mat.comm() );
   setOptions();
 
   typename Matrix::Export matExport;

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreExport.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreExport.cpp
@@ -86,8 +86,7 @@ void exportArray( HYPRE_MemoryLocation const location,
   }
   else // src is on device
   {
-    forAll< parallelDevicePolicy<> >( dst.size(),
-                                      [dst, src] GEOSX_HYPRE_DEVICE ( localIndex const i )
+    forAll< hypre::execPolicy >( dst.size(), [dst, src] GEOSX_HYPRE_DEVICE ( localIndex const i )
     {
       dst[i] = static_cast< U >( src[i] );
     } );
@@ -107,7 +106,7 @@ void exportArray( HYPRE_MemoryLocation const location,
   }
   else // dst is on device
   {
-    forAll< parallelDevicePolicy<> >( src.size(), [dst, src] GEOSX_HYPRE_DEVICE ( localIndex const i )
+    forAll< hypre::execPolicy >( src.size(), [dst, src] GEOSX_HYPRE_DEVICE ( localIndex const i )
     {
       dst[i] = static_cast< U >( src[i] );
     } );

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreInterface.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreInterface.cpp
@@ -23,10 +23,13 @@
 #include "linearAlgebra/interfaces/hypre/HypreMatrix.hpp"
 #include "linearAlgebra/interfaces/hypre/HyprePreconditioner.hpp"
 #include "linearAlgebra/interfaces/hypre/HypreSolver.hpp"
+#include "linearAlgebra/interfaces/hypre/HypreUtils.hpp"
 
 #include "HYPRE_utilities.h"
+#if defined(GEOSX_USE_HYPRE_CUDA)
 #include "_hypre_utilities.h"
 #include "_hypre_utilities.hpp"
+#endif
 
 namespace geosx
 {
@@ -37,10 +40,8 @@ void HypreInterface::initialize()
 #if defined(GEOSX_USE_HYPRE_CUDA)
   hypre_HandleDefaultExecPolicy( hypre_handle() ) = HYPRE_EXEC_DEVICE;
   hypre_HandleSpgemmUseCusparse( hypre_handle() ) = 0;
-  HYPRE_SetMemoryLocation( HYPRE_MEMORY_DEVICE );
-#else
-  HYPRE_SetMemoryLocation( HYPRE_MEMORY_HOST );
 #endif
+  HYPRE_SetMemoryLocation( hypre::memoryLocation );
 }
 
 void HypreInterface::finalize()

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreMatrix.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreMatrix.cpp
@@ -912,7 +912,7 @@ void HypreMatrix::addDiagonal( HypreVector const & src,
   GEOSX_LAI_ASSERT( numLocalRows() == src.localSize() );
 
   hypre::CSRData< false > const csr{ hypre_ParCSRMatrixDiag( m_parcsr_mat ) };
-  real64 const * const values = src.extractLocalVector();
+  arrayView1d< real64 const > const values = src.values();
 
   if( isEqual( scale, 1.0 ) )
   {
@@ -1023,7 +1023,9 @@ void HypreMatrix::extractDiagonal( HypreVector & dst ) const
   GEOSX_LAI_ASSERT( dst.ready() );
   GEOSX_LAI_ASSERT_EQ( dst.localSize(), numLocalRows() );
 
-  hypre_CSRMatrixExtractDiagonal( hypre_ParCSRMatrixDiag( m_parcsr_mat ), dst.extractLocalVector(), 0 );
+  HYPRE_Real * const data = hypre_VectorData( hypre_ParVectorLocalVector( dst.unwrapped() ) );
+  hypre_CSRMatrixExtractDiagonal( hypre_ParCSRMatrixDiag( m_parcsr_mat ), data, 0 );
+  dst.touch();
 }
 
 namespace

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreMatrix.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreMatrix.cpp
@@ -585,6 +585,7 @@ void HypreMatrix::apply( HypreVector const & src,
                                                    src.unwrapped(),
                                                    0.0,
                                                    dst.unwrapped() ) );
+  dst.touch();
 }
 
 void HypreMatrix::applyTranspose( HypreVector const & src,
@@ -601,6 +602,7 @@ void HypreMatrix::applyTranspose( HypreVector const & src,
                                                     src.unwrapped(),
                                                     0.0,
                                                     dst.unwrapped() ) );
+  dst.touch();
 }
 
 void HypreMatrix::multiply( HypreMatrix const & src,
@@ -763,6 +765,7 @@ void HypreMatrix::gemv( real64 const alpha,
                                                       beta,
                                                       y.unwrapped() ) );
   }
+  y.touch();
 }
 
 void HypreMatrix::scale( real64 const scalingFactor )
@@ -1072,6 +1075,7 @@ void HypreMatrix::getRowSums( HypreVector & dst,
       break;
     }
   }
+  dst.touch();
 }
 
 real64 HypreMatrix::clearRow( globalIndex const globalRow,

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreMatrix.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreMatrix.hpp
@@ -386,9 +386,9 @@ public:
   virtual globalIndex getGlobalRowID( localIndex const index ) const override;
 
   /**
-   * @copydoc MatrixBase<HypreMatrix,HypreVector>::getComm
+   * @copydoc MatrixBase<HypreMatrix,HypreVector>::comm
    */
-  virtual MPI_Comm getComm() const override;
+  virtual MPI_Comm comm() const override;
 
   virtual void print( std::ostream & os = std::cout ) const override;
 

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HyprePreconditioner.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HyprePreconditioner.cpp
@@ -447,7 +447,7 @@ HypreMatrix const & HyprePreconditioner::setupPreconditioningMatrix( HypreMatrix
     HypreMatrix Auu;
     {
       Stopwatch timer( m_makeRestrictorTime );
-      mat.dofManager()->makeRestrictor( { { m_params.mgr.displacementFieldName, { 3, true } } }, mat.getComm(), true, Pu );
+      mat.dofManager()->makeRestrictor( { { m_params.mgr.displacementFieldName, { 3, true } } }, mat.comm(), true, Pu );
     }
     {
       Stopwatch timer( m_computeAuuTime );

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HyprePreconditioner.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HyprePreconditioner.cpp
@@ -519,6 +519,7 @@ void HyprePreconditioner::apply( Vector const & src,
   dst.zero();
 
   GEOSX_LAI_CHECK_ERROR( m_precond->solve( m_precond->ptr, matrix().unwrapped(), src.unwrapped(), dst.unwrapped() ) );
+  dst.touch();
 }
 
 void HyprePreconditioner::clear()

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreSolver.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreSolver.cpp
@@ -209,7 +209,7 @@ void HypreSolver::setup( HypreMatrix const & mat )
 
   // Setup the solver (need a dummy vector for rhs/sol to avoid hypre segfaulting in setup)
   HypreVector dummy;
-  dummy.createWithLocalSize( mat.numLocalRows(), mat.getComm() );
+  dummy.create( mat.numLocalRows(), mat.getComm() );
   GEOSX_LAI_CHECK_ERROR( m_solver->setup( m_solver->ptr,
                                           mat.unwrapped(),
                                           dummy.unwrapped(),
@@ -222,7 +222,9 @@ int HypreSolver::doSolve( HypreVector const & rhs,
   GEOSX_LAI_ASSERT( ready() );
   GEOSX_LAI_ASSERT( sol.ready() );
   GEOSX_LAI_ASSERT( rhs.ready() );
-  return m_solver->solve( m_solver->ptr, matrix().unwrapped(), rhs.unwrapped(), sol.unwrapped() );
+  HYPRE_Int const result = m_solver->solve( m_solver->ptr, matrix().unwrapped(), rhs.unwrapped(), sol.unwrapped() );
+  sol.touch();
+  return result;
 }
 
 void HypreSolver::apply( HypreVector const & rhs,

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreSolver.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreSolver.cpp
@@ -199,7 +199,7 @@ void HypreSolver::setup( HypreMatrix const & mat )
   m_computeAuuTime = m_precond.computeAuuTime();
 
   m_solver = std::make_unique< HypreSolverWrapper >();
-  createHypreKrylovSolver( m_params, mat.getComm(), *m_solver );
+  createHypreKrylovSolver( m_params, mat.comm(), *m_solver );
 
   // Set the preconditioner
   GEOSX_LAI_CHECK_ERROR( m_solver->setPrecond( m_solver->ptr,
@@ -209,7 +209,7 @@ void HypreSolver::setup( HypreMatrix const & mat )
 
   // Setup the solver (need a dummy vector for rhs/sol to avoid hypre segfaulting in setup)
   HypreVector dummy;
-  dummy.create( mat.numLocalRows(), mat.getComm() );
+  dummy.create( mat.numLocalRows(), mat.comm() );
   GEOSX_LAI_CHECK_ERROR( m_solver->setup( m_solver->ptr,
                                           mat.unwrapped(),
                                           dummy.unwrapped(),

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreUtils.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreUtils.cpp
@@ -20,6 +20,7 @@
 
 #include "linearAlgebra/interfaces/hypre/HypreVector.hpp"
 
+#include <_hypre_parcsr_mv.h>
 #include <_hypre_parcsr_ls.h>
 
 namespace geosx
@@ -27,6 +28,22 @@ namespace geosx
 
 namespace hypre
 {
+
+HYPRE_Vector parVectorToVectorAll( HYPRE_ParVector const vec )
+{
+  if( hypre_ParVectorMemoryLocation( vec ) == HYPRE_MEMORY_HOST )
+  {
+    return (HYPRE_Vector)hypre_ParVectorToVectorAll( vec );
+  }
+  else
+  {
+    // Explicitly copy data to host before gathering, since hypre_ParVectorToVectorAll relies on UM.
+    hypre_ParVector * const hostVec = hypre_ParVectorCloneDeep_v2( vec, HYPRE_MEMORY_HOST );
+    hypre_Vector * const fullVec = hypre_ParVectorToVectorAll( hostVec );
+    hypre_ParVectorDestroy( hostVec );
+    return (HYPRE_Vector)fullVec;
+  }
+}
 
 HYPRE_Int DummySetup( HYPRE_Solver,
                       HYPRE_ParCSRMatrix,

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreUtils.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreUtils.hpp
@@ -70,11 +70,13 @@ namespace hypre
 using execPolicy = parallelDevicePolicy<>;
 /// Memory space used by hypre matrix/vector objects
 constexpr LvArray::MemorySpace memorySpace = LvArray::MemorySpace::cuda;
+constexpr HYPRE_MemoryLocation memoryLocation = HYPRE_MEMORY_DEVICE;
 #else
 /// Execution policy for operations on hypre data
 using execPolicy = parallelHostPolicy;
 /// Memory space used by hypre matrix/vector objects
 constexpr LvArray::MemorySpace memorySpace = LvArray::MemorySpace::host;
+constexpr HYPRE_MemoryLocation memoryLocation = HYPRE_MEMORY_HOST;
 #endif
 
 // Check matching requirements on index/value types between GEOSX and Hypre

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreUtils.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreUtils.hpp
@@ -179,6 +179,16 @@ inline HYPRE_BigInt const * toHypreBigInt( geosx::globalIndex const * const inde
 }
 
 /**
+ * @brief Gather a parallel vector on a every rank
+ * @param vec the vector to gather
+ * @return A newly allocated serial vector (may be null on ranks that don't have any elements)
+ *
+ * This is a wrapper around hypre_ParVectorToVectorAll() that works for both host-based
+ * and device-based vectors without relying on Unified Memory.
+ */
+HYPRE_Vector parVectorToVectorAll( HYPRE_ParVector const vec );
+
+/**
  * @brief Dummy function that does nothing but conform to hypre's signature for preconditioner setup/apply functions.
  * @return always 0 (success).
  *

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreUtils.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreUtils.hpp
@@ -65,6 +65,30 @@ struct HyprePrecWrapper
 namespace hypre
 {
 
+constexpr HYPRE_MemoryLocation getHypreMemoryLocation( LvArray::MemorySpace const space )
+{
+  switch( space )
+  {
+    case LvArray::MemorySpace::host: return HYPRE_MEMORY_HOST;
+#ifdef GEOSX_USE_HYPRE_CUDA
+    case LvArray::MemorySpace::cuda: return HYPRE_MEMORY_DEVICE;
+#endif
+    default: return HYPRE_MEMORY_HOST;
+  }
+}
+
+constexpr LvArray::MemorySpace getLvArrayMemorySpace( HYPRE_MemoryLocation const location )
+{
+  switch( location )
+  {
+    case HYPRE_MEMORY_HOST: return LvArray::MemorySpace::host;
+#ifdef GEOSX_USE_HYPRE_CUDA
+    case HYPRE_MEMORY_DEVICE: return LvArray::MemorySpace::cuda;
+#endif
+    default: return LvArray::MemorySpace::host;
+  }
+}
+
 #ifdef GEOSX_USE_HYPRE_CUDA
 /// Execution policy for operations on hypre data
 using execPolicy = parallelDevicePolicy<>;

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreUtils.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreUtils.hpp
@@ -65,6 +65,10 @@ struct HyprePrecWrapper
 namespace hypre
 {
 
+/**
+ * @brief @return Hypre memory location corresponding to a given LvArray memory space
+ * @param space the space
+ */
 constexpr HYPRE_MemoryLocation getHypreMemoryLocation( LvArray::MemorySpace const space )
 {
   switch( space )
@@ -77,6 +81,10 @@ constexpr HYPRE_MemoryLocation getHypreMemoryLocation( LvArray::MemorySpace cons
   }
 }
 
+/**
+ * @brief @return LvArray memory space corresponding to hypre's memory location
+ * @param location the location
+ */
 constexpr LvArray::MemorySpace getLvArrayMemorySpace( HYPRE_MemoryLocation const location )
 {
   switch( location )
@@ -94,12 +102,14 @@ constexpr LvArray::MemorySpace getLvArrayMemorySpace( HYPRE_MemoryLocation const
 using execPolicy = parallelDevicePolicy<>;
 /// Memory space used by hypre matrix/vector objects
 constexpr LvArray::MemorySpace memorySpace = LvArray::MemorySpace::cuda;
+/// Memory location used by hypre matrix/vector objects
 constexpr HYPRE_MemoryLocation memoryLocation = HYPRE_MEMORY_DEVICE;
 #else
 /// Execution policy for operations on hypre data
 using execPolicy = parallelHostPolicy;
 /// Memory space used by hypre matrix/vector objects
 constexpr LvArray::MemorySpace memorySpace = LvArray::MemorySpace::host;
+/// Memory location used by hypre matrix/vector objects
 constexpr HYPRE_MemoryLocation memoryLocation = HYPRE_MEMORY_HOST;
 #endif
 

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreVector.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreVector.cpp
@@ -55,10 +55,7 @@ HypreVector & HypreVector::operator=( HypreVector const & src )
     if( src.created() )
     {
       create( src.localSize(), src.getComm() );
-      if( src.ready() )
-      {
-        copy( src );
-      }
+      copy( src );
     }
   }
   return *this;

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreVector.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreVector.cpp
@@ -21,7 +21,6 @@
 #include "codingUtilities/Utilities.hpp"
 #include "linearAlgebra/interfaces/hypre/HypreUtils.hpp"
 
-#include <HYPRE.h>
 #include <_hypre_IJ_mv.h>
 
 #include <iomanip>
@@ -31,7 +30,7 @@ namespace geosx
 
 HypreVector::HypreVector()
   : VectorBase(),
-    m_vec{}
+  m_vec{}
 {}
 
 // Copy constructor
@@ -69,8 +68,9 @@ HypreVector & HypreVector::operator=( HypreVector && src ) noexcept
 {
   if( &src != this )
   {
-    std::swap( m_vec, src.m_vec );
-    std::swap( m_closed, src.m_closed );
+    m_vec = src.m_vec;
+    src.m_vec = nullptr;
+    VectorBase::operator=( std::move( src ) );
   }
   return *this;
 }
@@ -115,6 +115,7 @@ void HypreVector::create( localIndex const localSize,
 
   // Complete the initialization (vector will not allocate if data is already set)
   GEOSX_LAI_CHECK_ERROR( hypre_ParVectorInitialize_v2( m_vec, hypre::memoryLocation ) );
+  GEOSX_LAI_CHECK_ERROR( hypre_ParVectorSetConstantValues( m_vec, 0.0 ) );
 }
 
 bool HypreVector::created() const

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreVector.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreVector.hpp
@@ -29,10 +29,11 @@
  */
 ///@{
 
-/// ParVector struct forward definition
 extern "C"
 {
+/// ParVector struct forward declaration
 struct hypre_ParVector_struct;
+/// ParVector struct alias
 typedef struct hypre_ParVector_struct hypre_ParVector;
 }
 

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreVector.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreVector.hpp
@@ -29,11 +29,12 @@
  */
 ///@{
 
-/// IJVector struct forward declaration
-extern "C" struct hypre_IJVector_struct;
-
 /// ParVector struct forward definition
-extern "C" struct hypre_ParVector_struct;
+extern "C"
+{
+struct hypre_ParVector_struct;
+typedef struct hypre_ParVector_struct hypre_ParVector;
+}
 
 ///@}
 
@@ -49,12 +50,6 @@ namespace geosx
 class HypreVector final : private VectorBase< HypreVector >
 {
 public:
-
-  /// IJVector pointer alias
-  using HYPRE_IJVector = hypre_IJVector_struct *;
-
-  /// ParVector pointer alias
-  using HYPRE_ParVector = hypre_ParVector_struct *;
 
   /**
    * @name Constructor/Destructor Methods
@@ -105,53 +100,28 @@ public:
    */
   ///@{
 
+  using VectorBase::setName;
   using VectorBase::closed;
   using VectorBase::ready;
-  using VectorBase::extract;
+  using VectorBase::open;
+  using VectorBase::zero;
+  using VectorBase::values;
 
   /**
    * @copydoc VectorBase<HypreVector>::created
    */
   virtual bool created() const override;
 
-  virtual void createWithLocalSize( localIndex const localSize,
-                                    MPI_Comm const & comm ) override;
-
-  virtual void createWithGlobalSize( globalIndex const globalSize,
-                                     MPI_Comm const & comm ) override;
-
-  virtual void create( arrayView1d< real64 const > const & localValues,
+  virtual void create( localIndex const localSize,
                        MPI_Comm const & comm ) override;
-
-  virtual void open() override;
 
   virtual void close() override;
 
+  virtual void touch() override;
+
   virtual void reset() override;
 
-  virtual void set( globalIndex const globalRowIndex,
-                    real64 const value ) override;
-
-  virtual void add( globalIndex const globalRowIndex,
-                    real64 const value ) override;
-
-  virtual void set( globalIndex const * globalRowIndices,
-                    real64 const * values,
-                    localIndex size ) override;
-
-  virtual void add( globalIndex const * globalRowIndices,
-                    real64 const * values,
-                    localIndex const size ) override;
-
-  virtual void set( arraySlice1d< globalIndex const > const & globalRowIndices,
-                    arraySlice1d< real64 const > const & values ) override;
-
-  virtual void add( arraySlice1d< globalIndex const > const & globalRowIndices,
-                    arraySlice1d< real64 const > const & values ) override;
-
   virtual void set( real64 const value ) override;
-
-  virtual void zero() override;
 
   virtual void rand( unsigned const seed ) override;
 
@@ -208,30 +178,6 @@ public:
    */
   virtual globalIndex iupper() const override;
 
-  virtual real64 get( globalIndex globalRow ) const override;
-
-  virtual void get( arraySlice1d< globalIndex const > const & globalRowIndices,
-                    arraySlice1d< real64 > const & values ) const override;
-
-  virtual localIndex getLocalRowID( globalIndex const globalRowIndex ) const override;
-
-  virtual globalIndex getGlobalRowID( localIndex const localRowIndex ) const override;
-
-  /**
-   * @copydoc VectorBase<HypreVector>::extractLocalVector
-   */
-  virtual real64 const * extractLocalVector() const override;
-
-  /**
-   * @copydoc VectorBase<HypreVector>::extractLocalVector
-   */
-  virtual real64 * extractLocalVector() override;
-
-  /**
-   * @copydoc VectorBase<HypreVector>::extract
-   */
-  virtual void extract( arrayView1d< real64 > const & localVector ) const override;
-
   /**
    * @copydoc VectorBase<HypreVector>::getComm
    */
@@ -244,29 +190,25 @@ public:
 
   ///@}
 
+private:
+
+  /// ParVector pointer alias
+  using HYPRE_ParVector = hypre_ParVector *;
+
+public:
+
   /**
    * @brief Returns a pointer to the implementation.
    * @return the underlying HYPRE_ParVector object.
    */
   HYPRE_ParVector const & unwrapped() const;
 
-  /**
-   * @brief Returns a pointer to the implementation.
-   * @return the underlying HYPRE_IJVector object.
-   */
-  HYPRE_IJVector const & unwrappedIJ() const;
-
 private:
-
-  /**
-   * Pointer to underlying HYPRE_IJVector type.
-   */
-  HYPRE_IJVector m_ij_vector;
 
   /**
    * Pointer to underlying HYPRE_ParVector type.
    */
-  HYPRE_ParVector m_par_vector;
+  HYPRE_ParVector m_vec;
 
 };
 

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreVector.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreVector.hpp
@@ -33,8 +33,6 @@ extern "C"
 {
 /// ParVector struct forward declaration
 struct hypre_ParVector_struct;
-/// ParVector struct alias
-typedef struct hypre_ParVector_struct hypre_ParVector;
 }
 
 ///@}
@@ -180,9 +178,9 @@ public:
   virtual globalIndex iupper() const override;
 
   /**
-   * @copydoc VectorBase<HypreVector>::getComm
+   * @copydoc VectorBase<HypreVector>::comm
    */
-  virtual MPI_Comm getComm() const override;
+  virtual MPI_Comm comm() const override;
 
   virtual void print( std::ostream & os = std::cout ) const override;
 
@@ -194,7 +192,7 @@ public:
 private:
 
   /// ParVector pointer alias
-  using HYPRE_ParVector = hypre_ParVector *;
+  using HYPRE_ParVector = struct hypre_ParVector_struct *;
 
 public:
 

--- a/src/coreComponents/linearAlgebra/interfaces/petsc/PetscExport.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/petsc/PetscExport.cpp
@@ -134,8 +134,9 @@ void PetscExport::exportVector( PetscVector const & vec,
   }
   else
   {
-    real64 const * const data = vec.extractLocalVector();
-    std::copy( data, data + vec.localSize(), values.data() );
+    arrayView1d< real64 const > const data = vec.values();
+    data.move( LvArray::MemorySpace::host, false );
+    std::copy( data.begin(), data.end(), values.data() );
   }
 }
 
@@ -158,8 +159,9 @@ void PetscExport::importVector( arrayView1d< const real64 > const & values,
   }
   else
   {
-    real64 * const data = vec.extractLocalVector();
-    std::copy( values.data(), values.data() + vec.localSize(), data );
+    arrayView1d< real64 > const data = vec.open();
+    std::copy( values.data(), values.data() + vec.localSize(), data.begin() );
+    vec.close();
   }
 }
 

--- a/src/coreComponents/linearAlgebra/interfaces/petsc/PetscExport.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/petsc/PetscExport.cpp
@@ -35,13 +35,13 @@ PetscExport::PetscExport( PetscMatrix const & mat,
   globalIndex const numGlobalRows = mat.numGlobalRows();
   localIndex const numLocalRows = mat.numLocalRows();
 
-  int const rank = MpiWrapper::commRank( mat.getComm() );
+  int const rank = MpiWrapper::commRank( mat.comm() );
   localIndex const N = ( rank == m_targetRank ) ? numGlobalRows : 0;
 
   // create vector scatter context
   Vec tmpGlobal;
   Vec tmpLocal;
-  GEOSX_LAI_CHECK_ERROR( VecCreateMPI( mat.getComm(), numLocalRows, numGlobalRows, &tmpGlobal ) );
+  GEOSX_LAI_CHECK_ERROR( VecCreateMPI( mat.comm(), numLocalRows, numGlobalRows, &tmpGlobal ) );
   GEOSX_LAI_CHECK_ERROR( VecCreateSeq( PETSC_COMM_SELF, N, &tmpLocal ) );
   GEOSX_LAI_CHECK_ERROR( ISCreateStride( PETSC_COMM_SELF, N, 0, 1, &m_indexSet ) );
   GEOSX_LAI_CHECK_ERROR( VecScatterCreate( tmpGlobal, m_indexSet, tmpLocal, m_indexSet, &m_scatter ) );
@@ -61,7 +61,7 @@ void PetscExport::exportCRS( PetscMatrix const & mat,
                              arrayView1d< COLUMN_TYPE > const & colIndices,
                              arrayView1d< real64 > const & values ) const
 {
-  int const rank = MpiWrapper::commRank( mat.getComm() );
+  int const rank = MpiWrapper::commRank( mat.comm() );
 
   // import on target rank if needed, or extract diag+offdiag part in each rank
   Mat * submat; // needed by MatCreateSubMatrices API
@@ -123,7 +123,7 @@ void PetscExport::exportVector( PetscVector const & vec,
   values.move( LvArray::MemorySpace::host, false );
   if( m_targetRank >= 0 )
   {
-    int const rank = MpiWrapper::commRank( vec.getComm() );
+    int const rank = MpiWrapper::commRank( vec.comm() );
     localIndex const N = ( rank == m_targetRank ) ? vec.globalSize() : 0;
 
     Vec localVector;
@@ -146,7 +146,7 @@ void PetscExport::importVector( arrayView1d< const real64 > const & values,
   values.move( LvArray::MemorySpace::host, false );
   if( m_targetRank >= 0 )
   {
-    int const rank = MpiWrapper::commRank( vec.getComm() );
+    int const rank = MpiWrapper::commRank( vec.comm() );
     localIndex const N = ( rank == m_targetRank ) ? vec.globalSize() : 0;
 
     // Note: PETSc creates a vector wrapper around values by taking a pointer-to-const and casting away const-ness (!)

--- a/src/coreComponents/linearAlgebra/interfaces/petsc/PetscMatrix.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/petsc/PetscMatrix.cpp
@@ -540,6 +540,7 @@ void PetscMatrix::apply( PetscVector const & src,
   GEOSX_LAI_ASSERT_EQ( numGlobalCols(), src.globalSize() );
 
   GEOSX_LAI_CHECK_ERROR( MatMult( m_mat, src.unwrapped(), dst.unwrapped() ) );
+  dst.touch();
 }
 
 void PetscMatrix::applyTranspose( Vector const & src,
@@ -552,6 +553,7 @@ void PetscMatrix::applyTranspose( Vector const & src,
   GEOSX_LAI_ASSERT_EQ( numGlobalRows(), src.globalSize() );
 
   GEOSX_LAI_CHECK_ERROR( MatMultTranspose( m_mat, src.unwrapped(), dst.unwrapped() ) );
+  dst.touch();
 }
 
 void PetscMatrix::multiply( PetscMatrix const & src,
@@ -616,6 +618,7 @@ void PetscMatrix::gemv( real64 const alpha,
     GEOSX_LAI_CHECK_ERROR( MatMult( m_mat, x_.unwrapped(), b_.unwrapped() ) ); // alpha*A*x_ = b_
   }
   GEOSX_LAI_CHECK_ERROR( VecAXPY( y.unwrapped(), 1, b_.unwrapped() ) ); // alpha*A*x_ + beta*y = y
+  y.touch();
 }
 
 void PetscMatrix::scale( real64 const scalingFactor )
@@ -909,6 +912,7 @@ void PetscMatrix::extractDiagonal( PetscVector & dst ) const
   GEOSX_LAI_ASSERT_EQ( dst.localSize(), numLocalRows() );
 
   GEOSX_LAI_CHECK_ERROR( MatGetDiagonal( m_mat, dst.unwrapped() ) );
+  dst.touch();
 }
 
 namespace

--- a/src/coreComponents/linearAlgebra/interfaces/petsc/PetscMatrix.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/petsc/PetscMatrix.cpp
@@ -860,7 +860,7 @@ localIndex PetscMatrix::maxRowLength() const
   {
     maxLocalLength.max( rowLength( globalRow ) );
   } );
-  return MpiWrapper::max( maxLocalLength.get(), getComm() );
+  return MpiWrapper::max( maxLocalLength.get(), comm() );
 }
 
 localIndex PetscMatrix::rowLength( globalIndex const globalRowIndex ) const
@@ -1158,7 +1158,7 @@ real64 PetscMatrix::normMax() const
     GEOSX_LAI_CHECK_ERROR( MatRestoreRow( m_mat, row, &numEntries, nullptr, &vals ) );
   }
 
-  return MpiWrapper::max( norm, getComm() );
+  return MpiWrapper::max( norm, comm() );
 }
 
 real64 PetscMatrix::normMax( arrayView1d< globalIndex const > const & rowIndices ) const
@@ -1180,7 +1180,7 @@ real64 PetscMatrix::normMax( arrayView1d< globalIndex const > const & rowIndices
     GEOSX_LAI_CHECK_ERROR( MatRestoreRow( m_mat, row, &numEntries, nullptr, &vals ) );
   }
 
-  return MpiWrapper::max( norm, getComm() );
+  return MpiWrapper::max( norm, comm() );
 }
 
 localIndex PetscMatrix::getLocalRowID( globalIndex const index ) const
@@ -1217,7 +1217,7 @@ localIndex PetscMatrix::numLocalRows() const
   return LvArray::integerConversion< localIndex >( rows );
 }
 
-MPI_Comm PetscMatrix::getComm() const
+MPI_Comm PetscMatrix::comm() const
 {
   GEOSX_LAI_ASSERT( created() );
   MPI_Comm comm;
@@ -1229,7 +1229,7 @@ void PetscMatrix::print( std::ostream & os ) const
 {
   GEOSX_LAI_ASSERT( ready() );
   GEOSX_ERROR_IF( &os != &std::cout, "Only output to stdout currently supported" );
-  GEOSX_LAI_CHECK_ERROR( MatView( m_mat, PETSC_VIEWER_STDOUT_( getComm() ) ) );
+  GEOSX_LAI_CHECK_ERROR( MatView( m_mat, PETSC_VIEWER_STDOUT_( comm() ) ) );
 }
 
 void PetscMatrix::write( string const & filename,
@@ -1276,11 +1276,11 @@ void PetscMatrix::write( string const & filename,
 
   if( ASCIIfile )
   {
-    GEOSX_LAI_CHECK_ERROR( PetscViewerASCIIOpen( getComm(), filename.c_str(), &viewer ) );
+    GEOSX_LAI_CHECK_ERROR( PetscViewerASCIIOpen( comm(), filename.c_str(), &viewer ) );
   }
   else
   {
-    GEOSX_LAI_CHECK_ERROR( PetscViewerBinaryOpen( getComm(), filename.c_str(), FILE_MODE_WRITE, &viewer ) );
+    GEOSX_LAI_CHECK_ERROR( PetscViewerBinaryOpen( comm(), filename.c_str(), FILE_MODE_WRITE, &viewer ) );
   }
   GEOSX_LAI_CHECK_ERROR( PetscViewerPushFormat( viewer, petscFormat ) );
   GEOSX_LAI_CHECK_ERROR( MatView( m_mat, viewer ) );

--- a/src/coreComponents/linearAlgebra/interfaces/petsc/PetscMatrix.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/petsc/PetscMatrix.hpp
@@ -372,9 +372,9 @@ public:
   virtual globalIndex getGlobalRowID( localIndex const index ) const override;
 
   /**
-   * @copydoc MatrixBase<PetscMatrix,PetscVector>::getComm
+   * @copydoc MatrixBase<PetscMatrix,PetscVector>::comm
    */
-  virtual MPI_Comm getComm() const override;
+  virtual MPI_Comm comm() const override;
 
   virtual void print( std::ostream & os = std::cout ) const override;
 

--- a/src/coreComponents/linearAlgebra/interfaces/petsc/PetscPreconditioner.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/petsc/PetscPreconditioner.cpp
@@ -294,7 +294,7 @@ void PetscPreconditioner::setup( PetscMatrix const & mat )
   // Basic setup common for all preconditioners
   if( create )
   {
-    GEOSX_LAI_CHECK_ERROR( PCCreate( precondMat.getComm(), &m_precond ) );
+    GEOSX_LAI_CHECK_ERROR( PCCreate( precondMat.comm(), &m_precond ) );
   }
   GEOSX_LAI_CHECK_ERROR( PCSetOperators( m_precond, mat.unwrapped(), precondMat.unwrapped() ) );
 

--- a/src/coreComponents/linearAlgebra/interfaces/petsc/PetscPreconditioner.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/petsc/PetscPreconditioner.cpp
@@ -357,6 +357,7 @@ void PetscPreconditioner::apply( Vector const & src,
   GEOSX_LAI_ASSERT_EQ( dst.globalSize(), this->numGlobalRows() );
 
   GEOSX_LAI_CHECK_ERROR( PCApply( m_precond, src.unwrapped(), dst.unwrapped() ) );
+  dst.touch();
 }
 
 void PetscPreconditioner::clear()

--- a/src/coreComponents/linearAlgebra/interfaces/petsc/PetscSolver.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/petsc/PetscSolver.cpp
@@ -108,6 +108,7 @@ void PetscSolver::apply( PetscVector const & rhs,
   GEOSX_LAI_ASSERT( sol.ready() );
   GEOSX_LAI_ASSERT( rhs.ready() );
   GEOSX_LAI_CHECK_ERROR( KSPSolve( m_solver, rhs.unwrapped(), sol.unwrapped() ) );
+  sol.touch();
 }
 
 void PetscSolver::solve( PetscVector const & rhs,

--- a/src/coreComponents/linearAlgebra/interfaces/petsc/PetscSolver.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/petsc/PetscSolver.cpp
@@ -86,7 +86,7 @@ void PetscSolver::setup( PetscMatrix const & mat )
 
   m_precond.setup( mat );
 
-  createPetscKrylovSolver( m_params, mat.getComm(), m_solver );
+  createPetscKrylovSolver( m_params, mat.comm(), m_solver );
   GEOSX_LAI_CHECK_ERROR( KSPSetPC( m_solver, m_precond.unwrapped() ) );
 
   // display output

--- a/src/coreComponents/linearAlgebra/interfaces/petsc/PetscVector.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/petsc/PetscVector.cpp
@@ -82,35 +82,11 @@ void PetscVector::reset()
   }
 }
 
-void PetscVector::createWithLocalSize( localIndex const localSize, MPI_Comm const & comm )
+void PetscVector::create( localIndex const localSize, MPI_Comm const & comm )
 {
-  GEOSX_LAI_ASSERT( closed() );
-  GEOSX_LAI_ASSERT_GE( localSize, 0 );
-  reset();
-  GEOSX_LAI_CHECK_ERROR( VecCreateMPI( comm, localSize, PETSC_DETERMINE, &m_vec ) );
-}
-
-void PetscVector::createWithGlobalSize( globalIndex const globalSize, MPI_Comm const & comm )
-{
-  GEOSX_LAI_ASSERT( closed() );
-  GEOSX_LAI_ASSERT_GE( globalSize, 0 );
-  reset();
-  GEOSX_LAI_CHECK_ERROR( VecCreateMPI( comm, PETSC_DECIDE, globalSize, &m_vec ) );
-}
-
-void PetscVector::create( arrayView1d< real64 const > const & localValues, MPI_Comm const & comm )
-{
-  GEOSX_LAI_ASSERT( closed() );
-  reset();
-
-  GEOSX_LAI_CHECK_ERROR( VecCreateMPI( comm, localValues.size(), PETSC_DETERMINE, &m_vec ) );
-
-  // set vector values
-  PetscScalar * values;
-  localValues.move( LvArray::MemorySpace::host, false );
-  GEOSX_LAI_CHECK_ERROR( VecGetArray( m_vec, &values ) );
-  std::copy( localValues.begin(), localValues.end(), values );
-  GEOSX_LAI_CHECK_ERROR( VecRestoreArray( m_vec, &values ) );
+  VectorBase::create( localSize, comm );
+  m_data.move( LvArray::MemorySpace::host, false );
+  GEOSX_LAI_CHECK_ERROR( VecCreateMPIWithArray( comm, 1, localSize, PETSC_DETERMINE, m_data.data(), &m_vec ) );
 }
 
 bool PetscVector::created() const
@@ -118,67 +94,11 @@ bool PetscVector::created() const
   return m_vec != nullptr;
 }
 
-void PetscVector::set( globalIndex const globalRow,
-                       real64 const value )
-{
-  GEOSX_LAI_ASSERT( !closed() );
-  GEOSX_LAI_CHECK_ERROR( VecSetValue( m_vec, globalRow, value, INSERT_VALUES ) );
-}
-
-void PetscVector::add( globalIndex const globalRow,
-                       real64 const value )
-{
-  GEOSX_LAI_ASSERT( !closed() );
-  GEOSX_LAI_CHECK_ERROR( VecSetValue( m_vec, globalRow, value, ADD_VALUES ) );
-}
-
-void PetscVector::set( globalIndex const * globalIndices,
-                       real64 const * values,
-                       localIndex size )
-{
-  GEOSX_LAI_ASSERT( !closed() );
-  GEOSX_LAI_CHECK_ERROR( VecSetValues( m_vec, size, petsc::toPetscInt( globalIndices ), values, INSERT_VALUES ) );
-}
-
-void PetscVector::add( globalIndex const * globalIndices,
-                       real64 const * values,
-                       localIndex size )
-{
-  GEOSX_LAI_ASSERT( !closed() );
-  GEOSX_LAI_CHECK_ERROR( VecSetValues( m_vec, size, petsc::toPetscInt( globalIndices ), values, ADD_VALUES ) );
-}
-
-void PetscVector::set( arraySlice1d< globalIndex const > const & globalIndices,
-                       arraySlice1d< real64 const > const & values )
-{
-  GEOSX_LAI_ASSERT( !closed() );
-  GEOSX_LAI_CHECK_ERROR( VecSetValues( m_vec,
-                                       values.size(),
-                                       petsc::toPetscInt( globalIndices.dataIfContiguous()),
-                                       values.dataIfContiguous(),
-                                       INSERT_VALUES ) );
-}
-
-void PetscVector::add( arraySlice1d< globalIndex const > const & globalIndices,
-                       arraySlice1d< real64 const > const & values )
-{
-  GEOSX_LAI_ASSERT( !closed() );
-  GEOSX_LAI_CHECK_ERROR( VecSetValues( m_vec,
-                                       values.size(),
-                                       petsc::toPetscInt( globalIndices.dataIfContiguous()),
-                                       values.dataIfContiguous(),
-                                       ADD_VALUES ) );
-}
-
 void PetscVector::set( real64 const value )
 {
   GEOSX_LAI_ASSERT( ready() );
   GEOSX_LAI_CHECK_ERROR( VecSet( m_vec, value ) );
-}
-
-void PetscVector::zero()
-{
-  set( 0.0 );
+  touch();
 }
 
 void PetscVector::rand( unsigned const seed )
@@ -197,21 +117,21 @@ void PetscVector::rand( unsigned const seed )
   // create random vector
   GEOSX_LAI_CHECK_ERROR( VecSetRandom( m_vec, ran ) );
   GEOSX_LAI_CHECK_ERROR( PetscRandomDestroy( &ran ) );
-}
 
-void PetscVector::open()
-{
-  GEOSX_LAI_ASSERT( ready() );
-  m_closed = false;
+  touch();
 }
 
 void PetscVector::close()
 {
   GEOSX_LAI_ASSERT( !closed() );
-  // assemble the vector after setting values
-  GEOSX_LAI_CHECK_ERROR( VecAssemblyBegin( m_vec ) );
-  GEOSX_LAI_CHECK_ERROR( VecAssemblyEnd( m_vec ) );
+  m_data.move( LvArray::MemorySpace::host, false );
   m_closed = true;
+}
+
+void PetscVector::touch()
+{
+  GEOSX_LAI_ASSERT( ready() );
+  m_data.registerTouch( LvArray::MemorySpace::host );
 }
 
 void PetscVector::scale( real64 const scalingFactor )
@@ -221,6 +141,7 @@ void PetscVector::scale( real64 const scalingFactor )
   if( !isEqual( scalingFactor, 1.0 ) )
   {
     GEOSX_LAI_CHECK_ERROR( VecScale( m_vec, scalingFactor ) );
+    touch();
   }
 }
 
@@ -228,6 +149,7 @@ void PetscVector::reciprocal()
 {
   GEOSX_LAI_ASSERT( ready() );
   GEOSX_LAI_CHECK_ERROR( VecReciprocal( m_vec ) );
+  touch();
 }
 
 real64 PetscVector::dot( PetscVector const & vec ) const
@@ -249,6 +171,7 @@ void PetscVector::copy( PetscVector const & x )
 
   GEOSX_LAI_CHECK_ERROR( VecSet( m_vec, 0 ) );
   GEOSX_LAI_CHECK_ERROR( VecAXPY( m_vec, 1.0, x.m_vec ) );
+  touch();
 }
 
 void PetscVector::axpy( real64 const alpha, PetscVector const & x )
@@ -260,6 +183,7 @@ void PetscVector::axpy( real64 const alpha, PetscVector const & x )
   if( &x != this )
   {
     GEOSX_LAI_CHECK_ERROR( VecAXPY( m_vec, alpha, x.m_vec ) );
+    touch();
   }
   else
   {
@@ -278,6 +202,7 @@ void PetscVector::axpby( real64 const alpha,
   if( &x != this )
   {
     GEOSX_LAI_CHECK_ERROR( VecAXPBY( m_vec, alpha, beta, x.m_vec ) );
+    touch();
   }
   else
   {
@@ -295,6 +220,7 @@ void PetscVector::pointwiseProduct( PetscVector const & x,
   GEOSX_LAI_ASSERT_EQ( globalSize(), y.globalSize() );
 
   GEOSX_LAI_CHECK_ERROR( VecPointwiseMult( y.m_vec, m_vec, x.m_vec ) );
+  y.touch();
 }
 
 real64 PetscVector::norm1() const
@@ -319,6 +245,38 @@ real64 PetscVector::normInf() const
   real64 result;
   GEOSX_LAI_CHECK_ERROR( VecNorm( m_vec, NORM_INFINITY, &result ) );
   return result;
+}
+
+globalIndex PetscVector::globalSize() const
+{
+  GEOSX_LAI_ASSERT( created() );
+  PetscInt size;
+  GEOSX_LAI_CHECK_ERROR( VecGetSize( m_vec, &size ) );
+  return LvArray::integerConversion< globalIndex >( size );
+}
+
+localIndex PetscVector::localSize() const
+{
+  GEOSX_LAI_ASSERT( created() );
+  PetscInt size;
+  GEOSX_LAI_CHECK_ERROR( VecGetLocalSize( m_vec, &size ) );
+  return LvArray::integerConversion< localIndex >( size );
+}
+
+globalIndex PetscVector::ilower() const
+{
+  GEOSX_LAI_ASSERT( created() );
+  PetscInt low, high;
+  GEOSX_LAI_CHECK_ERROR( VecGetOwnershipRange( m_vec, &low, &high ) );
+  return low;
+}
+
+globalIndex PetscVector::iupper() const
+{
+  GEOSX_LAI_ASSERT( created() );
+  PetscInt low, high;
+  GEOSX_LAI_CHECK_ERROR( VecGetOwnershipRange( m_vec, &low, &high ) );
+  return high;
 }
 
 void PetscVector::print( std::ostream & os ) const
@@ -350,20 +308,22 @@ void PetscVector::write( string const & filename,
     case LAIOutputFormat::NATIVE_ASCII:
     {
       petscFormat = PETSC_VIEWER_ASCII_COMMON;
+      break;
     }
-    break;
     case LAIOutputFormat::MATLAB_ASCII:
     {
       petscFormat = PETSC_VIEWER_ASCII_MATLAB;
+      break;
     }
-    break;
     case LAIOutputFormat::MATRIX_MARKET:
     {
       useMatrixMarket = true;
+      break;
     }
-    break;
     default:
+    {
       GEOSX_ERROR( "Unsupported vector output format" );
+    }
   }
 
   if( !useMatrixMarket )
@@ -402,32 +362,6 @@ void PetscVector::write( string const & filename,
   }
 }
 
-real64 PetscVector::get( globalIndex globalRow ) const
-{
-  GEOSX_LAI_ASSERT( ready() );
-  GEOSX_LAI_ASSERT_GE( globalRow, ilower() );
-  GEOSX_LAI_ASSERT_GT( iupper(), globalRow );
-
-  real64 value;
-  GEOSX_LAI_CHECK_ERROR( VecGetValues( m_vec, 1, petsc::toPetscInt( &globalRow ), &value ) );
-  return value;
-}
-
-void PetscVector::get( arraySlice1d< globalIndex const > const & globalIndices,
-                       arraySlice1d< real64 > const & values ) const
-{
-  GEOSX_LAI_ASSERT( ready() );
-  GEOSX_LAI_ASSERT_GE( values.size(), globalIndices.size() );
-  GEOSX_LAI_ASSERT_GE( *std::min_element( globalIndices.dataIfContiguous(), globalIndices.dataIfContiguous() + globalIndices.size() ), ilower() );
-  GEOSX_LAI_ASSERT_GT( iupper(), *std::max_element( globalIndices.dataIfContiguous(),
-                                                    globalIndices.dataIfContiguous() + globalIndices.size() ) );
-
-  GEOSX_LAI_CHECK_ERROR( VecGetValues( m_vec,
-                                       globalIndices.size(),
-                                       petsc::toPetscInt( globalIndices.dataIfContiguous() ),
-                                       values.dataIfContiguous() ) );
-}
-
 Vec const & PetscVector::unwrapped() const
 {
   GEOSX_LAI_ASSERT( created() );
@@ -446,74 +380,6 @@ MPI_Comm PetscVector::getComm() const
   MPI_Comm comm;
   GEOSX_LAI_CHECK_ERROR( PetscObjectGetComm( reinterpret_cast< PetscObject >( m_vec ), &comm ) );
   return comm;
-}
-
-globalIndex PetscVector::globalSize() const
-{
-  GEOSX_LAI_ASSERT( created() );
-  PetscInt size;
-  GEOSX_LAI_CHECK_ERROR( VecGetSize( m_vec, &size ) );
-  return LvArray::integerConversion< globalIndex >( size );
-}
-
-localIndex PetscVector::localSize() const
-{
-  GEOSX_LAI_ASSERT( created() );
-  PetscInt size;
-  GEOSX_LAI_CHECK_ERROR( VecGetLocalSize( m_vec, &size ) );
-  return LvArray::integerConversion< localIndex >( size );
-}
-
-localIndex PetscVector::getLocalRowID( globalIndex const globalRow ) const
-{
-  GEOSX_LAI_ASSERT( created() );
-  PetscInt low, high;
-  GEOSX_LAI_CHECK_ERROR( VecGetOwnershipRange( m_vec, &low, &high ) );
-  return ( globalRow >= low && globalRow < high) ? LvArray::integerConversion< localIndex >( globalRow - low ) : -1;
-}
-
-globalIndex PetscVector::getGlobalRowID( localIndex const localRow ) const
-{
-  GEOSX_LAI_ASSERT( created() );
-  GEOSX_LAI_ASSERT_GE( localRow, 0 );
-  GEOSX_LAI_ASSERT_GT( localSize(), localRow );
-  return ilower() + localRow;
-}
-
-real64 const * PetscVector::extractLocalVector() const
-{
-  GEOSX_LAI_ASSERT( ready() );
-  PetscScalar * avec;
-  GEOSX_LAI_CHECK_ERROR( VecGetArray( m_vec, &avec ) );
-  real64 const * const localVector = avec;
-  GEOSX_LAI_CHECK_ERROR( VecRestoreArray( m_vec, &avec ) );
-  return localVector;
-}
-
-real64 * PetscVector::extractLocalVector()
-{
-  GEOSX_LAI_ASSERT( ready() );
-  PetscScalar * avec;
-  GEOSX_LAI_CHECK_ERROR( VecGetArray( m_vec, &avec ) );
-  real64 * const localVector = avec;
-  GEOSX_LAI_CHECK_ERROR( VecRestoreArray( m_vec, &avec ) );
-  return localVector;
-}
-
-globalIndex PetscVector::ilower() const
-{
-  GEOSX_LAI_ASSERT( created() );
-  PetscInt low, high;
-  GEOSX_LAI_CHECK_ERROR( VecGetOwnershipRange( m_vec, &low, &high ) );
-  return low;
-}
-
-globalIndex PetscVector::iupper() const
-{
-  GEOSX_LAI_ASSERT( created() );
-  PetscInt low, high;
-  GEOSX_LAI_CHECK_ERROR( VecGetOwnershipRange( m_vec, &low, &high ) );
-  return high;
 }
 
 } // end geosx

--- a/src/coreComponents/linearAlgebra/interfaces/petsc/PetscVector.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/petsc/PetscVector.cpp
@@ -50,8 +50,8 @@ PetscVector & PetscVector::operator=( PetscVector const & src )
     reset();
     if( src.created() )
     {
-      GEOSX_LAI_CHECK_ERROR( VecDuplicate( src.m_vec, &m_vec ) );
-      GEOSX_LAI_CHECK_ERROR( VecCopy( src.m_vec, m_vec ) );
+      create( src.localSize(), src.getComm() );
+      copy( src );
     }
   }
   return *this;

--- a/src/coreComponents/linearAlgebra/interfaces/petsc/PetscVector.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/petsc/PetscVector.cpp
@@ -61,8 +61,9 @@ PetscVector & PetscVector::operator=( PetscVector && src ) noexcept
 {
   if( &src != this )
   {
-    std::swap( m_vec, src.m_vec );
-    std::swap( m_closed, src.m_closed );
+    m_vec = src.m_vec;
+    src.m_vec = nullptr;
+    VectorBase::operator=( std::move( src ) );
   }
   return *this;
 }

--- a/src/coreComponents/linearAlgebra/interfaces/petsc/PetscVector.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/petsc/PetscVector.cpp
@@ -86,8 +86,8 @@ void PetscVector::reset()
 void PetscVector::create( localIndex const localSize, MPI_Comm const & comm )
 {
   VectorBase::create( localSize, comm );
-  m_data.move( LvArray::MemorySpace::host, false );
-  GEOSX_LAI_CHECK_ERROR( VecCreateMPIWithArray( comm, 1, localSize, PETSC_DETERMINE, m_data.data(), &m_vec ) );
+  m_values.move( LvArray::MemorySpace::host, false );
+  GEOSX_LAI_CHECK_ERROR( VecCreateMPIWithArray( comm, 1, localSize, PETSC_DETERMINE, m_values.data(), &m_vec ) );
 }
 
 bool PetscVector::created() const
@@ -125,14 +125,14 @@ void PetscVector::rand( unsigned const seed )
 void PetscVector::close()
 {
   GEOSX_LAI_ASSERT( !closed() );
-  m_data.move( LvArray::MemorySpace::host, false );
+  m_values.move( LvArray::MemorySpace::host, false );
   m_closed = true;
 }
 
 void PetscVector::touch()
 {
   GEOSX_LAI_ASSERT( ready() );
-  m_data.registerTouch( LvArray::MemorySpace::host );
+  m_values.registerTouch( LvArray::MemorySpace::host );
 }
 
 void PetscVector::scale( real64 const scalingFactor )

--- a/src/coreComponents/linearAlgebra/interfaces/petsc/PetscVector.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/petsc/PetscVector.cpp
@@ -50,7 +50,7 @@ PetscVector & PetscVector::operator=( PetscVector const & src )
     reset();
     if( src.created() )
     {
-      create( src.localSize(), src.getComm() );
+      create( src.localSize(), src.comm() );
       copy( src );
     }
   }
@@ -330,7 +330,7 @@ void PetscVector::write( string const & filename,
   if( !useMatrixMarket )
   {
     PetscViewer viewer;
-    GEOSX_LAI_CHECK_ERROR( PetscViewerASCIIOpen( getComm(), filename.c_str(), &viewer ) );
+    GEOSX_LAI_CHECK_ERROR( PetscViewerASCIIOpen( comm(), filename.c_str(), &viewer ) );
     GEOSX_LAI_CHECK_ERROR( PetscViewerPushFormat( viewer, petscFormat ) );
     GEOSX_LAI_CHECK_ERROR( VecView( m_vec, viewer ) );
     GEOSX_LAI_CHECK_ERROR( PetscViewerDestroy( &viewer ) );
@@ -342,7 +342,7 @@ void PetscVector::write( string const & filename,
     GEOSX_LAI_CHECK_ERROR( VecScatterCreateToAll( m_vec, &scatter, &globalVec ) );
     GEOSX_LAI_CHECK_ERROR( VecScatterBegin( scatter, m_vec, globalVec, INSERT_VALUES, SCATTER_FORWARD ) );
     GEOSX_LAI_CHECK_ERROR( VecScatterEnd( scatter, m_vec, globalVec, INSERT_VALUES, SCATTER_FORWARD ) );
-    if( MpiWrapper::commRank( getComm() ) == 0 )
+    if( MpiWrapper::commRank( comm() ) == 0 )
     {
       PetscScalar *v;
       GEOSX_LAI_CHECK_ERROR( VecGetArray( globalVec, &v ) );
@@ -375,7 +375,7 @@ Vec & PetscVector::unwrapped()
   return m_vec;
 }
 
-MPI_Comm PetscVector::getComm() const
+MPI_Comm PetscVector::comm() const
 {
   GEOSX_LAI_ASSERT( created() );
   MPI_Comm comm;

--- a/src/coreComponents/linearAlgebra/interfaces/petsc/PetscVector.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/petsc/PetscVector.hpp
@@ -177,9 +177,9 @@ public:
                       LAIOutputFormat const format = LAIOutputFormat::MATRIX_MARKET ) const override;
 
   /**
-   * @copydoc VectorBase<PetscVector>::getComm
+   * @copydoc VectorBase<PetscVector>::comm
    */
-  virtual MPI_Comm getComm() const override;
+  virtual MPI_Comm comm() const override;
 
   ///@}
 

--- a/src/coreComponents/linearAlgebra/interfaces/petsc/PetscVector.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/petsc/PetscVector.hpp
@@ -45,9 +45,6 @@ class PetscVector final : private VectorBase< PetscVector >
 {
 public:
 
-  /// Alias for PETSc vector struct pointer
-  using Vec = struct _p_Vec *;
-
   /**
    * @name Constructor/Destructor Methods
    */
@@ -96,53 +93,28 @@ public:
    */
   ///@{
 
+  using VectorBase::setName;
   using VectorBase::closed;
   using VectorBase::ready;
-  using VectorBase::extract;
+  using VectorBase::open;
+  using VectorBase::zero;
+  using VectorBase::values;
 
   /**
    * @copydoc VectorBase<PetscVector>::created
    */
   virtual bool created() const override;
 
-  virtual void createWithLocalSize( localIndex const localSize,
-                                    MPI_Comm const & comm ) override;
-
-  virtual void createWithGlobalSize( globalIndex const globalSize,
-                                     MPI_Comm const & comm ) override;
-
-  virtual void create( arrayView1d< real64 const > const & localValues,
+  virtual void create( localIndex const localSize,
                        MPI_Comm const & comm ) override;
-
-  virtual void open() override;
 
   virtual void close() override;
 
+  virtual void touch() override;
+
   virtual void reset() override;
 
-  virtual void set( globalIndex const globalRow,
-                    real64 const value ) override;
-
-  virtual void add( globalIndex const globalRow,
-                    real64 const value ) override;
-
-  virtual void set( globalIndex const * globalIndices,
-                    real64 const * values,
-                    localIndex size ) override;
-
-  virtual void add( globalIndex const * globalIndices,
-                    real64 const * values,
-                    localIndex size ) override;
-
-  virtual void set( arraySlice1d< globalIndex const > const & globalIndices,
-                    arraySlice1d< real64 const > const & values ) override;
-
-  virtual void add( arraySlice1d< globalIndex const > const & globalIndices,
-                    arraySlice1d< real64 const > const & values ) override;
-
   virtual void set( real64 const value ) override;
-
-  virtual void zero() override;
 
   virtual void rand( unsigned const seed ) override;
 
@@ -199,29 +171,10 @@ public:
    */
   virtual globalIndex iupper() const override;
 
-  virtual real64 get( globalIndex const globalRow ) const override;
-
-  void get( arraySlice1d< globalIndex const > const & globalIndices,
-            arraySlice1d< real64 > const & values ) const override;
-
   virtual void print( std::ostream & os = std::cout ) const override;
 
   virtual void write( string const & filename,
                       LAIOutputFormat const format = LAIOutputFormat::MATRIX_MARKET ) const override;
-
-  virtual localIndex getLocalRowID( globalIndex const globalRow ) const override;
-
-  virtual globalIndex getGlobalRowID( localIndex const localRow ) const override;
-
-  /**
-   * @copydoc VectorBase<PetscVector>::extractLocalVector
-   */
-  virtual real64 const * extractLocalVector() const override;
-
-  /**
-   * @copydoc VectorBase<PetscVector>::extractLocalVector
-   */
-  virtual real64 * extractLocalVector() override;
 
   /**
    * @copydoc VectorBase<PetscVector>::getComm
@@ -229,6 +182,13 @@ public:
   virtual MPI_Comm getComm() const override;
 
   ///@}
+
+private:
+
+  /// Alias for PETSc vector struct pointer
+  using Vec = struct _p_Vec *;
+
+public:
 
   /**
    * @brief Returns a const pointer to the underlying Vec.
@@ -242,7 +202,7 @@ public:
    */
   Vec & unwrapped();
 
-protected:
+private:
 
   /**
    * Pointer to underlying PETSc Vec

--- a/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraExport.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraExport.cpp
@@ -24,7 +24,7 @@
 
 #include <Epetra_Map.h>
 #include <Epetra_FECrsMatrix.h>
-#include <Epetra_FEVector.h>
+#include <Epetra_Vector.h>
 #include <Epetra_Import.h>
 
 namespace geosx
@@ -95,8 +95,9 @@ void EpetraExport::exportVector( EpetraVector const & vec,
   }
   else
   {
-    real64 const * const data = vec.extractLocalVector();
-    std::copy( data, data + vec.localSize(), values.data() );
+    arrayView1d< real64 const > const data = vec.values();
+    data.move( LvArray::MemorySpace::host, false );
+    std::copy( data.begin(), data.end(), values.data() );
   }
 }
 
@@ -113,8 +114,9 @@ void EpetraExport::importVector( arrayView1d< const real64 > const & values,
   }
   else
   {
-    real64 * const data = vec.extractLocalVector();
-    std::copy( values.data(), values.data() + vec.localSize(), data );
+    arrayView1d< real64 > const data = vec.open();
+    std::copy( values.data(), values.data() + vec.localSize(), data.begin() );
+    vec.close();
   }
 }
 

--- a/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraExport.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraExport.cpp
@@ -37,7 +37,7 @@ EpetraExport::EpetraExport( EpetraMatrix const & mat,
   : m_targetRank( targetRank )
 {
   globalIndex const numGlobalRows = mat.numGlobalRows();
-  localIndex const numLocalRows = ( m_targetRank == MpiWrapper::commRank( mat.getComm() ) ) ? numGlobalRows : 0;
+  localIndex const numLocalRows = ( m_targetRank == MpiWrapper::commRank( mat.comm() ) ) ? numGlobalRows : 0;
   m_serialMap = std::make_unique< Epetra_Map >( numGlobalRows, numLocalRows, 0, mat.unwrapped().Comm() );
   m_serialImport = std::make_unique< Epetra_Import >( *m_serialMap, mat.unwrapped().RowMap() );
 }
@@ -51,7 +51,7 @@ void EpetraExport::exportCRS( EpetraMatrix const & mat,
                               arrayView1d< real64 > const & values ) const
 {
 
-  int const rank = MpiWrapper::commRank( mat.getComm() );
+  int const rank = MpiWrapper::commRank( mat.comm() );
   Epetra_CrsMatrix const * localMatrix = &mat.unwrapped();
 
   rowOffsets.move( LvArray::MemorySpace::host, false );

--- a/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraMatrix.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraMatrix.cpp
@@ -376,6 +376,7 @@ void EpetraMatrix::apply( EpetraVector const & src,
   GEOSX_LAI_ASSERT_EQ( numGlobalCols(), src.globalSize() );
 
   GEOSX_LAI_CHECK_ERROR( m_matrix->Multiply( false, src.unwrapped(), dst.unwrapped() ) );
+  dst.touch();
 }
 
 void EpetraMatrix::applyTranspose( EpetraVector const & src,
@@ -388,6 +389,7 @@ void EpetraMatrix::applyTranspose( EpetraVector const & src,
   GEOSX_LAI_ASSERT_EQ( numGlobalRows(), src.globalSize() );
 
   GEOSX_LAI_CHECK_ERROR( m_matrix->Multiply( true, src.unwrapped(), dst.unwrapped() ) );
+  dst.touch();
 }
 
 void EpetraMatrix::multiply( EpetraMatrix const & src,
@@ -773,6 +775,7 @@ void EpetraMatrix::extractDiagonal( EpetraVector & dst ) const
   GEOSX_LAI_ASSERT_EQ( dst.localSize(), numLocalRows() );
 
   GEOSX_LAI_CHECK_ERROR( m_matrix->ExtractDiagonalCopy( dst.unwrapped() ) );
+  dst.touch();
 }
 
 namespace
@@ -863,6 +866,7 @@ void EpetraMatrix::getRowSums( EpetraVector & dst,
       break;
     }
   }
+  dst.touch();
 }
 
 void EpetraMatrix::rescaleRows( arrayView1d< globalIndex const > const & rowIndices,

--- a/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraMatrix.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraMatrix.cpp
@@ -986,7 +986,7 @@ real64 EpetraMatrix::normMax() const
   {
     maxAbsValue.max( LvArray::math::abs( values[k] ) );
   } );
-  return MpiWrapper::max( maxAbsValue.get(), getComm() );
+  return MpiWrapper::max( maxAbsValue.get(), comm() );
 }
 
 real64 EpetraMatrix::normMax( arrayView1d< globalIndex const > const & rowIndices ) const
@@ -1006,7 +1006,7 @@ real64 EpetraMatrix::normMax( arrayView1d< globalIndex const > const & rowIndice
       maxAbsValue.max( LvArray::math::abs( values[k] ) );
     }
   } );
-  return MpiWrapper::max( maxAbsValue.get(), getComm() );
+  return MpiWrapper::max( maxAbsValue.get(), comm() );
 }
 
 localIndex EpetraMatrix::getLocalRowID( globalIndex const index ) const
@@ -1035,7 +1035,7 @@ localIndex EpetraMatrix::numLocalRows() const
   return LvArray::integerConversion< localIndex >( m_matrix->RowMap().NumMyElements() );
 }
 
-MPI_Comm EpetraMatrix::getComm() const
+MPI_Comm EpetraMatrix::comm() const
 {
   GEOSX_LAI_ASSERT( created() );
 #ifdef GEOSX_USE_MPI
@@ -1089,7 +1089,7 @@ void EpetraMatrix::multiply( bool const transA,
   C.createWithLocalSize( transA ? numLocalCols() : numLocalRows(),
                          transB ? B.numLocalRows() : B.numLocalCols(),
                          1, // TODO: estimate entries per row?
-                         getComm() );
+                         comm() );
 
   GEOSX_LAI_CHECK_ERROR( EpetraExt::MatrixMatrix::Multiply( unwrapped(),
                                                             transA,

--- a/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraMatrix.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraMatrix.hpp
@@ -361,9 +361,9 @@ public:
   virtual globalIndex getGlobalRowID( localIndex const index ) const override;
 
   /**
-   * @copydoc MatrixBase<EpetraMatrix,EpetraVector>::getComm
+   * @copydoc MatrixBase<EpetraMatrix,EpetraVector>::comm
    */
-  virtual MPI_Comm getComm() const override;
+  virtual MPI_Comm comm() const override;
 
   virtual void print( std::ostream & os = std::cout ) const override;
 

--- a/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraVector.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraVector.cpp
@@ -50,9 +50,10 @@ EpetraVector & EpetraVector::operator=( EpetraVector const & src )
   if( &src != this )
   {
     reset();
-    if( src.ready() )
+    if( src.created() )
     {
-      m_vec = std::make_unique< Epetra_Vector >( *src.m_vec );
+      create( src.localSize(), src.getComm() );
+      copy( src );
     }
   }
   return *this;

--- a/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraVector.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraVector.cpp
@@ -85,8 +85,8 @@ void EpetraVector::create( localIndex const localSize,
                         LvArray::integerConversion< int >( localSize ),
                         0,
                         trilinos::EpetraComm( MPI_PARAM( comm ) ) );
-  m_data.move( LvArray::MemorySpace::host, false );
-  m_vec = std::make_unique< Epetra_Vector >( View, map, m_data.data() );
+  m_values.move( LvArray::MemorySpace::host, false );
+  m_vec = std::make_unique< Epetra_Vector >( View, map, m_values.data() );
 }
 
 void EpetraVector::set( real64 value )
@@ -107,14 +107,14 @@ void EpetraVector::rand( unsigned const seed )
 void EpetraVector::close()
 {
   GEOSX_LAI_ASSERT( !closed() );
-  m_data.move( LvArray::MemorySpace::host, false );
+  m_values.move( LvArray::MemorySpace::host, false );
   m_closed = true;
 }
 
 void EpetraVector::touch()
 {
   GEOSX_LAI_ASSERT( ready() );
-  m_data.registerTouch( LvArray::MemorySpace::host );
+  m_values.registerTouch( LvArray::MemorySpace::host );
 }
 
 void EpetraVector::reset()

--- a/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraVector.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraVector.cpp
@@ -21,7 +21,7 @@
 #include "codingUtilities/Utilities.hpp"
 #include "linearAlgebra/interfaces/trilinos/EpetraUtils.hpp"
 
-#include <Epetra_FEVector.h>
+#include <Epetra_Vector.h>
 #include <Epetra_Map.h>
 #include <EpetraExt_MultiVectorOut.h>
 
@@ -30,7 +30,7 @@ namespace geosx
 
 EpetraVector::EpetraVector()
   : VectorBase(),
-  m_vector{}
+    m_vec{}
 {}
 
 EpetraVector::EpetraVector( EpetraVector const & src )
@@ -52,7 +52,7 @@ EpetraVector & EpetraVector::operator=( EpetraVector const & src )
     reset();
     if( src.ready() )
     {
-      m_vector = std::make_unique< Epetra_FEVector >( *src.m_vector );
+      m_vec = std::make_unique< Epetra_Vector >( *src.m_vec );
     }
   }
   return *this;
@@ -62,7 +62,7 @@ EpetraVector & EpetraVector::operator=( EpetraVector && src ) noexcept
 {
   if( &src != this )
   {
-    std::swap( m_vector, src.m_vector );
+    std::swap( m_vec, src.m_vec );
     std::swap( m_closed, src.m_closed );
   }
   return *this;
@@ -72,156 +72,71 @@ EpetraVector::~EpetraVector() = default;
 
 bool EpetraVector::created() const
 {
-  return bool(m_vector);
+  return bool( m_vec);
 }
 
-void EpetraVector::createWithLocalSize( localIndex const localSize,
-                                        MPI_Comm const & MPI_PARAM( comm ) )
+void EpetraVector::create( localIndex const localSize,
+                           MPI_Comm const & MPI_PARAM( comm ) )
 {
-  GEOSX_LAI_ASSERT( closed() );
-  GEOSX_LAI_ASSERT_GE( localSize, 0 );
+  VectorBase::create( localSize, comm );
   Epetra_Map const map( LvArray::integerConversion< long long >( -1 ),
                         LvArray::integerConversion< int >( localSize ),
                         0,
                         trilinos::EpetraComm( MPI_PARAM( comm ) ) );
-  m_vector = std::make_unique< Epetra_FEVector >( map );
-}
-
-void EpetraVector::createWithGlobalSize( globalIndex const globalSize,
-                                         MPI_Comm const & MPI_PARAM( comm ) )
-{
-  GEOSX_LAI_ASSERT( closed() );
-  GEOSX_LAI_ASSERT_GE( globalSize, 0 );
-  Epetra_Map const map( LvArray::integerConversion< long long >( globalSize ),
-                        0,
-                        trilinos::EpetraComm( MPI_PARAM( comm ) ) );
-  m_vector = std::make_unique< Epetra_FEVector >( map );
-}
-
-void EpetraVector::create( arrayView1d< real64 const > const & localValues,
-                           MPI_Comm const & MPI_PARAM( comm ) )
-{
-  GEOSX_LAI_ASSERT( closed() );
-
-  localValues.move( LvArray::MemorySpace::host, false );
-
-  int const localSize = LvArray::integerConversion< int >( localValues.size() );
-  Epetra_Map const map( LvArray::integerConversion< long long >( -1 ),
-                        localSize,
-                        0,
-                        trilinos::EpetraComm( MPI_PARAM( comm ) ) );
-  m_vector = std::make_unique< Epetra_FEVector >( Copy,
-                                                  map,
-                                                  const_cast< real64 * >( localValues.data() ),
-                                                  localSize,
-                                                  1 );
-}
-
-void EpetraVector::set( globalIndex const globalRowIndex,
-                        real64 const value )
-{
-  GEOSX_LAI_ASSERT( !closed() );
-  GEOSX_LAI_CHECK_ERROR( m_vector->ReplaceGlobalValues( 1, trilinos::toEpetraLongLong( &globalRowIndex ), &value ) );
-}
-
-void EpetraVector::add( globalIndex const globalRowIndex,
-                        real64 const value )
-{
-  GEOSX_LAI_ASSERT( !closed() );
-  GEOSX_LAI_CHECK_ERROR( m_vector->SumIntoGlobalValues( 1, trilinos::toEpetraLongLong( &globalRowIndex ), &value ) );
-}
-
-void EpetraVector::set( globalIndex const * globalRowIndices,
-                        real64 const * values,
-                        localIndex const size )
-{
-  GEOSX_LAI_ASSERT( !closed() );
-  GEOSX_LAI_CHECK_ERROR( m_vector->ReplaceGlobalValues( LvArray::integerConversion< int >( size ),
-                                                        trilinos::toEpetraLongLong( globalRowIndices ),
-                                                        values ) );
-}
-
-void EpetraVector::add( globalIndex const * globalRowIndices,
-                        real64 const * values,
-                        localIndex const size )
-{
-  GEOSX_LAI_ASSERT( !closed() );
-  GEOSX_LAI_CHECK_ERROR( m_vector->SumIntoGlobalValues( LvArray::integerConversion< int >( size ),
-                                                        trilinos::toEpetraLongLong( globalRowIndices ),
-                                                        values ) );
-}
-
-void EpetraVector::set( arraySlice1d< globalIndex const > const & globalRowIndices,
-                        arraySlice1d< real64 const > const & values )
-{
-  GEOSX_LAI_ASSERT( !closed() );
-  GEOSX_LAI_CHECK_ERROR( m_vector->ReplaceGlobalValues( LvArray::integerConversion< int >( values.size() ),
-                                                        trilinos::toEpetraLongLong( globalRowIndices.dataIfContiguous() ),
-                                                        values.dataIfContiguous() ) );
-}
-
-void EpetraVector::add( arraySlice1d< globalIndex const > const & globalRowIndices,
-                        arraySlice1d< real64 const > const & values )
-{
-  GEOSX_LAI_ASSERT( !closed() );
-  GEOSX_LAI_CHECK_ERROR( m_vector->SumIntoGlobalValues( LvArray::integerConversion< int >( values.size() ),
-                                                        trilinos::toEpetraLongLong( globalRowIndices.dataIfContiguous() ),
-                                                        values.dataIfContiguous() ) );
+  m_data.move( LvArray::MemorySpace::host, false );
+  m_vec = std::make_unique< Epetra_Vector >( View, map, m_data.data() );
 }
 
 void EpetraVector::set( real64 value )
 {
   GEOSX_LAI_ASSERT( ready() );
-  GEOSX_LAI_CHECK_ERROR( m_vector->PutScalar( value ) );
-}
-
-void EpetraVector::zero()
-{
-  set( 0.0 );
+  GEOSX_LAI_CHECK_ERROR( m_vec->PutScalar( value ) );
+  touch();
 }
 
 void EpetraVector::rand( unsigned const seed )
 {
   GEOSX_LAI_ASSERT( ready() );
-  GEOSX_LAI_CHECK_ERROR( m_vector->SetSeed( seed ) );
-  GEOSX_LAI_CHECK_ERROR( m_vector->Random() );
-}
-
-void EpetraVector::open()
-{
-  GEOSX_LAI_ASSERT( ready() );
-  m_closed = false;
+  GEOSX_LAI_CHECK_ERROR( m_vec->SetSeed( seed ) );
+  GEOSX_LAI_CHECK_ERROR( m_vec->Random() );
+  touch();
 }
 
 void EpetraVector::close()
 {
   GEOSX_LAI_ASSERT( !closed() );
-  GEOSX_LAI_CHECK_ERROR( m_vector->GlobalAssemble() );
+  m_data.move( LvArray::MemorySpace::host, false );
   m_closed = true;
+}
+
+void EpetraVector::touch()
+{
+  GEOSX_LAI_ASSERT( ready() );
+  m_data.registerTouch( LvArray::MemorySpace::host );
 }
 
 void EpetraVector::reset()
 {
   VectorBase::reset();
-  m_vector.reset();
+  m_vec.reset();
 }
 
 void EpetraVector::scale( real64 const scalingFactor )
 {
   GEOSX_LAI_ASSERT( ready() );
 
-  if( isEqual( scalingFactor, 1.0 ) )
+  if( !isEqual( scalingFactor, 1.0 ) )
   {
-    return;
+    GEOSX_LAI_CHECK_ERROR( m_vec->Scale( scalingFactor ) );
+    touch();
   }
-
-  GEOSX_LAI_CHECK_ERROR( m_vector->Scale( scalingFactor ) );
 }
 
 void EpetraVector::reciprocal()
 {
   GEOSX_LAI_ASSERT( ready() );
-  GEOSX_LAI_CHECK_ERROR( m_vector->Reciprocal( *m_vector ) );
+  GEOSX_LAI_CHECK_ERROR( m_vec->Reciprocal( *m_vec ) );
+  touch();
 }
 
 real64 EpetraVector::dot( EpetraVector const & vec ) const
@@ -231,7 +146,7 @@ real64 EpetraVector::dot( EpetraVector const & vec ) const
   GEOSX_LAI_ASSERT_EQ( globalSize(), vec.globalSize() );
 
   real64 tmp;
-  GEOSX_LAI_CHECK_ERROR( m_vector->Dot( vec.unwrapped(), &tmp ) );
+  GEOSX_LAI_CHECK_ERROR( m_vec->Dot( vec.unwrapped(), &tmp ) );
   return tmp;
 }
 
@@ -241,7 +156,8 @@ void EpetraVector::copy( EpetraVector const & x )
   GEOSX_LAI_ASSERT( x.ready() );
   GEOSX_LAI_ASSERT_EQ( globalSize(), x.globalSize() );
 
-  GEOSX_LAI_CHECK_ERROR( m_vector->Update( 1., x.unwrapped(), 0. ) );
+  GEOSX_LAI_CHECK_ERROR( m_vec->Update( 1., x.unwrapped(), 0. ) );
+  touch();
 }
 
 void EpetraVector::axpy( real64 const alpha,
@@ -251,7 +167,8 @@ void EpetraVector::axpy( real64 const alpha,
   GEOSX_LAI_ASSERT( x.ready() );
   GEOSX_LAI_ASSERT_EQ( globalSize(), x.globalSize() );
 
-  GEOSX_LAI_CHECK_ERROR( m_vector->Update( alpha, x.unwrapped(), 1. ) );
+  GEOSX_LAI_CHECK_ERROR( m_vec->Update( alpha, x.unwrapped(), 1. ) );
+  touch();
 }
 
 void EpetraVector::axpby( real64 const alpha,
@@ -262,7 +179,8 @@ void EpetraVector::axpby( real64 const alpha,
   GEOSX_LAI_ASSERT( x.ready() );
   GEOSX_LAI_ASSERT_EQ( globalSize(), x.globalSize() );
 
-  GEOSX_LAI_CHECK_ERROR( m_vector->Update( alpha, x.unwrapped(), beta ) );
+  GEOSX_LAI_CHECK_ERROR( m_vec->Update( alpha, x.unwrapped(), beta ) );
+  touch();
 }
 
 void EpetraVector::pointwiseProduct( EpetraVector const & x,
@@ -275,6 +193,7 @@ void EpetraVector::pointwiseProduct( EpetraVector const & x,
   GEOSX_LAI_ASSERT_EQ( globalSize(), y.globalSize() );
 
   GEOSX_LAI_CHECK_ERROR( ( y.unwrapped() ).Multiply( 1.0, unwrapped(), x.unwrapped(), 0.0 ) );
+  y.touch();
 }
 
 real64 EpetraVector::norm1() const
@@ -282,7 +201,7 @@ real64 EpetraVector::norm1() const
   GEOSX_LAI_ASSERT( ready() );
 
   real64 tmp;
-  m_vector->Norm1( &tmp );
+  m_vec->Norm1( &tmp );
   return tmp;
 }
 
@@ -290,7 +209,7 @@ real64 EpetraVector::norm2() const
 {
   GEOSX_LAI_ASSERT( ready() );
   real64 tmp;
-  m_vector->Norm2( &tmp );
+  m_vec->Norm2( &tmp );
   return tmp;
 }
 
@@ -298,14 +217,14 @@ real64 EpetraVector::normInf() const
 {
   GEOSX_LAI_ASSERT( ready() );
   real64 tmp;
-  m_vector->NormInf( &tmp );
+  m_vec->NormInf( &tmp );
   return tmp;
 }
 
 void EpetraVector::print( std::ostream & os ) const
 {
   GEOSX_LAI_ASSERT( ready() );
-  m_vector->Print( os );
+  m_vec->Print( os );
 }
 
 void EpetraVector::write( string const & filename,
@@ -316,12 +235,12 @@ void EpetraVector::write( string const & filename,
   {
     case LAIOutputFormat::MATLAB_ASCII:
     {
-      GEOSX_LAI_CHECK_ERROR( EpetraExt::MultiVectorToMatlabFile( filename.c_str(), *m_vector ) );
+      GEOSX_LAI_CHECK_ERROR( EpetraExt::MultiVectorToMatlabFile( filename.c_str(), *m_vec ) );
       break;
     }
     case LAIOutputFormat::MATRIX_MARKET:
     {
-      GEOSX_LAI_CHECK_ERROR( EpetraExt::MultiVectorToMatrixMarketFile( filename.c_str(), *m_vector ) );
+      GEOSX_LAI_CHECK_ERROR( EpetraExt::MultiVectorToMatrixMarketFile( filename.c_str(), *m_vec ) );
       break;
     }
     default:
@@ -329,104 +248,47 @@ void EpetraVector::write( string const & filename,
   }
 }
 
-real64 EpetraVector::get( globalIndex globalRow ) const
-{
-  GEOSX_LAI_ASSERT( ready() );
-  GEOSX_LAI_ASSERT_GE( globalRow, ilower() );
-  GEOSX_LAI_ASSERT_GT( iupper(), globalRow );
-
-  return extractLocalVector()[getLocalRowID( globalRow )];
-}
-
-void EpetraVector::get( arraySlice1d< globalIndex const > const & globalIndices,
-                        arraySlice1d< real64 > const & values ) const
-{
-  GEOSX_LAI_ASSERT( ready() );
-  GEOSX_LAI_ASSERT_GE( values.size(), globalIndices.size() );
-  GEOSX_LAI_ASSERT_GE( *std::min_element( globalIndices.dataIfContiguous(), globalIndices.dataIfContiguous() + globalIndices.size() ), ilower() );
-  GEOSX_LAI_ASSERT_GT( iupper(), *std::max_element( globalIndices.dataIfContiguous(),
-                                                    globalIndices.dataIfContiguous() + globalIndices.size() ) );
-
-  real64 const * const localVector = extractLocalVector();
-  for( localIndex i = 0; i < globalIndices.size(); ++i )
-  {
-    values[i] = localVector[getLocalRowID( globalIndices[i] )];
-  }
-}
-
-Epetra_FEVector const & EpetraVector::unwrapped() const
+Epetra_Vector const & EpetraVector::unwrapped() const
 {
   GEOSX_LAI_ASSERT( created() );
-  return *m_vector;
+  return *m_vec;
 }
 
-Epetra_FEVector & EpetraVector::unwrapped()
+Epetra_Vector & EpetraVector::unwrapped()
 {
   GEOSX_LAI_ASSERT( created() );
-  return *m_vector;
+  return *m_vec;
 }
 
 globalIndex EpetraVector::globalSize() const
 {
   GEOSX_LAI_ASSERT( created() );
-  return m_vector->GlobalLength64();
+  return m_vec->GlobalLength64();
 }
 
 localIndex EpetraVector::localSize() const
 {
   GEOSX_LAI_ASSERT( created() );
-  return m_vector->MyLength();
-}
-
-localIndex EpetraVector::getLocalRowID( globalIndex const globalRow ) const
-{
-  GEOSX_LAI_ASSERT( created() );
-  return m_vector->Map().LID( LvArray::integerConversion< long long >( globalRow ) );
-}
-
-globalIndex EpetraVector::getGlobalRowID( localIndex const localRow ) const
-{
-  GEOSX_LAI_ASSERT( created() );
-  GEOSX_LAI_ASSERT_GE( localRow, 0 );
-  GEOSX_LAI_ASSERT_GT( localSize(), localRow );
-  return m_vector->Map().GID64( LvArray::integerConversion< int >( localRow ) );
-}
-
-real64 const * EpetraVector::extractLocalVector() const
-{
-  GEOSX_LAI_ASSERT( ready() );
-  int dummy;
-  double * localVector;
-  GEOSX_LAI_CHECK_ERROR( m_vector->ExtractView( &localVector, &dummy ) );
-  return localVector;
-}
-
-real64 * EpetraVector::extractLocalVector()
-{
-  GEOSX_LAI_ASSERT( ready() );
-  int dummy;
-  double * localVector;
-  GEOSX_LAI_CHECK_ERROR( m_vector->ExtractView( &localVector, &dummy ) );
-  return localVector;
+  return m_vec->MyLength();
 }
 
 globalIndex EpetraVector::ilower() const
 {
   GEOSX_LAI_ASSERT( created() );
-  return m_vector->Map().MinMyGID64();
+  return m_vec->Map().MinMyGID64();
 }
 
 globalIndex EpetraVector::iupper() const
 {
   GEOSX_LAI_ASSERT( created() );
-  return m_vector->Map().MaxMyGID64() + 1;
+  return m_vec->Map().MaxMyGID64() + 1;
 }
 
 MPI_Comm EpetraVector::getComm() const
 {
   GEOSX_LAI_ASSERT( created() );
 #ifdef GEOSX_USE_MPI
-  return dynamicCast< Epetra_MpiComm const & >( m_vector->Map().Comm() ).Comm();
+  return dynamicCast< Epetra_MpiComm const & >( m_vec->Map().Comm() ).Comm();
 #else
   return MPI_COMM_GEOSX;
 #endif

--- a/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraVector.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraVector.cpp
@@ -52,7 +52,7 @@ EpetraVector & EpetraVector::operator=( EpetraVector const & src )
     reset();
     if( src.created() )
     {
-      create( src.localSize(), src.getComm() );
+      create( src.localSize(), src.comm() );
       copy( src );
     }
   }
@@ -286,7 +286,7 @@ globalIndex EpetraVector::iupper() const
   return m_vec->Map().MaxMyGID64() + 1;
 }
 
-MPI_Comm EpetraVector::getComm() const
+MPI_Comm EpetraVector::comm() const
 {
   GEOSX_LAI_ASSERT( created() );
 #ifdef GEOSX_USE_MPI

--- a/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraVector.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraVector.cpp
@@ -30,7 +30,7 @@ namespace geosx
 
 EpetraVector::EpetraVector()
   : VectorBase(),
-    m_vec{}
+  m_vec{}
 {}
 
 EpetraVector::EpetraVector( EpetraVector const & src )
@@ -62,8 +62,9 @@ EpetraVector & EpetraVector::operator=( EpetraVector && src ) noexcept
 {
   if( &src != this )
   {
-    std::swap( m_vec, src.m_vec );
-    std::swap( m_closed, src.m_closed );
+    m_vec = std::move( src.m_vec );
+    src.m_vec = nullptr;
+    VectorBase::operator=( std::move( src ) );
   }
   return *this;
 }

--- a/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraVector.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraVector.hpp
@@ -161,9 +161,9 @@ public:
   virtual globalIndex iupper() const override;
 
   /**
-   * @copydoc VectorBase<EpetraVector>::getComm
+   * @copydoc VectorBase<EpetraVector>::comm
    */
-  virtual MPI_Comm getComm() const override;
+  virtual MPI_Comm comm() const override;
 
   virtual void print( std::ostream & os = std::cout ) const override;
 

--- a/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraVector.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraVector.hpp
@@ -21,15 +21,13 @@
 
 #include "linearAlgebra/interfaces/VectorBase.hpp"
 
-class Epetra_FEVector;
+class Epetra_Vector;
 
 namespace geosx
 {
 
 /**
- * @brief This class creates and provides basic support for the Epetra_FEVector
- *        vector object type used in Trilinos.  We use the FE version because
- *        Epetra_Vector support for long globalIDs is haphazard.
+ * @brief Wrapper around Trilinos' Epetra_Vector object.
  */
 class EpetraVector final : private VectorBase< EpetraVector >
 {
@@ -84,53 +82,28 @@ public:
    */
   ///@{
 
+  using VectorBase::setName;
   using VectorBase::closed;
   using VectorBase::ready;
-  using VectorBase::extract;
+  using VectorBase::open;
+  using VectorBase::zero;
+  using VectorBase::values;
 
   /**
    * @copydoc VectorBase<EpetraVector>::created
    */
   virtual bool created() const override;
 
-  virtual void createWithLocalSize( localIndex const localSize,
-                                    MPI_Comm const & comm ) override;
-
-  virtual void createWithGlobalSize( globalIndex const globalSize,
-                                     MPI_Comm const & comm ) override;
-
-  virtual void create( arrayView1d< real64 const > const & localValues,
+  virtual void create( localIndex const localSize,
                        MPI_Comm const & comm ) override;
-
-  virtual void open() override;
 
   virtual void close() override;
 
+  virtual void touch() override;
+
   virtual void reset() override;
 
-  virtual void set( globalIndex const globalRowIndex,
-                    real64 const value ) override;
-
-  virtual void add( globalIndex const globalRowIndex,
-                    real64 const value ) override;
-
-  virtual void set( globalIndex const * globalRowIndices,
-                    real64 const * values,
-                    localIndex size ) override;
-
-  virtual void add( globalIndex const * globalRowIndices,
-                    real64 const * values,
-                    localIndex const size ) override;
-
-  virtual void set( arraySlice1d< globalIndex const > const & globalRowIndices,
-                    arraySlice1d< real64 const > const & values ) override;
-
-  virtual void add( arraySlice1d< globalIndex const > const & globalRowIndices,
-                    arraySlice1d< real64 const > const & values ) override;
-
   virtual void set( real64 const value ) override;
-
-  virtual void zero() override;
 
   virtual void rand( unsigned const seed ) override;
 
@@ -187,25 +160,6 @@ public:
    */
   virtual globalIndex iupper() const override;
 
-  virtual real64 get( globalIndex globalRow ) const override;
-
-  virtual void get( arraySlice1d< globalIndex const > const & globalIndices,
-                    arraySlice1d< real64 > const & values ) const override;
-
-  virtual localIndex getLocalRowID( globalIndex const globalRow ) const override;
-
-  virtual globalIndex getGlobalRowID( localIndex const localRow ) const override;
-
-  /**
-   * @copydoc VectorBase<EpetraVector>::extractLocalVector
-   */
-  virtual real64 const * extractLocalVector() const override;
-
-  /**
-   * @copydoc VectorBase<EpetraVector>::extractLocalVector
-   */
-  virtual real64 * extractLocalVector() override;
-
   /**
    * @copydoc VectorBase<EpetraVector>::getComm
    */
@@ -222,18 +176,18 @@ public:
    * @brief Returns a const pointer to the underlying Epetra object.
    * @return const pointer to the underlying Epetra object
    */
-  Epetra_FEVector const & unwrapped() const;
+  Epetra_Vector const & unwrapped() const;
 
   /**
    * @brief Returns a non-const pointer to the underlying Epetra object.
    * @return non-const pointer to the underlying Epetra object
    */
-  Epetra_FEVector & unwrapped();
+  Epetra_Vector & unwrapped();
 
 private:
 
   /// Unique pointer to underlying Epetra_FEVector object.
-  std::unique_ptr< Epetra_FEVector > m_vector;
+  std::unique_ptr< Epetra_Vector > m_vec;
 };
 
 } // end geosx namespace

--- a/src/coreComponents/linearAlgebra/interfaces/trilinos/TrilinosSolver.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/trilinos/TrilinosSolver.cpp
@@ -119,9 +119,11 @@ int TrilinosSolver::doSolve( EpetraVector const & rhs,
   GEOSX_LAI_ASSERT( rhs.ready() );
 
   // HACK: Epetra is not const-correct, so we need the cast. The vector is not actually modified.
-  GEOSX_LAI_CHECK_ERROR( m_solver->SetRHS( &const_cast< Epetra_FEVector & >( rhs.unwrapped() ) ) );
+  GEOSX_LAI_CHECK_ERROR( m_solver->SetRHS( &const_cast< Epetra_Vector & >( rhs.unwrapped() ) ) );
   GEOSX_LAI_CHECK_ERROR( m_solver->SetLHS( &sol.unwrapped() ) );
-  return m_solver->Iterate( m_params.krylov.maxIterations, m_params.krylov.relTolerance );
+  int const result = m_solver->Iterate( m_params.krylov.maxIterations, m_params.krylov.relTolerance );
+  sol.touch();
+  return result;
 }
 
 void TrilinosSolver::apply( EpetraVector const & rhs,

--- a/src/coreComponents/linearAlgebra/solvers/BlockPreconditioner.cpp
+++ b/src/coreComponents/linearAlgebra/solvers/BlockPreconditioner.cpp
@@ -47,7 +47,7 @@ BlockPreconditioner< LAI >::~BlockPreconditioner() = default;
 template< typename LAI >
 void BlockPreconditioner< LAI >::reinitialize( Matrix const & mat, DofManager const & dofManager )
 {
-  MPI_Comm const & comm = mat.getComm();
+  MPI_Comm const & comm = mat.comm();
 
   if( m_blockDofs[1].empty() )
   {

--- a/src/coreComponents/linearAlgebra/solvers/BlockPreconditioner.cpp
+++ b/src/coreComponents/linearAlgebra/solvers/BlockPreconditioner.cpp
@@ -58,8 +58,8 @@ void BlockPreconditioner< LAI >::reinitialize( Matrix const & mat, DofManager co
   {
     dofManager.makeRestrictor( m_blockDofs[i], comm, false, m_restrictors[i] );
     dofManager.makeRestrictor( m_blockDofs[i], comm, true, m_prolongators[i] );
-    m_rhs( i ).createWithLocalSize( m_restrictors[i].numLocalRows(), comm );
-    m_sol( i ).createWithLocalSize( m_restrictors[i].numLocalRows(), comm );
+    m_rhs( i ).create( m_restrictors[i].numLocalRows(), comm );
+    m_sol( i ).create( m_restrictors[i].numLocalRows(), comm );
   }
 }
 

--- a/src/coreComponents/linearAlgebra/solvers/KrylovSolver.hpp
+++ b/src/coreComponents/linearAlgebra/solvers/KrylovSolver.hpp
@@ -104,9 +104,9 @@ public:
     return m_operator.numLocalCols();
   }
 
-  virtual MPI_Comm getComm() const override final
+  virtual MPI_Comm comm() const override final
   {
-    return m_operator.getComm();
+    return m_operator.comm();
   }
 
   /**
@@ -152,7 +152,7 @@ private:
     static VEC createFrom( VEC const & src )
     {
       VEC v;
-      v.create( src.localSize(), src.getComm() );
+      v.create( src.localSize(), src.comm() );
       return v;
     }
   };
@@ -167,7 +167,7 @@ private:
       BlockVector< VEC > v( src.blockSize() );
       for( localIndex i = 0; i < src.blockSize(); ++i )
       {
-        v.block( i ).create( src.block( i ).localSize(), src.block( i ).getComm() );
+        v.block( i ).create( src.block( i ).localSize(), src.block( i ).comm() );
       }
       return v;
     }

--- a/src/coreComponents/linearAlgebra/solvers/KrylovSolver.hpp
+++ b/src/coreComponents/linearAlgebra/solvers/KrylovSolver.hpp
@@ -152,7 +152,7 @@ private:
     static VEC createFrom( VEC const & src )
     {
       VEC v;
-      v.createWithLocalSize( src.localSize(), src.getComm() );
+      v.create( src.localSize(), src.getComm() );
       return v;
     }
   };
@@ -167,7 +167,7 @@ private:
       BlockVector< VEC > v( src.blockSize() );
       for( localIndex i = 0; i < src.blockSize(); ++i )
       {
-        v.block( i ).createWithLocalSize( src.block( i ).localSize(), src.block( i ).getComm() );
+        v.block( i ).create( src.block( i ).localSize(), src.block( i ).getComm() );
       }
       return v;
     }

--- a/src/coreComponents/linearAlgebra/solvers/PreconditionerBlockJacobi.hpp
+++ b/src/coreComponents/linearAlgebra/solvers/PreconditionerBlockJacobi.hpp
@@ -63,7 +63,7 @@ public:
 
     PreconditionerBase< LAI >::setup( mat );
 
-    m_blockDiag.createWithLocalSize( mat.numLocalRows(), mat.numLocalCols(), m_blockSize, mat.getComm() );
+    m_blockDiag.createWithLocalSize( mat.numLocalRows(), mat.numLocalCols(), m_blockSize, mat.comm() );
     m_blockDiag.open();
 
     array1d< globalIndex > idxBlk( m_blockSize );

--- a/src/coreComponents/linearAlgebra/solvers/PreconditionerJacobi.hpp
+++ b/src/coreComponents/linearAlgebra/solvers/PreconditionerJacobi.hpp
@@ -46,7 +46,7 @@ public:
   virtual void setup( Matrix const & mat ) override
   {
     GEOSX_LAI_ASSERT( mat.ready() );
-    m_diagInv.createWithLocalSize( mat.numLocalRows(), mat.getComm() );
+    m_diagInv.createWithLocalSize( mat.numLocalRows(), mat.comm() );
     mat.extractDiagonal( m_diagInv );
     m_diagInv.reciprocal();
   }

--- a/src/coreComponents/linearAlgebra/unitTests/testExternalSolvers.cpp
+++ b/src/coreComponents/linearAlgebra/unitTests/testExternalSolvers.cpp
@@ -107,17 +107,17 @@ protected:
   {
     // Create a random "true" solution vector
     Vector sol_true;
-    sol_true.createWithLocalSize( matrix.numLocalCols(), matrix.getComm() );
+    sol_true.create( matrix.numLocalCols(), matrix.getComm() );
     sol_true.rand( 1984 );
 
     // Create and compute the right-hand side vector
     Vector rhs;
-    rhs.createWithLocalSize( matrix.numLocalRows(), matrix.getComm() );
+    rhs.create( matrix.numLocalRows(), matrix.getComm() );
     matrix.apply( sol_true, rhs );
 
     // Create and zero out the computed solution vector
     Vector sol_comp;
-    sol_comp.createWithLocalSize( sol_true.localSize(), sol_true.getComm() );
+    sol_comp.create( sol_true.localSize(), sol_true.getComm() );
     sol_comp.zero();
 
     // Create the solver and solve the system

--- a/src/coreComponents/linearAlgebra/unitTests/testExternalSolvers.cpp
+++ b/src/coreComponents/linearAlgebra/unitTests/testExternalSolvers.cpp
@@ -107,17 +107,17 @@ protected:
   {
     // Create a random "true" solution vector
     Vector sol_true;
-    sol_true.create( matrix.numLocalCols(), matrix.getComm() );
+    sol_true.create( matrix.numLocalCols(), matrix.comm() );
     sol_true.rand( 1984 );
 
     // Create and compute the right-hand side vector
     Vector rhs;
-    rhs.create( matrix.numLocalRows(), matrix.getComm() );
+    rhs.create( matrix.numLocalRows(), matrix.comm() );
     matrix.apply( sol_true, rhs );
 
     // Create and zero out the computed solution vector
     Vector sol_comp;
-    sol_comp.create( sol_true.localSize(), sol_true.getComm() );
+    sol_comp.create( sol_true.localSize(), sol_true.comm() );
     sol_comp.zero();
 
     // Create the solver and solve the system

--- a/src/coreComponents/linearAlgebra/unitTests/testKrylovSolvers.cpp
+++ b/src/coreComponents/linearAlgebra/unitTests/testKrylovSolvers.cpp
@@ -127,9 +127,9 @@ protected:
     this->precond.setup( this->matrix );
 
     // Set up vectors
-    this->sol_true.createWithGlobalSize( this->matrix.numGlobalCols(), MPI_COMM_GEOSX );
-    this->sol_comp.createWithGlobalSize( this->matrix.numGlobalCols(), MPI_COMM_GEOSX );
-    this->rhs_true.createWithGlobalSize( this->matrix.numGlobalRows(), MPI_COMM_GEOSX );
+    this->sol_true.create( this->matrix.numLocalCols(), MPI_COMM_GEOSX );
+    this->sol_comp.create( this->matrix.numLocalCols(), MPI_COMM_GEOSX );
+    this->rhs_true.create( this->matrix.numLocalRows(), MPI_COMM_GEOSX );
 
     // Condition number for the Laplacian matrix estimate: 4 * n^2 / pi^2
     this->cond_est = 1.5 * 4.0 * n * n / std::pow( M_PI, 2 );
@@ -216,9 +216,9 @@ protected:
 
     for( localIndex i = 0; i < 2; ++i )
     {
-      this->sol_true.block( i ).createWithGlobalSize( laplace2D.numGlobalCols(), MPI_COMM_GEOSX );
-      this->sol_comp.block( i ).createWithGlobalSize( laplace2D.numGlobalCols(), MPI_COMM_GEOSX );
-      this->rhs_true.block( i ).createWithGlobalSize( laplace2D.numGlobalRows(), MPI_COMM_GEOSX );
+      this->sol_true.block( i ).create( laplace2D.numLocalCols(), MPI_COMM_GEOSX );
+      this->sol_comp.block( i ).create( laplace2D.numLocalCols(), MPI_COMM_GEOSX );
+      this->rhs_true.block( i ).create( laplace2D.numLocalRows(), MPI_COMM_GEOSX );
     }
 
     // Condition number for the Laplacian matrix estimate: 4 * n^2 / pi^2

--- a/src/coreComponents/linearAlgebra/unitTests/testVectors.cpp
+++ b/src/coreComponents/linearAlgebra/unitTests/testVectors.cpp
@@ -101,7 +101,7 @@ void compareVectors( VEC const & x,
     return;
   }
 
-  EXPECT_TRUE( MpiWrapper::commCompare( y.getComm(), x.getComm() ) );
+  EXPECT_TRUE( MpiWrapper::commCompare( y.comm(), x.comm() ) );
   EXPECT_EQ( y.localSize(), x.localSize() );
   EXPECT_EQ( y.globalSize(), x.globalSize() );
 
@@ -138,7 +138,7 @@ TYPED_TEST_P( VectorTest, create )
   x.create( localSize, comm );
 
   EXPECT_TRUE( x.ready() );
-  EXPECT_TRUE( MpiWrapper::commCompare( x.getComm(), comm ) );
+  EXPECT_TRUE( MpiWrapper::commCompare( x.comm(), comm ) );
   EXPECT_EQ( x.localSize(), localSize );
   EXPECT_EQ( x.globalSize(), globalSize );
   EXPECT_EQ( x.ilower(), rankOffset );
@@ -178,7 +178,7 @@ TYPED_TEST_P( VectorTest, moveConstruction )
   Vector y( std::move( x ) );
 
   EXPECT_TRUE( y.ready() );
-  EXPECT_TRUE( MpiWrapper::commCompare( y.getComm(), MPI_COMM_GEOSX ) );
+  EXPECT_TRUE( MpiWrapper::commCompare( y.comm(), MPI_COMM_GEOSX ) );
   EXPECT_EQ( y.localSize(), localSize );
   EXPECT_EQ( y.globalSize(), globalSize );
   compareValues( y.values(), values );
@@ -192,7 +192,7 @@ TYPED_TEST_P( VectorTest, copy )
   createAndAssemble< parallelDevicePolicy<> >( 3, x );
 
   Vector y;
-  y.create( x.localSize(), x.getComm() );
+  y.create( x.localSize(), x.comm() );
   y.copy( x );
 
   compareVectors( x, y );

--- a/src/coreComponents/linearAlgebra/utilities/Arnoldi.hpp
+++ b/src/coreComponents/linearAlgebra/utilities/Arnoldi.hpp
@@ -44,13 +44,13 @@ real64 ArnoldiLargestEigenvalue( LinearOperator< VECTOR > const & op, localIndex
   array1d< VECTOR > V( mInternal + 1 );
 
   // Initial unitary vector
-  V[0].createWithLocalSize( numLocalRows, op.getComm() );
+  V[0].create( numLocalRows, op.getComm() );
   V[0].set( 1.0 / sqrt( static_cast< real64 >( numGlobalRows ) ) );
 
   for( localIndex j = 0; j < mInternal; ++j )
   {
     // Apply operator
-    V[j+1].createWithLocalSize( numLocalRows, op.getComm() );
+    V[j+1].create( numLocalRows, op.getComm() );
     op.apply( V[j], V[j+1] );
     // Arnoldi process
     for( localIndex i = 0; i <= j; ++i )

--- a/src/coreComponents/linearAlgebra/utilities/Arnoldi.hpp
+++ b/src/coreComponents/linearAlgebra/utilities/Arnoldi.hpp
@@ -44,13 +44,13 @@ real64 ArnoldiLargestEigenvalue( LinearOperator< VECTOR > const & op, localIndex
   array1d< VECTOR > V( mInternal + 1 );
 
   // Initial unitary vector
-  V[0].create( numLocalRows, op.getComm() );
+  V[0].create( numLocalRows, op.comm() );
   V[0].set( 1.0 / sqrt( static_cast< real64 >( numGlobalRows ) ) );
 
   for( localIndex j = 0; j < mInternal; ++j )
   {
     // Apply operator
-    V[j+1].create( numLocalRows, op.getComm() );
+    V[j+1].create( numLocalRows, op.comm() );
     op.apply( V[j], V[j+1] );
     // Arnoldi process
     for( localIndex i = 0; i <= j; ++i )

--- a/src/coreComponents/linearAlgebra/utilities/BlockOperatorView.hpp
+++ b/src/coreComponents/linearAlgebra/utilities/BlockOperatorView.hpp
@@ -176,9 +176,9 @@ public:
    * @note when build without MPI, may return anything
    *       (MPI_Comm will be a mock type defined in MpiWrapper)
    */
-  virtual MPI_Comm getComm() const override
+  virtual MPI_Comm comm() const override
   {
-    return m_operators( 0, 0 )->getComm();
+    return m_operators( 0, 0 )->comm();
   }
 
   ///@}

--- a/src/coreComponents/linearAlgebra/utilities/InverseNormalOperator.hpp
+++ b/src/coreComponents/linearAlgebra/utilities/InverseNormalOperator.hpp
@@ -170,9 +170,9 @@ public:
   /**
    * @brief @return the communicator
    */
-  MPI_Comm getComm() const override
+  MPI_Comm comm() const override
   {
-    return m_matrix.getComm();
+    return m_matrix.comm();
   }
 
 private:

--- a/src/coreComponents/linearAlgebra/utilities/LAIHelperFunctions.hpp
+++ b/src/coreComponents/linearAlgebra/utilities/LAIHelperFunctions.hpp
@@ -123,7 +123,7 @@ void createPermutationMatrix( ElementRegionManager const & elemManager,
   {
     if( elementSubRegion.hasWrapper( dofKey ) )
     {
-      numLocalRows += elementSubRegion.getNumberOfLocalIndices();
+      numLocalRows += elementSubRegion.getNumberOfLocalIndices() * nDofPerCell;
     }
   } );
   permutationMatrix.createWithLocalSize( numLocalRows, numLocalRows, 1, MPI_COMM_GEOSX );
@@ -142,7 +142,7 @@ void createPermutationMatrix( ElementRegionManager const & elemManager,
         for( int d = 0; d < nDofPerCell; ++d )
         {
           globalIndex const rowIndex    = localToGlobal[k] * nDofPerCell + d;
-          globalIndex const columnIndex = dofNumber[k] * nDofPerCell + d;
+          globalIndex const columnIndex = dofNumber[k] + d;
           permutationMatrix.insert( rowIndex, columnIndex, 1.0 );
         }
       }
@@ -165,7 +165,7 @@ VECTOR permuteVector( VECTOR const & vector,
                       MATRIX const & permutationMatrix )
 {
   VECTOR permutedVector;
-  permutedVector.createWithLocalSize( vector.localSize(), MPI_COMM_GEOSX );
+  permutedVector.create( vector.localSize(), permutationMatrix.getComm() );
   permutationMatrix.apply( vector, permutedVector );
   return permutedVector;
 }

--- a/src/coreComponents/linearAlgebra/utilities/LAIHelperFunctions.hpp
+++ b/src/coreComponents/linearAlgebra/utilities/LAIHelperFunctions.hpp
@@ -165,7 +165,7 @@ VECTOR permuteVector( VECTOR const & vector,
                       MATRIX const & permutationMatrix )
 {
   VECTOR permutedVector;
-  permutedVector.create( vector.localSize(), permutationMatrix.getComm() );
+  permutedVector.create( vector.localSize(), permutationMatrix.comm() );
   permutationMatrix.apply( vector, permutedVector );
   return permutedVector;
 }
@@ -182,6 +182,7 @@ MATRIX permuteMatrix( MATRIX const & matrix,
 {
   MATRIX permutedMatrix;
   matrix.multiplyRARt( permutationMatrix, permutedMatrix );
+  return matrix;
 }
 
 /**
@@ -198,6 +199,7 @@ MATRIX permuteMatrix( MATRIX const & matrix,
 {
   MATRIX permutedMatrix;
   matrix.multiplyRAP( permutationMatrixLeft, permutationMatrixRight, permutedMatrix );
+  return matrix;
 }
 
 /**
@@ -297,7 +299,7 @@ void computeRigidBodyModes( MeshLevel const & mesh,
       {
         rigidBodyModes[k].axpy( -rigidBodyModes[k].dot( rigidBodyModes[j] ), rigidBodyModes[j] );
       }
-      rigidBodyModes[k].scale( 1.0/rigidBodyModes[k].norm2() );
+      rigidBodyModes[k].scale( 1.0 / rigidBodyModes[k].norm2() );
 
       ++k;
       rigidBodyModes[k].create( numNodes*numComponents, MPI_COMM_GEOSX );
@@ -315,7 +317,7 @@ void computeRigidBodyModes( MeshLevel const & mesh,
       {
         rigidBodyModes[k].axpy( -rigidBodyModes[k].dot( rigidBodyModes[j] ), rigidBodyModes[j] );
       }
-      rigidBodyModes[k].scale( 1.0/rigidBodyModes[k].norm2() );
+      rigidBodyModes[k].scale( 1.0 / rigidBodyModes[k].norm2() );
 
       ++k;
       rigidBodyModes[k].create( numNodes*numComponents, MPI_COMM_GEOSX );
@@ -333,7 +335,7 @@ void computeRigidBodyModes( MeshLevel const & mesh,
       {
         rigidBodyModes[k].axpy( -rigidBodyModes[k].dot( rigidBodyModes[j] ), rigidBodyModes[j] );
       }
-      rigidBodyModes[k].scale( 1.0/rigidBodyModes[k].norm2() );
+      rigidBodyModes[k].scale( 1.0 / rigidBodyModes[k].norm2() );
       break;
     }
     default:

--- a/src/coreComponents/linearAlgebra/utilities/NormalOperator.hpp
+++ b/src/coreComponents/linearAlgebra/utilities/NormalOperator.hpp
@@ -102,9 +102,9 @@ public:
   /**
    * @brief @return the communicator
    */
-  MPI_Comm getComm() const override
+  MPI_Comm comm() const override
   {
-    return m_matrix.getComm();
+    return m_matrix.comm();
   }
 
 private:

--- a/src/coreComponents/linearAlgebra/utilities/TransposeOperator.hpp
+++ b/src/coreComponents/linearAlgebra/utilities/TransposeOperator.hpp
@@ -108,9 +108,9 @@ public:
    * @brief Get the MPI communicator the matrix was created with
    * @return MPI communicator of the underlying matrix
    */
-  virtual MPI_Comm getComm() const override
+  virtual MPI_Comm comm() const override
   {
-    return m_matrix.getComm();
+    return m_matrix.comm();
   }
 
 private:

--- a/src/coreComponents/physicsSolvers/SolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/SolverBase.cpp
@@ -668,10 +668,10 @@ void SolverBase::setupSystem( DomainPartition & domain,
     localMatrix.assimilate< parallelDevicePolicy<> >( std::move( pattern ) );
   }
 
-  rhs.create( localMatrix.numRows(), MPI_COMM_GEOSX );
+  rhs.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
   rhs.setName( this->getName() + "/rhs" );
 
-  solution.create( localMatrix.numRows(), MPI_COMM_GEOSX );
+  solution.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
   solution.setName( this->getName() + "/solution" );
 }
 

--- a/src/coreComponents/physicsSolvers/SolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/SolverBase.cpp
@@ -661,18 +661,19 @@ void SolverBase::setupSystem( DomainPartition & domain,
   setupDofs( domain, dofManager );
   dofManager.reorderByRank();
 
-  SparsityPattern< globalIndex > pattern;
   if( setSparsity )
   {
+    SparsityPattern< globalIndex > pattern;
     dofManager.setSparsityPattern( pattern );
     localMatrix.assimilate< parallelDevicePolicy<> >( std::move( pattern ) );
   }
+  localMatrix.setName( this->getName() + "/matrix" );
 
-  rhs.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
   rhs.setName( this->getName() + "/rhs" );
+  rhs.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
 
-  solution.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
   solution.setName( this->getName() + "/solution" );
+  solution.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
 }
 
 void SolverBase::assembleSystem( real64 const GEOSX_UNUSED_PARAM( time ),

--- a/src/coreComponents/physicsSolvers/SolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/SolverBase.cpp
@@ -79,7 +79,6 @@ SolverBase::SolverBase( string const & name,
   registerGroup( groupKeyStruct::nonlinearSolverParametersString(), &m_nonlinearSolverParameters );
 
   m_localMatrix.setName( this->getName() + "/localMatrix" );
-  m_localRhs.setName( this->getName() + "/localRhs" );
   m_matrix.setDofManager( &m_dofManager );
 }
 
@@ -235,7 +234,9 @@ real64 SolverBase::linearImplicitStep( real64 const & time_n,
 
   // zero out matrix/rhs before assembly
   m_localMatrix.zero();
-  m_localRhs.zero();
+  m_rhs.zero();
+
+  arrayView1d< real64 > localRhs = m_rhs.open();
 
   // call assemble to fill the matrix and the rhs
   assembleSystem( time_n,
@@ -243,7 +244,7 @@ real64 SolverBase::linearImplicitStep( real64 const & time_n,
                   domain,
                   m_dofManager,
                   m_localMatrix.toViewConstSizes(),
-                  m_localRhs.toView() );
+                  localRhs );
 
   // apply boundary conditions to system
   applyBoundaryConditions( time_n,
@@ -251,11 +252,14 @@ real64 SolverBase::linearImplicitStep( real64 const & time_n,
                            domain,
                            m_dofManager,
                            m_localMatrix.toViewConstSizes(),
-                           m_localRhs.toView() );
+                           localRhs );
+
+  m_rhs.close();
 
   if( m_assemblyCallback )
   {
-    m_assemblyCallback( m_localMatrix, m_localRhs );
+    // TODO: figure out why callback takes LA objects by value, not by view
+    // m_assemblyCallback( m_localMatrix, localRhs );
   }
 
   // TODO: Trilinos currently requires this, re-evaluate after moving to Tpetra-based solvers
@@ -264,10 +268,8 @@ real64 SolverBase::linearImplicitStep( real64 const & time_n,
     m_precond->clear();
   }
 
-  // Compose parallel LA matrix/rhs out of local LA matrix/rhs
+  // Compose parallel LA matrix out of local matrix
   m_matrix.create( m_localMatrix.toViewConst(), m_dofManager.numLocalDofs(), MPI_COMM_GEOSX );
-  m_rhs.create( m_localRhs.toViewConst(), MPI_COMM_GEOSX );
-  m_solution.createWithLocalSize( m_matrix.numLocalCols(), MPI_COMM_GEOSX );
 
   // Output the linear system matrix/rhs for debugging purposes
   debugOutputSystem( 0.0, 0, 0, m_matrix, m_rhs );
@@ -278,12 +280,8 @@ real64 SolverBase::linearImplicitStep( real64 const & time_n,
   // Output the linear system solution for debugging purposes
   debugOutputSolution( 0.0, 0, 0, m_solution );
 
-  // Copy solution from parallel vector back to local
-  // TODO: This step will not be needed when we teach LA vectors to wrap our pointers
-  m_solution.extract( m_localSolution );
-
   // apply the system solution to the fields/variables
-  applySystemSolution( m_dofManager, m_localSolution, 1.0, domain );
+  applySystemSolution( m_dofManager, m_solution.values(), 1.0, domain );
 
   // update non-primary variables (constitutive models)
   updateState( domain );
@@ -302,8 +300,8 @@ bool SolverBase::lineSearch( real64 const & time_n,
                              DomainPartition & domain,
                              DofManager const & dofManager,
                              CRSMatrixView< real64, globalIndex const > const & localMatrix,
-                             arrayView1d< real64 > const & localRhs,
-                             arrayView1d< real64 const > const & localSolution,
+                             ParallelVector & rhs,
+                             ParallelVector & solution,
                              real64 const scaleFactor,
                              real64 & lastResidual )
 {
@@ -329,24 +327,27 @@ bool SolverBase::lineSearch( real64 const & time_n,
     localScaleFactor *= lineSearchCutFactor;
     cumulativeScale += localScaleFactor;
 
-    if( !checkSystemSolution( domain, dofManager, localSolution, localScaleFactor ) )
+    if( !checkSystemSolution( domain, dofManager, solution.values(), localScaleFactor ) )
     {
       GEOSX_LOG_LEVEL_RANK_0( 1, GEOSX_FMT( "        Line search {}, solution check failed", lineSearchIteration ) );
       continue;
     }
 
-    applySystemSolution( dofManager, localSolution, localScaleFactor, domain );
+    applySystemSolution( dofManager, solution.values(), localScaleFactor, domain );
 
     // update non-primary variables (constitutive models)
     updateState( domain );
 
     // re-assemble system
     localMatrix.zero();
-    localRhs.zero();
-    assembleSystem( time_n, dt, domain, dofManager, localMatrix, localRhs );
+    rhs.zero();
 
-    // apply boundary conditions to system
-    applyBoundaryConditions( time_n, dt, domain, dofManager, localMatrix, localRhs );
+    {
+      arrayView1d< real64 > const localRhs = rhs.open();
+      assembleSystem( time_n, dt, domain, dofManager, localMatrix, localRhs );
+      applyBoundaryConditions( time_n, dt, domain, dofManager, localMatrix, localRhs );
+      rhs.close();
+    }
 
     if( getLogLevel() >= 1 && logger::internal::rank==0 )
     {
@@ -354,7 +355,7 @@ bool SolverBase::lineSearch( real64 const & time_n,
     }
 
     // get residual norm
-    residualNorm = calculateResidualNorm( domain, dofManager, localRhs );
+    residualNorm = calculateResidualNorm( domain, dofManager, rhs.values() );
 
     if( getLogLevel() >= 1 && logger::internal::rank==0 )
     {
@@ -467,34 +468,41 @@ real64 SolverBase::nonlinearImplicitStep( real64 const & time_n,
 
       // zero out matrix/rhs before assembly
       m_localMatrix.zero();
-      m_localRhs.zero();
+      m_rhs.zero();
 
-      // call assemble to fill the matrix and the rhs
-      assembleSystem( time_n,
-                      stepDt,
-                      domain,
-                      m_dofManager,
-                      m_localMatrix.toViewConstSizes(),
-                      m_localRhs.toView() );
+      {
+        arrayView1d< real64 > const localRhs = m_rhs.open();
 
-      // apply boundary conditions to system
-      applyBoundaryConditions( time_n,
-                               stepDt,
-                               domain,
-                               m_dofManager,
-                               m_localMatrix.toViewConstSizes(),
-                               m_localRhs.toView() );
+        // call assemble to fill the matrix and the rhs
+        assembleSystem( time_n,
+                        stepDt,
+                        domain,
+                        m_dofManager,
+                        m_localMatrix.toViewConstSizes(),
+                        localRhs );
+
+        // apply boundary conditions to system
+        applyBoundaryConditions( time_n,
+                                 stepDt,
+                                 domain,
+                                 m_dofManager,
+                                 m_localMatrix.toViewConstSizes(),
+                                 localRhs );
+
+        m_rhs.close();
+      }
 
       if( m_assemblyCallback )
       {
-        m_assemblyCallback( m_localMatrix, m_localRhs );
+        // TODO: figure out why callback takes LA objects by value, not by view
+        // m_assemblyCallback( m_localMatrix, localRhs );
       }
 
       // TODO: maybe add scale function here?
       // Scale()
 
       // get residual norm
-      real64 residualNorm = calculateResidualNorm( domain, m_dofManager, m_localRhs.toViewConst() );
+      real64 residualNorm = calculateResidualNorm( domain, m_dofManager, m_rhs.values() );
 
       GEOSX_LOG_LEVEL_RANK_0( 1, GEOSX_FMT( "    ( R ) = ( {:4.2e} ) ; ", residualNorm ) );
       if( newtonIter > 0 )
@@ -524,8 +532,8 @@ real64 SolverBase::nonlinearImplicitStep( real64 const & time_n,
                                              domain,
                                              m_dofManager,
                                              m_localMatrix.toViewConstSizes(),
-                                             m_localRhs.toView(),
-                                             m_localSolution.toViewConst(),
+                                             m_rhs,
+                                             m_solution,
                                              scaleFactor,
                                              residualNorm );
 
@@ -559,8 +567,6 @@ real64 SolverBase::nonlinearImplicitStep( real64 const & time_n,
 
       // Compose parallel LA matrix/rhs out of local LA matrix/rhs
       m_matrix.create( m_localMatrix.toViewConst(), m_dofManager.numLocalDofs(), MPI_COMM_GEOSX );
-      m_rhs.create( m_localRhs.toViewConst(), MPI_COMM_GEOSX );
-      m_solution.createWithLocalSize( m_matrix.numLocalCols(), MPI_COMM_GEOSX );
 
       // Output the linear system matrix/rhs for debugging purposes
       debugOutputSystem( time_n, cycleNumber, newtonIter, m_matrix, m_rhs );
@@ -571,13 +577,9 @@ real64 SolverBase::nonlinearImplicitStep( real64 const & time_n,
       // Output the linear system solution for debugging purposes
       debugOutputSolution( time_n, cycleNumber, newtonIter, m_solution );
 
-      // Copy solution from parallel vector back to local
-      // TODO: This step will not be needed when we teach LA vectors to wrap our pointers
-      m_solution.extract( m_localSolution );
+      scaleFactor = scalingForSystemSolution( domain, m_dofManager, m_solution.values() );
 
-      scaleFactor = scalingForSystemSolution( domain, m_dofManager, m_localSolution );
-
-      if( !checkSystemSolution( domain, m_dofManager, m_localSolution, scaleFactor ) )
+      if( !checkSystemSolution( domain, m_dofManager, m_solution.values(), scaleFactor ) )
       {
         // TODO try chopping (similar to line search)
         GEOSX_LOG_RANK_0( "    Solution check failed. Newton loop terminated." );
@@ -585,7 +587,7 @@ real64 SolverBase::nonlinearImplicitStep( real64 const & time_n,
       }
 
       // apply the system solution to the fields/variables
-      applySystemSolution( m_dofManager, m_localSolution, scaleFactor, domain );
+      applySystemSolution( m_dofManager, m_solution.values(), scaleFactor, domain );
 
       // update non-primary variables (constitutive models)
       updateState( domain );
@@ -648,8 +650,8 @@ void SolverBase::setupDofs( DomainPartition const & GEOSX_UNUSED_PARAM( domain )
 void SolverBase::setupSystem( DomainPartition & domain,
                               DofManager & dofManager,
                               CRSMatrix< real64, globalIndex > & localMatrix,
-                              array1d< real64 > & localRhs,
-                              array1d< real64 > & localSolution,
+                              ParallelVector & rhs,
+                              ParallelVector & solution,
                               bool const setSparsity )
 {
   GEOSX_MARK_FUNCTION;
@@ -659,8 +661,6 @@ void SolverBase::setupSystem( DomainPartition & domain,
   setupDofs( domain, dofManager );
   dofManager.reorderByRank();
 
-  localIndex const numLocalRows = dofManager.numLocalDofs();
-
   SparsityPattern< globalIndex > pattern;
   if( setSparsity )
   {
@@ -668,12 +668,11 @@ void SolverBase::setupSystem( DomainPartition & domain,
     localMatrix.assimilate< parallelDevicePolicy<> >( std::move( pattern ) );
   }
 
-  localRhs.resize( numLocalRows );
-  localSolution.resize( numLocalRows );
+  rhs.create( localMatrix.numRows(), MPI_COMM_GEOSX );
+  rhs.setName( this->getName() + "/rhs" );
 
-  localMatrix.setName( this->getName() + "/localMatrix" );
-  localRhs.setName( this->getName() + "/localRhs" );
-  localSolution.setName( this->getName() + "/localSolution" );
+  solution.create( localMatrix.numRows(), MPI_COMM_GEOSX );
+  solution.setName( this->getName() + "/solution" );
 }
 
 void SolverBase::assembleSystem( real64 const GEOSX_UNUSED_PARAM( time ),

--- a/src/coreComponents/physicsSolvers/SolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/SolverBase.hpp
@@ -102,20 +102,6 @@ public:
   CRSMatrixView< real64 const, globalIndex const > getLocalMatrix() const { return m_localMatrix.toViewConst(); }
 
   /**
-   * @brief Getter for local rhs vector
-   * @return a reference to linear system right-hand side of this solver
-   */
-  array1d< real64 > & getLocalRhs() { return m_localRhs; }
-  arrayView1d< real64 const > getLocalRhs() const { return m_localRhs; }
-
-  /**
-   * @brief Getter for local solution vector
-   * @return a reference to solution vector of this solver
-   */
-  array1d< real64 > & getLocalSolution() { return m_localSolution; }
-  arrayView1d< real64 const > getLocalSolution() const { return m_localSolution; }
-
-  /**
    * @defgroup Solver Interface Functions
    *
    * These functions provide the primary interface that is required for derived classes
@@ -223,8 +209,8 @@ public:
               DomainPartition & domain,
               DofManager const & dofManager,
               CRSMatrixView< real64, globalIndex const > const & localMatrix,
-              arrayView1d< real64 > const & localRhs,
-              arrayView1d< real64 const > const & localSolution,
+              ParallelVector & rhs,
+              ParallelVector & solution,
               real64 const scaleFactor,
               real64 & lastResidual );
 
@@ -295,8 +281,8 @@ public:
   setupSystem( DomainPartition & domain,
                DofManager & dofManager,
                CRSMatrix< real64, globalIndex > & localMatrix,
-               array1d< real64 > & localRhs,
-               array1d< real64 > & localSolution,
+               ParallelVector & rhs,
+               ParallelVector & solution,
                bool const setSparsity = true );
 
   /**
@@ -722,8 +708,6 @@ protected:
 
   /// Local system matrix and rhs
   CRSMatrix< real64, globalIndex > m_localMatrix;
-  array1d< real64 > m_localRhs;
-  array1d< real64 > m_localSolution;
 
   /// Custom preconditioner for the "native" iterative solver
   std::unique_ptr< PreconditionerBase< LAInterface > > m_precond;

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.cpp
@@ -885,7 +885,7 @@ real64 CompositionalMultiphaseBase::solverStep( real64 const & time_n,
   static bool systemSetupDone = false;
   if( !systemSetupDone )
   {
-    setupSystem( domain, m_dofManager, m_localMatrix, m_localRhs, m_localSolution );
+    setupSystem( domain, m_dofManager, m_localMatrix, m_rhs, m_solution );
     systemSetupDone = true;
   }
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseBase.cpp
@@ -452,7 +452,7 @@ real64 SinglePhaseBase::solverStep( real64 const & time_n,
   real64 dt_return;
 
   // setup dof numbers and linear system
-  setupSystem( domain, m_dofManager, m_localMatrix, m_localRhs, m_localSolution );
+  setupSystem( domain, m_dofManager, m_localMatrix, m_rhs, m_solution );
 
   implicitStepSetup( time_n, dt, domain );
 
@@ -468,8 +468,8 @@ real64 SinglePhaseBase::solverStep( real64 const & time_n,
 void SinglePhaseBase::setupSystem( DomainPartition & domain,
                                    DofManager & dofManager,
                                    CRSMatrix< real64, globalIndex > & localMatrix,
-                                   array1d< real64 > & localRhs,
-                                   array1d< real64 > & localSolution,
+                                   ParallelVector & rhs,
+                                   ParallelVector & solution,
                                    bool const setSparsity )
 {
   GEOSX_MARK_FUNCTION;
@@ -478,8 +478,8 @@ void SinglePhaseBase::setupSystem( DomainPartition & domain,
   SolverBase::setupSystem( domain,
                            dofManager,
                            localMatrix,
-                           localRhs,
-                           localSolution,
+                           rhs,
+                           solution,
                            setSparsity );
 }
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseBase.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseBase.hpp
@@ -74,8 +74,8 @@ public:
   virtual void setupSystem( DomainPartition & domain,
                             DofManager & dofManager,
                             CRSMatrix< real64, globalIndex > & localMatrix,
-                            array1d< real64 > & localRhs,
-                            array1d< real64 > & localSolution,
+                            ParallelVector & rhs,
+                            ParallelVector & solution,
                             bool const setSparsity = true ) override;
 
   virtual real64

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseFVM.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseFVM.cpp
@@ -89,16 +89,16 @@ template< typename BASE >
 void SinglePhaseFVM< BASE >::setupSystem( DomainPartition & domain,
                                           DofManager & dofManager,
                                           CRSMatrix< real64, globalIndex > & localMatrix,
-                                          array1d< real64 > & localRhs,
-                                          array1d< real64 > & localSolution,
+                                          ParallelVector & rhs,
+                                          ParallelVector & solution,
                                           bool const setSparsity )
 {
   GEOSX_MARK_FUNCTION;
   BASE::setupSystem( domain,
                      dofManager,
                      localMatrix,
-                     localRhs,
-                     localSolution,
+                     rhs,
+                     solution,
                      setSparsity );
 
 }

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseFVM.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseFVM.hpp
@@ -59,8 +59,6 @@ public:
   using BASE::m_rhs;
   using BASE::m_solution;
   using BASE::m_localMatrix;
-  using BASE::m_localRhs;
-  using BASE::m_localSolution;
   using BASE::m_linearSolverParameters;
   using BASE::m_nonlinearSolverParameters;
 
@@ -156,8 +154,8 @@ public:
   setupSystem( DomainPartition & domain,
                DofManager & dofManager,
                CRSMatrix< real64, globalIndex > & localMatrix,
-               array1d< real64 > & localRhs,
-               array1d< real64 > & localSolution,
+               ParallelVector & rhs,
+               ParallelVector & solution,
                bool const setSparsity = true ) override;
 
   virtual void

--- a/src/coreComponents/physicsSolvers/multiphysics/FlowProppantTransportSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/FlowProppantTransportSolver.cpp
@@ -77,8 +77,8 @@ void FlowProppantTransportSolver::preStepUpdate( real64 const & time_n,
   m_flowSolver->setupSystem( domain,
                              m_flowSolver->getDofManager(),
                              m_flowSolver->getLocalMatrix(),
-                             m_flowSolver->getLocalRhs(),
-                             m_flowSolver->getLocalSolution() );
+                             m_flowSolver->getSystemRhs(),
+                             m_flowSolver->getSystemSolution() );
 
 
   m_flowSolver->implicitStepSetup( time_n, dt, domain );
@@ -86,8 +86,8 @@ void FlowProppantTransportSolver::preStepUpdate( real64 const & time_n,
   m_proppantSolver->setupSystem( domain,
                                  m_proppantSolver->getDofManager(),
                                  m_proppantSolver->getLocalMatrix(),
-                                 m_proppantSolver->getLocalRhs(),
-                                 m_proppantSolver->getLocalSolution() );
+                                 m_proppantSolver->getSystemRhs(),
+                                 m_proppantSolver->getSystemSolution() );
 
 
   m_proppantSolver->implicitStepSetup( time_n, dt, domain );

--- a/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.cpp
@@ -514,14 +514,13 @@ void HydrofractureSolver::setupSystem( DomainPartition & domain,
   addFluxApertureCouplingSparsityPattern( domain, dofManager, pattern.toView() );
 
   localMatrix.assimilate< parallelDevicePolicy<> >( std::move( pattern ) );
+  localMatrix.setName( this->getName() + "/matrix" );
 
-  localMatrix.setName( this->getName() + "/localMatrix" );
-
-  rhs.create( numLocalRows, MPI_COMM_GEOSX );
   rhs.setName( this->getName() + "/rhs" );
+  rhs.create( numLocalRows, MPI_COMM_GEOSX );
 
-  solution.create( numLocalRows, MPI_COMM_GEOSX );
   solution.setName( this->getName() + "/solution" );
+  solution.create( numLocalRows, MPI_COMM_GEOSX );
 
   setUpDflux_dApertureMatrix( domain, dofManager, localMatrix );
 }

--- a/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.cpp
@@ -184,8 +184,8 @@ real64 HydrofractureSolver::solverStep( real64 const & time_n,
       setupSystem( domain,
                    m_dofManager,
                    m_localMatrix,
-                   m_localRhs,
-                   m_localSolution );
+                   m_rhs,
+                   m_solution );
 
       // currently the only method is implicit time integration
       dtReturn = nonlinearImplicitStep( time_n, dt, cycleNumber, domain );
@@ -466,8 +466,8 @@ void HydrofractureSolver::setupDofs( DomainPartition const & domain,
 void HydrofractureSolver::setupSystem( DomainPartition & domain,
                                        DofManager & dofManager,
                                        CRSMatrix< real64, globalIndex > & localMatrix,
-                                       array1d< real64 > & localRhs,
-                                       array1d< real64 > & localSolution,
+                                       ParallelVector & rhs,
+                                       ParallelVector & solution,
                                        bool const setSparsity )
 {
   GEOSX_MARK_FUNCTION;
@@ -515,12 +515,13 @@ void HydrofractureSolver::setupSystem( DomainPartition & domain,
 
   localMatrix.assimilate< parallelDevicePolicy<> >( std::move( pattern ) );
 
-  localRhs.resize( numLocalRows );
-  localSolution.resize( numLocalRows );
-
   localMatrix.setName( this->getName() + "/localMatrix" );
-  localRhs.setName( this->getName() + "/localRhs" );
-  localSolution.setName( this->getName() + "/localSolution" );
+
+  rhs.create( numLocalRows, MPI_COMM_GEOSX );
+  rhs.setName( this->getName() + "/rhs" );
+
+  solution.create( numLocalRows, MPI_COMM_GEOSX );
+  solution.setName( this->getName() + "/solution" );
 
   setUpDflux_dApertureMatrix( domain, dofManager, localMatrix );
 }

--- a/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.hpp
@@ -55,8 +55,8 @@ public:
   virtual void setupSystem( DomainPartition & domain,
                             DofManager & dofManager,
                             CRSMatrix< real64, globalIndex > & localMatrix,
-                            array1d< real64 > & localRhs,
-                            array1d< real64 > & localSolution,
+                            ParallelVector & rhs,
+                            ParallelVector & solution,
                             bool const setSparsity = true ) override;
 
   virtual void

--- a/src/coreComponents/physicsSolvers/multiphysics/LagrangianContactSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/LagrangianContactSolver.cpp
@@ -191,8 +191,8 @@ void LagrangianContactSolver::initializePreSubGroups()
 void LagrangianContactSolver::setupSystem( DomainPartition & domain,
                                            DofManager & dofManager,
                                            CRSMatrix< real64, globalIndex > & localMatrix,
-                                           array1d< real64 > & localRhs,
-                                           array1d< real64 > & localSolution,
+                                           ParallelVector & rhs,
+                                           ParallelVector & solution,
                                            bool const setSparsity )
 {
   if( m_precond )
@@ -201,7 +201,7 @@ void LagrangianContactSolver::setupSystem( DomainPartition & domain,
   }
 
   // setup monolithic coupled system
-  SolverBase::setupSystem( domain, dofManager, localMatrix, localRhs, localSolution, setSparsity );
+  SolverBase::setupSystem( domain, dofManager, localMatrix, rhs, solution, setSparsity );
 
   if( !m_precond && m_linearSolverParameters.get().solverType != LinearSolverParameters::SolverType::direct )
   {
@@ -478,8 +478,8 @@ real64 LagrangianContactSolver::solverStep( real64 const & time_n,
   setupSystem( domain,
                m_dofManager,
                m_localMatrix,
-               m_localRhs,
-               m_localSolution );
+               m_rhs,
+               m_solution );
 
   // currently the only method is implicit time integration
   dtReturn = nonlinearImplicitStep( time_n, dt, cycleNumber, domain );
@@ -614,24 +614,29 @@ real64 LagrangianContactSolver::nonlinearImplicitStep( real64 const & time_n,
 
         // zero out matrix/rhs before assembly
         m_localMatrix.zero();
-        m_localRhs.zero();
+        m_rhs.zero();
 
-        // call assemble to fill the matrix and the rhs
-        assembleSystem( time_n,
-                        stepDt,
-                        domain,
-                        m_dofManager,
-                        m_localMatrix.toViewConstSizes(),
-                        m_localRhs );
+        {
+          arrayView1d< real64 > const localRhs = m_rhs.open();
 
-        // apply boundary conditions to system
-        applyBoundaryConditions( time_n,
-                                 stepDt,
-                                 domain,
-                                 m_dofManager,
-                                 m_localMatrix.toViewConstSizes(),
-                                 m_localRhs );
+          // call assemble to fill the matrix and the rhs
+          assembleSystem( time_n,
+                          stepDt,
+                          domain,
+                          m_dofManager,
+                          m_localMatrix.toViewConstSizes(),
+                          localRhs );
 
+          // apply boundary conditions to system
+          applyBoundaryConditions( time_n,
+                                   stepDt,
+                                   domain,
+                                   m_dofManager,
+                                   m_localMatrix.toViewConstSizes(),
+                                   localRhs );
+
+          m_rhs.close();
+        }
         // TODO: maybe add scale function here?
         // Scale()
 
@@ -639,7 +644,7 @@ real64 LagrangianContactSolver::nonlinearImplicitStep( real64 const & time_n,
         // get residual norm
         if( computeResidual )
         {
-          residualNorm = calculateResidualNorm( domain, m_dofManager, m_localRhs );
+          residualNorm = calculateResidualNorm( domain, m_dofManager, m_rhs.values() );
         }
         else
         {
@@ -674,8 +679,6 @@ real64 LagrangianContactSolver::nonlinearImplicitStep( real64 const & time_n,
 
         // Compose parallel LA matrix/rhs out of local LA matrix/rhs
         m_matrix.create( m_localMatrix.toViewConst(), m_dofManager.numLocalDofs(), MPI_COMM_GEOSX );
-        m_rhs.create( m_localRhs, MPI_COMM_GEOSX );
-        m_solution.createWithLocalSize( m_matrix.numLocalCols(), MPI_COMM_GEOSX );
 
         // Output the linear system matrix/rhs for debugging purposes
         debugOutputSystem( time_n, cycleNumber, newtonIter, m_matrix, m_rhs );
@@ -686,11 +689,7 @@ real64 LagrangianContactSolver::nonlinearImplicitStep( real64 const & time_n,
         // Output the linear system solution for debugging purposes
         debugOutputSolution( time_n, cycleNumber, newtonIter, m_solution );
 
-        // Copy solution from parallel vector back to local
-        // TODO: This step will not be needed when we teach LA vectors to wrap our pointers
-        m_solution.extract( m_localSolution );
-
-        scaleFactor = scalingForSystemSolution( domain, m_dofManager, m_localSolution );
+        scaleFactor = scalingForSystemSolution( domain, m_dofManager, m_solution.values() );
 
         // do line search in case residual has increased
         if( m_nonlinearSolverParameters.m_lineSearchAction != NonlinearSolverParameters::LineSearchAction::None && newtonIter > 0 )
@@ -701,8 +700,8 @@ real64 LagrangianContactSolver::nonlinearImplicitStep( real64 const & time_n,
                                                domain,
                                                m_dofManager,
                                                m_localMatrix.toViewConstSizes(),
-                                               m_localRhs,
-                                               m_localSolution,
+                                               m_rhs,
+                                               m_solution,
                                                scaleFactor,
                                                residualNorm );
 
@@ -725,12 +724,12 @@ real64 LagrangianContactSolver::nonlinearImplicitStep( real64 const & time_n,
         else
         {
           // apply the system solution to the fields/variables
-          applySystemSolution( m_dofManager, m_localSolution, scaleFactor, domain );
+          applySystemSolution( m_dofManager, m_solution.values(), scaleFactor, domain );
           // Need to compute the residual norm
           computeResidual = true;
         }
 
-        if( !checkSystemSolution( domain, m_dofManager, m_localSolution, scaleFactor ) )
+        if( !checkSystemSolution( domain, m_dofManager, m_solution.values(), scaleFactor ) )
         {
           // TODO try chopping (similar to line search)
           GEOSX_LOG_RANK_0( "    Solution check failed. Newton loop terminated." );
@@ -826,8 +825,8 @@ bool LagrangianContactSolver::lineSearch( real64 const & time_n,
                                           DomainPartition & domain,
                                           DofManager const & dofManager,
                                           CRSMatrixView< real64, globalIndex const > const & localMatrix,
-                                          arrayView1d< real64 > const & localRhs,
-                                          arrayView1d< real64 const > const & localSolution,
+                                          ParallelVector & rhs,
+                                          ParallelVector & solution,
                                           real64 const scaleFactor,
                                           real64 & lastResidual )
 {
@@ -846,18 +845,21 @@ bool LagrangianContactSolver::lineSearch( real64 const & time_n,
   // get residual norm
   real64 residualNorm0 = lastResidual;
 
-  applySystemSolution( dofManager, localSolution, scaleFactor, domain );
+  applySystemSolution( dofManager, solution.values(), scaleFactor, domain );
 
   // re-assemble system
   localMatrix.zero();
-  localRhs.zero();
-  assembleSystem( time_n, dt, domain, dofManager, localMatrix, localRhs );
+  rhs.zero();
 
-  // apply boundary conditions to system
-  applyBoundaryConditions( time_n, dt, domain, dofManager, localMatrix, localRhs );
+  {
+    arrayView1d< real64 > const localRhs = rhs.open();
+    assembleSystem( time_n, dt, domain, dofManager, localMatrix, localRhs );
+    applyBoundaryConditions( time_n, dt, domain, dofManager, localMatrix, localRhs );
+    rhs.close();
+  }
 
   // get residual norm
-  real64 residualNormT = calculateResidualNorm( domain, dofManager, localRhs );
+  real64 residualNormT = calculateResidualNorm( domain, dofManager, rhs.values() );
 
   real64 ff0 = residualNorm0*residualNorm0;
   real64 ffT = residualNormT*residualNormT;
@@ -881,13 +883,13 @@ bool LagrangianContactSolver::lineSearch( real64 const & time_n,
     real64 const deltaLocalScaleFactor = ( localScaleFactor - previousLocalScaleFactor );
     cumulativeScale += deltaLocalScaleFactor;
 
-    if( !checkSystemSolution( domain, dofManager, localSolution, deltaLocalScaleFactor ) )
+    if( !checkSystemSolution( domain, dofManager, solution.values(), deltaLocalScaleFactor ) )
     {
       GEOSX_LOG_LEVEL_RANK_0( 1, "        Line search " << lineSearchIteration << ", solution check failed" );
       continue;
     }
 
-    applySystemSolution( dofManager, localSolution, deltaLocalScaleFactor, domain );
+    applySystemSolution( dofManager, solution.values(), deltaLocalScaleFactor, domain );
     lamm = lamc;
     lamc = localScaleFactor;
 
@@ -895,11 +897,14 @@ bool LagrangianContactSolver::lineSearch( real64 const & time_n,
     // re-assemble system
     // TODO: add a flag to avoid a completely useless Jacobian computation: rhs is enough
     localMatrix.zero();
-    localRhs.zero();
-    assembleSystem( time_n, dt, domain, dofManager, localMatrix, localRhs );
+    rhs.zero();
 
-    // apply boundary conditions to system
-    applyBoundaryConditions( time_n, dt, domain, dofManager, localMatrix, localRhs );
+    {
+      arrayView1d< real64 > const localRhs = rhs.open();
+      assembleSystem( time_n, dt, domain, dofManager, localMatrix, localRhs );
+      applyBoundaryConditions( time_n, dt, domain, dofManager, localMatrix, localRhs );
+      rhs.close();
+    }
 
     if( getLogLevel() >= 1 && logger::internal::rank==0 )
     {
@@ -907,7 +912,7 @@ bool LagrangianContactSolver::lineSearch( real64 const & time_n,
     }
 
     // get residual norm
-    residualNormT = calculateResidualNorm( domain, dofManager, localRhs );
+    residualNormT = calculateResidualNorm( domain, dofManager, rhs.values() );
     ffm = ffT;
     ffT = residualNormT*residualNormT;
     lineSearchIteration += 1;

--- a/src/coreComponents/physicsSolvers/multiphysics/LagrangianContactSolver.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/LagrangianContactSolver.hpp
@@ -57,8 +57,8 @@ public:
   setupSystem( DomainPartition & domain,
                DofManager & dofManager,
                CRSMatrix< real64, globalIndex > & localMatrix,
-               array1d< real64 > & localRhs,
-               array1d< real64 > & localSolution,
+               ParallelVector & rhs,
+               ParallelVector & solution,
                bool const setSparsity = true ) override;
 
   virtual void
@@ -137,8 +137,8 @@ public:
               DomainPartition & domain,
               DofManager const & dofManager,
               CRSMatrixView< real64, globalIndex const > const & localMatrix,
-              arrayView1d< real64 > const & localRhs,
-              arrayView1d< real64 const > const & localSolution,
+              ParallelVector & rhs,
+              ParallelVector & solution,
               real64 const scaleFactor,
               real64 & lastResidual ) override;
 

--- a/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoromechanicsSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoromechanicsSolver.cpp
@@ -84,8 +84,8 @@ void MultiphasePoromechanicsSolver::setupDofs( DomainPartition const & domain,
 void MultiphasePoromechanicsSolver::setupSystem( DomainPartition & domain,
                                                  DofManager & dofManager,
                                                  CRSMatrix< real64, globalIndex > & localMatrix,
-                                                 array1d< real64 > & localRhs,
-                                                 array1d< real64 > & localSolution,
+                                                 ParallelVector & rhs,
+                                                 ParallelVector & solution,
                                                  bool const setSparsity )
 {
 //  if( m_precond )
@@ -94,7 +94,7 @@ void MultiphasePoromechanicsSolver::setupSystem( DomainPartition & domain,
 //  }
 
   // setup monolithic coupled system
-  SolverBase::setupSystem( domain, dofManager, localMatrix, localRhs, localSolution, setSparsity );
+  SolverBase::setupSystem( domain, dofManager, localMatrix, rhs, solution, setSparsity );
 
 //  if( !m_precond && m_linearSolverParameters.get().solverType != LinearSolverParameters::SolverType::direct )
 //  {
@@ -155,8 +155,8 @@ real64 MultiphasePoromechanicsSolver::solverStep( real64 const & time_n,
   setupSystem( domain,
                m_dofManager,
                m_localMatrix,
-               m_localRhs,
-               m_localSolution );
+               m_rhs,
+               m_solution );
 
   implicitStepSetup( time_n, dt, domain );
 

--- a/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoromechanicsSolver.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoromechanicsSolver.hpp
@@ -46,8 +46,8 @@ public:
   virtual void setupSystem( DomainPartition & domain,
                             DofManager & dofManager,
                             CRSMatrix< real64, globalIndex > & localMatrix,
-                            array1d< real64 > & localRhs,
-                            array1d< real64 > & localSolution,
+                            ParallelVector & rhs,
+                            ParallelVector & solution,
                             bool const setSparsity = true ) override;
 
   virtual void

--- a/src/coreComponents/physicsSolvers/multiphysics/PhaseFieldFractureSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/PhaseFieldFractureSolver.cpp
@@ -189,15 +189,15 @@ real64 PhaseFieldFractureSolver::splitOperatorStep( real64 const & time_n,
   damageSolver.setupSystem( domain,
                             damageSolver.getDofManager(),
                             damageSolver.getLocalMatrix(),
-                            damageSolver.getLocalRhs(),
-                            damageSolver.getLocalSolution(),
+                            damageSolver.getSystemRhs(),
+                            damageSolver.getSystemSolution(),
                             true );
 
   solidSolver.setupSystem( domain,
                            solidSolver.getDofManager(),
                            solidSolver.getLocalMatrix(),
-                           solidSolver.getLocalRhs(),
-                           solidSolver.getLocalSolution() );
+                           solidSolver.getSystemRhs(),
+                           solidSolver.getSystemSolution() );
 
   damageSolver.implicitStepSetup( time_n, dt, domain );
 

--- a/src/coreComponents/physicsSolvers/multiphysics/ReservoirSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/ReservoirSolverBase.cpp
@@ -246,11 +246,11 @@ void ReservoirSolverBase::setupSystem( DomainPartition & domain,
   localMatrix.assimilate< parallelDevicePolicy<> >( std::move( pattern ) );
   localMatrix.setName( this->getName() + "/localMatrix" );
 
-  rhs.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
   rhs.setName( this->getName() + "/rhs" );
+  rhs.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
 
-  solution.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
   solution.setName( this->getName() + "/solution" );
+  solution.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
 }
 
 

--- a/src/coreComponents/physicsSolvers/multiphysics/ReservoirSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/ReservoirSolverBase.cpp
@@ -246,10 +246,10 @@ void ReservoirSolverBase::setupSystem( DomainPartition & domain,
   localMatrix.assimilate< parallelDevicePolicy<> >( std::move( pattern ) );
   localMatrix.setName( this->getName() + "/localMatrix" );
 
-  rhs.create( localMatrix.numRows(), MPI_COMM_GEOSX );
+  rhs.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
   rhs.setName( this->getName() + "/rhs" );
 
-  solution.create( localMatrix.numRows(), MPI_COMM_GEOSX );
+  solution.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
   solution.setName( this->getName() + "/solution" );
 }
 

--- a/src/coreComponents/physicsSolvers/multiphysics/ReservoirSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/ReservoirSolverBase.cpp
@@ -103,7 +103,7 @@ real64 ReservoirSolverBase::solverStep( real64 const & time_n,
   real64 dt_return = dt;
 
   // setup the coupled linear system
-  setupSystem( domain, m_dofManager, m_localMatrix, m_localRhs, m_localSolution );
+  setupSystem( domain, m_dofManager, m_localMatrix, m_rhs, m_solution );
 
   // setup reservoir and well systems
   implicitStepSetup( time_n, dt, domain );
@@ -203,8 +203,8 @@ void ReservoirSolverBase::addCouplingNumNonzeros( DomainPartition & domain,
 void ReservoirSolverBase::setupSystem( DomainPartition & domain,
                                        DofManager & dofManager,
                                        CRSMatrix< real64, globalIndex > & localMatrix,
-                                       array1d< real64 > & localRhs,
-                                       array1d< real64 > & localSolution,
+                                       ParallelVector & rhs,
+                                       ParallelVector & solution,
                                        bool const )
 {
   GEOSX_MARK_FUNCTION;
@@ -244,12 +244,13 @@ void ReservoirSolverBase::setupSystem( DomainPartition & domain,
 
   // Finally, steal the pattern into a CRS matrix
   localMatrix.assimilate< parallelDevicePolicy<> >( std::move( pattern ) );
-  localRhs.resize( localMatrix.numRows() );
-  localSolution.resize( localMatrix.numRows() );
-
   localMatrix.setName( this->getName() + "/localMatrix" );
-  localRhs.setName( this->getName() + "/localRhs" );
-  localSolution.setName( this->getName() + "/localSolution" );
+
+  rhs.create( localMatrix.numRows(), MPI_COMM_GEOSX );
+  rhs.setName( this->getName() + "/rhs" );
+
+  solution.create( localMatrix.numRows(), MPI_COMM_GEOSX );
+  solution.setName( this->getName() + "/solution" );
 }
 
 

--- a/src/coreComponents/physicsSolvers/multiphysics/ReservoirSolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/ReservoirSolverBase.hpp
@@ -83,8 +83,8 @@ public:
   setupSystem( DomainPartition & domain,
                DofManager & dofManager,
                CRSMatrix< real64, globalIndex > & localMatrix,
-               array1d< real64 > & localRhs,
-               array1d< real64 > & localSolution,
+               ParallelVector & rhs,
+               ParallelVector & solution,
                bool const setSparsity = true ) override;
 
   virtual void

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolver.cpp
@@ -84,8 +84,8 @@ void SinglePhasePoromechanicsSolver::setupDofs( DomainPartition const & domain,
 void SinglePhasePoromechanicsSolver::setupSystem( DomainPartition & domain,
                                                   DofManager & dofManager,
                                                   CRSMatrix< real64, globalIndex > & localMatrix,
-                                                  array1d< real64 > & localRhs,
-                                                  array1d< real64 > & localSolution,
+                                                  ParallelVector & rhs,
+                                                  ParallelVector & solution,
                                                   bool const setSparsity )
 {
   if( m_precond )
@@ -94,7 +94,7 @@ void SinglePhasePoromechanicsSolver::setupSystem( DomainPartition & domain,
   }
 
   // setup monolithic coupled system
-  SolverBase::setupSystem( domain, dofManager, localMatrix, localRhs, localSolution, setSparsity );
+  SolverBase::setupSystem( domain, dofManager, localMatrix, rhs, solution, setSparsity );
 
   if( !m_precond && m_linearSolverParameters.get().solverType != LinearSolverParameters::SolverType::direct )
   {
@@ -155,8 +155,8 @@ real64 SinglePhasePoromechanicsSolver::solverStep( real64 const & time_n,
   setupSystem( domain,
                m_dofManager,
                m_localMatrix,
-               m_localRhs,
-               m_localSolution );
+               m_rhs,
+               m_solution );
 
   implicitStepSetup( time_n, dt, domain );
 

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolver.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolver.hpp
@@ -46,8 +46,8 @@ public:
   virtual void setupSystem( DomainPartition & domain,
                             DofManager & dofManager,
                             CRSMatrix< real64, globalIndex > & localMatrix,
-                            array1d< real64 > & localRhs,
-                            array1d< real64 > & localSolution,
+                            ParallelVector & rhs,
+                            ParallelVector & solution,
                             bool const setSparsity = true ) override;
 
   virtual void

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolverEmbeddedFractures.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolverEmbeddedFractures.cpp
@@ -170,10 +170,10 @@ void SinglePhasePoromechanicsSolverEmbeddedFractures::setupSystem( DomainPartiti
   localMatrix.assimilate< parallelDevicePolicy<> >( std::move( pattern ) );
   localMatrix.setName( this->getName() + "/localMatrix" );
 
-  rhs.create( localMatrix.numRows(), MPI_COMM_GEOSX );
+  rhs.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
   rhs.setName( this->getName() + "/rhs" );
 
-  solution.create( localMatrix.numRows(), MPI_COMM_GEOSX );
+  solution.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
   solution.setName( this->getName() + "/solution" );
 }
 

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolverEmbeddedFractures.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolverEmbeddedFractures.cpp
@@ -167,14 +167,14 @@ void SinglePhasePoromechanicsSolverEmbeddedFractures::setupSystem( DomainPartiti
   addCouplingSparsityPattern( domain, dofManager, pattern.toView() );
 
   // Finally, steal the pattern into a CRS matrix
-  localMatrix.assimilate< parallelDevicePolicy<> >( std::move( pattern ) );
   localMatrix.setName( this->getName() + "/localMatrix" );
+  localMatrix.assimilate< parallelDevicePolicy<> >( std::move( pattern ) );
 
-  rhs.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
   rhs.setName( this->getName() + "/rhs" );
+  rhs.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
 
-  solution.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
   solution.setName( this->getName() + "/solution" );
+  solution.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
 }
 
 void SinglePhasePoromechanicsSolverEmbeddedFractures::addCouplingNumNonzeros( DomainPartition & domain,

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolverEmbeddedFractures.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolverEmbeddedFractures.hpp
@@ -45,8 +45,8 @@ public:
   virtual void setupSystem( DomainPartition & domain,
                             DofManager & dofManager,
                             CRSMatrix< real64, globalIndex > & localMatrix,
-                            array1d< real64 > & localRhs,
-                            array1d< real64 > & localSolution,
+                            ParallelVector & rhs,
+                            ParallelVector & solution,
                             bool const setSparsity = true ) override;
 
   virtual void

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhaseReservoir.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhaseReservoir.cpp
@@ -51,22 +51,6 @@ void SinglePhaseReservoir::initializePostInitialConditionsPreSubGroups()
   }
 }
 
-void SinglePhaseReservoir::setupSystem( DomainPartition & domain,
-                                        DofManager & dofManager,
-                                        CRSMatrix< real64, globalIndex > & localMatrix,
-                                        array1d< real64 > & localRhs,
-                                        array1d< real64 > & localSolution,
-                                        bool const setSparsity )
-{
-  ReservoirSolverBase::setupSystem( domain,
-                                    dofManager,
-                                    localMatrix,
-                                    localRhs,
-                                    localSolution,
-                                    setSparsity );
-}
-
-
 void SinglePhaseReservoir::addCouplingSparsityPattern( DomainPartition const & domain,
                                                        DofManager const & dofManager,
                                                        SparsityPatternView< globalIndex > const & pattern ) const

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhaseReservoir.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhaseReservoir.hpp
@@ -60,23 +60,6 @@ public:
    */
   static string catalogName() { return "SinglePhaseReservoir"; }
 
-  /**
-   * @defgroup Solver Interface Functions
-   *
-   * These functions provide the primary interface that is required for derived classes
-   */
-  /**@{*/
-
-  virtual void
-  setupSystem( DomainPartition & domain,
-               DofManager & dofManager,
-               CRSMatrix< real64, globalIndex > & localMatrix,
-               array1d< real64 > & localRhs,
-               array1d< real64 > & localSolution,
-               bool const setSparsity = true ) override;
-
-  /**@}*/
-
   virtual void addCouplingSparsityPattern( DomainPartition const & domain,
                                            DofManager const & dofManager,
                                            SparsityPatternView< globalIndex > const & pattern ) const override;

--- a/src/coreComponents/physicsSolvers/simplePDE/LaplaceBaseH1.cpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/LaplaceBaseH1.cpp
@@ -111,7 +111,7 @@ void LaplaceBaseH1::implicitStepSetup( real64 const & GEOSX_UNUSED_PARAM( time_n
                                        DomainPartition & domain )
 {
   // Computation of the sparsity pattern
-  setupSystem( domain, m_dofManager, m_localMatrix, m_localRhs, m_localSolution );
+  setupSystem( domain, m_dofManager, m_localMatrix, m_rhs, m_solution );
 }
 
 void LaplaceBaseH1::implicitStepComplete( real64 const & GEOSX_UNUSED_PARAM( time_n ),

--- a/src/coreComponents/physicsSolvers/simplePDE/LaplaceFEM.cpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/LaplaceFEM.cpp
@@ -91,12 +91,12 @@ LaplaceFEM::~LaplaceFEM()
 void LaplaceFEM::setupSystem( DomainPartition & domain,
                               DofManager & dofManager,
                               CRSMatrix< real64, globalIndex > & localMatrix,
-                              array1d< real64 > & localRhs,
-                              array1d< real64 > & localSolution,
+                              ParallelVector & rhs,
+                              ParallelVector & solution,
                               bool const setSparsity )
 {
   GEOSX_MARK_FUNCTION;
-  SolverBase::setupSystem( domain, dofManager, localMatrix, localRhs, localSolution, setSparsity );
+  SolverBase::setupSystem( domain, dofManager, localMatrix, rhs, solution, setSparsity );
 
   MeshLevel & mesh = domain.getMeshBody( 0 ).getMeshLevel( 0 );
   NodeManager const & nodeManager = mesh.getNodeManager();

--- a/src/coreComponents/physicsSolvers/simplePDE/LaplaceFEM.hpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/LaplaceFEM.hpp
@@ -57,8 +57,8 @@ public:
   setupSystem( DomainPartition & domain,
                DofManager & dofManager,
                CRSMatrix< real64, globalIndex > & localMatrix,
-               array1d< real64 > & localRhs,
-               array1d< real64 > & localSolution,
+               ParallelVector & rhs,
+               ParallelVector & solution,
                bool const setSparsity = false ) override;
 
   virtual void

--- a/src/coreComponents/physicsSolvers/simplePDE/LaplaceVEM.cpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/LaplaceVEM.cpp
@@ -90,12 +90,12 @@ LaplaceVEM::~LaplaceVEM()
 void LaplaceVEM::setupSystem( DomainPartition & domain,
                               DofManager & dofManager,
                               CRSMatrix< real64, globalIndex > & localMatrix,
-                              array1d< real64 > & localRhs,
-                              array1d< real64 > & localSolution,
+                              ParallelVector & rhs,
+                              ParallelVector & solution,
                               bool const setSparsity )
 {
   GEOSX_MARK_FUNCTION;
-  SolverBase::setupSystem( domain, dofManager, localMatrix, localRhs, localSolution, setSparsity );
+  SolverBase::setupSystem( domain, dofManager, localMatrix, rhs, solution, setSparsity );
 }
 
 /*

--- a/src/coreComponents/physicsSolvers/simplePDE/LaplaceVEM.hpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/LaplaceVEM.hpp
@@ -53,8 +53,8 @@ public:
   setupSystem( DomainPartition & domain,
                DofManager & dofManager,
                CRSMatrix< real64, globalIndex > & localMatrix,
-               array1d< real64 > & localRhs,
-               array1d< real64 > & localSolution,
+               ParallelVector & rhs,
+               ParallelVector & solution,
                bool const setSparsity = true ) override;
 
   virtual void

--- a/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEM.cpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEM.cpp
@@ -161,7 +161,7 @@ real64 PhaseFieldDamageFEM::solverStep( real64 const & time_n,
            timeIntegrationOption::ImplicitTransient ||
            m_timeIntegrationOption == timeIntegrationOption::SteadyState )
   {
-    this->setupSystem( domain, m_dofManager, m_localMatrix, m_localRhs, m_localSolution, false );
+    this->setupSystem( domain, m_dofManager, m_localMatrix, m_rhs, m_solution, false );
 
     dtReturn = this->nonlinearImplicitStep( time_n,
                                             dt,
@@ -171,24 +171,12 @@ real64 PhaseFieldDamageFEM::solverStep( real64 const & time_n,
   return dtReturn;
 }
 
-real64 PhaseFieldDamageFEM::explicitStep(
-  real64 const & GEOSX_UNUSED_PARAM( time_n ),
-  real64 const & dt,
-  const int GEOSX_UNUSED_PARAM( cycleNumber ),
-  DomainPartition & GEOSX_UNUSED_PARAM( domain ) )
+real64 PhaseFieldDamageFEM::explicitStep( real64 const & GEOSX_UNUSED_PARAM( time_n ),
+                                          real64 const & dt,
+                                          const int GEOSX_UNUSED_PARAM( cycleNumber ),
+                                          DomainPartition & GEOSX_UNUSED_PARAM( domain ) )
 {
   return dt;
-}
-
-void PhaseFieldDamageFEM::setupSystem( DomainPartition & domain,
-                                       DofManager & dofManager,
-                                       CRSMatrix< real64, globalIndex > & localMatrix,
-                                       array1d< real64 > & localRhs,
-                                       array1d< real64 > & localSolution,
-                                       bool const setSparsity )
-{
-  GEOSX_MARK_FUNCTION;
-  SolverBase::setupSystem( domain, dofManager, localMatrix, localRhs, localSolution, setSparsity );
 }
 
 void PhaseFieldDamageFEM::implicitStepComplete( real64 const & GEOSX_UNUSED_PARAM( time_n ),

--- a/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEM.hpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEM.hpp
@@ -71,13 +71,6 @@ public:
                                integer const cycleNumber,
                                DomainPartition & domain ) override;
 
-  virtual void setupSystem( DomainPartition & domain,
-                            DofManager & dofManager,
-                            CRSMatrix< real64, globalIndex > & localMatrix,
-                            array1d< real64 > & localRhs,
-                            array1d< real64 > & localSolution,
-                            bool const setSparsity ) override;
-
   virtual void setupDofs( DomainPartition const & domain,
                           DofManager & dofManager ) const override;
 

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsEmbeddedFractures.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsEmbeddedFractures.cpp
@@ -234,12 +234,11 @@ void SolidMechanicsEmbeddedFractures::setupSystem( DomainPartition & domain,
   localMatrix.assimilate< parallelDevicePolicy<> >( std::move( pattern ) );
   localMatrix.setName( this->getName() + "/localMatrix" );
 
-  rhs.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
   rhs.setName( this->getName() + "/rhs" );
+  rhs.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
 
-  solution.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
   solution.setName( this->getName() + "/solution" );
-
+  solution.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
 }
 
 void SolidMechanicsEmbeddedFractures::assembleSystem( real64 const time,

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsEmbeddedFractures.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsEmbeddedFractures.cpp
@@ -234,10 +234,10 @@ void SolidMechanicsEmbeddedFractures::setupSystem( DomainPartition & domain,
   localMatrix.assimilate< parallelDevicePolicy<> >( std::move( pattern ) );
   localMatrix.setName( this->getName() + "/localMatrix" );
 
-  rhs.create( localMatrix.numRows(), MPI_COMM_GEOSX );
+  rhs.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
   rhs.setName( this->getName() + "/rhs" );
 
-  solution.create( localMatrix.numRows(), MPI_COMM_GEOSX );
+  solution.create( dofManager.numLocalDofs(), MPI_COMM_GEOSX );
   solution.setName( this->getName() + "/solution" );
 
 }

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsEmbeddedFractures.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsEmbeddedFractures.hpp
@@ -53,8 +53,8 @@ public:
   virtual void setupSystem( DomainPartition & domain,
                             DofManager & dofManager,
                             CRSMatrix< real64, globalIndex > & localMatrix,
-                            array1d< real64 > & localRhs,
-                            array1d< real64 > & localSolution,
+                            ParallelVector & rhs,
+                            ParallelVector & solution,
                             bool const setSparsity = true ) override;
 
   virtual void

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
@@ -359,10 +359,8 @@ void SolidMechanicsLagrangianFEM::initializePostInitialConditionsPreSubGroups()
         real64 N[numNodesPerElem];
         for( localIndex k=0; k < elemsToNodes.size( 0 ); ++k )
         {
-          real64 elemMass = 0;
           for( localIndex q=0; q<numQuadraturePointsPerElem; ++q )
           {
-            elemMass += rho[er][esr][k][q] * detJ[k][q];
             FE_TYPE::calcN( q, N );
 
             for( localIndex a=0; a< numNodesPerElem; ++a )
@@ -442,7 +440,7 @@ real64 SolidMechanicsLagrangianFEM::solverStep( real64 const & time_n,
     implicitStepSetup( time_n, dt, domain );
     for( int solveIter=0; solveIter<maxNumResolves; ++solveIter )
     {
-      setupSystem( domain, m_dofManager, m_localMatrix, m_localRhs, m_localSolution );
+      setupSystem( domain, m_dofManager, m_localMatrix, m_rhs, m_solution );
 
       dtReturn = nonlinearImplicitStep( time_n,
                                         dt,
@@ -843,12 +841,12 @@ void SolidMechanicsLagrangianFEM::setupDofs( DomainPartition const & GEOSX_UNUSE
 void SolidMechanicsLagrangianFEM::setupSystem( DomainPartition & domain,
                                                DofManager & dofManager,
                                                CRSMatrix< real64, globalIndex > & localMatrix,
-                                               array1d< real64 > & localRhs,
-                                               array1d< real64 > & localSolution,
+                                               ParallelVector & rhs,
+                                               ParallelVector & solution,
                                                bool const setSparsity )
 {
   GEOSX_MARK_FUNCTION;
-  SolverBase::setupSystem( domain, dofManager, localMatrix, localRhs, localSolution, setSparsity );
+  SolverBase::setupSystem( domain, dofManager, localMatrix, rhs, solution, setSparsity );
 
   MeshLevel & mesh = domain.getMeshBody( 0 ).getMeshLevel( 0 );
   NodeManager const & nodeManager = mesh.getNodeManager();
@@ -983,7 +981,7 @@ SolidMechanicsLagrangianFEM::
   if( faceManager.hasWrapper( "ChomboPressure" ) )
   {
     fsManager.applyFieldValue( time_n, domain, "faceManager", "ChomboPressure" );
-    applyChomboPressure( dofManager, domain, m_localRhs );
+    applyChomboPressure( dofManager, domain, localRhs );
   }
 
   applyDisplacementBCImplicit( time_n + dt, dofManager, domain, localMatrix, localRhs );

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.hpp
@@ -115,8 +115,8 @@ public:
   setupSystem( DomainPartition & domain,
                DofManager & dofManager,
                CRSMatrix< real64, globalIndex > & localMatrix,
-               array1d< real64 > & localRhs,
-               array1d< real64 > & localSolution,
+               ParallelVector & rhs,
+               ParallelVector & solution,
                bool const setSparsity = false ) override;
 
   virtual void

--- a/src/coreComponents/schema/docs/CompressibleSolidCarmanKozenyPermeability.rst
+++ b/src/coreComponents/schema/docs/CompressibleSolidCarmanKozenyPermeability.rst
@@ -1,12 +1,13 @@
 
 
-===================== ====== ======== =========================================== 
-Name                  Type   Default  Description                                 
-===================== ====== ======== =========================================== 
-name                  string required A name is required for any non-unique nodes 
-permeabilityModelName string required Name of the permeability model.             
-porosityModelName     string required Name of the porosity model.                 
-solidModelName        string required Name of the solid model.                    
-===================== ====== ======== =========================================== 
+============================ ====== ======== =========================================== 
+Name                         Type   Default  Description                                 
+============================ ====== ======== =========================================== 
+name                         string required A name is required for any non-unique nodes 
+permeabilityModelName        string required Name of the permeability model.             
+porosityModelName            string required Name of the porosity model.                 
+solidInternalEnergyModelName string          Name of the solid internal energy model.    
+solidModelName               string required Name of the solid model.                    
+============================ ====== ======== =========================================== 
 
 

--- a/src/coreComponents/schema/docs/CompressibleSolidConstantPermeability.rst
+++ b/src/coreComponents/schema/docs/CompressibleSolidConstantPermeability.rst
@@ -1,12 +1,13 @@
 
 
-===================== ====== ======== =========================================== 
-Name                  Type   Default  Description                                 
-===================== ====== ======== =========================================== 
-name                  string required A name is required for any non-unique nodes 
-permeabilityModelName string required Name of the permeability model.             
-porosityModelName     string required Name of the porosity model.                 
-solidModelName        string required Name of the solid model.                    
-===================== ====== ======== =========================================== 
+============================ ====== ======== =========================================== 
+Name                         Type   Default  Description                                 
+============================ ====== ======== =========================================== 
+name                         string required A name is required for any non-unique nodes 
+permeabilityModelName        string required Name of the permeability model.             
+porosityModelName            string required Name of the porosity model.                 
+solidInternalEnergyModelName string          Name of the solid internal energy model.    
+solidModelName               string required Name of the solid model.                    
+============================ ====== ======== =========================================== 
 
 

--- a/src/coreComponents/schema/docs/CompressibleSolidParallelPlatesPermeability.rst
+++ b/src/coreComponents/schema/docs/CompressibleSolidParallelPlatesPermeability.rst
@@ -1,12 +1,13 @@
 
 
-===================== ====== ======== =========================================== 
-Name                  Type   Default  Description                                 
-===================== ====== ======== =========================================== 
-name                  string required A name is required for any non-unique nodes 
-permeabilityModelName string required Name of the permeability model.             
-porosityModelName     string required Name of the porosity model.                 
-solidModelName        string required Name of the solid model.                    
-===================== ====== ======== =========================================== 
+============================ ====== ======== =========================================== 
+Name                         Type   Default  Description                                 
+============================ ====== ======== =========================================== 
+name                         string required A name is required for any non-unique nodes 
+permeabilityModelName        string required Name of the permeability model.             
+porosityModelName            string required Name of the porosity model.                 
+solidInternalEnergyModelName string          Name of the solid internal energy model.    
+solidModelName               string required Name of the solid model.                    
+============================ ====== ======== =========================================== 
 
 

--- a/src/coreComponents/schema/docs/PorousDruckerPrager.rst
+++ b/src/coreComponents/schema/docs/PorousDruckerPrager.rst
@@ -1,12 +1,13 @@
 
 
-===================== ====== ======== =========================================== 
-Name                  Type   Default  Description                                 
-===================== ====== ======== =========================================== 
-name                  string required A name is required for any non-unique nodes 
-permeabilityModelName string required Name of the permeability model.             
-porosityModelName     string required Name of the porosity model.                 
-solidModelName        string required Name of the solid model.                    
-===================== ====== ======== =========================================== 
+============================ ====== ======== =========================================== 
+Name                         Type   Default  Description                                 
+============================ ====== ======== =========================================== 
+name                         string required A name is required for any non-unique nodes 
+permeabilityModelName        string required Name of the permeability model.             
+porosityModelName            string required Name of the porosity model.                 
+solidInternalEnergyModelName string          Name of the solid internal energy model.    
+solidModelName               string required Name of the solid model.                    
+============================ ====== ======== =========================================== 
 
 

--- a/src/coreComponents/schema/docs/PorousElasticIsotropic.rst
+++ b/src/coreComponents/schema/docs/PorousElasticIsotropic.rst
@@ -1,12 +1,13 @@
 
 
-===================== ====== ======== =========================================== 
-Name                  Type   Default  Description                                 
-===================== ====== ======== =========================================== 
-name                  string required A name is required for any non-unique nodes 
-permeabilityModelName string required Name of the permeability model.             
-porosityModelName     string required Name of the porosity model.                 
-solidModelName        string required Name of the solid model.                    
-===================== ====== ======== =========================================== 
+============================ ====== ======== =========================================== 
+Name                         Type   Default  Description                                 
+============================ ====== ======== =========================================== 
+name                         string required A name is required for any non-unique nodes 
+permeabilityModelName        string required Name of the permeability model.             
+porosityModelName            string required Name of the porosity model.                 
+solidInternalEnergyModelName string          Name of the solid internal energy model.    
+solidModelName               string required Name of the solid model.                    
+============================ ====== ======== =========================================== 
 
 

--- a/src/coreComponents/schema/docs/PorousElasticOrthotropic.rst
+++ b/src/coreComponents/schema/docs/PorousElasticOrthotropic.rst
@@ -1,12 +1,13 @@
 
 
-===================== ====== ======== =========================================== 
-Name                  Type   Default  Description                                 
-===================== ====== ======== =========================================== 
-name                  string required A name is required for any non-unique nodes 
-permeabilityModelName string required Name of the permeability model.             
-porosityModelName     string required Name of the porosity model.                 
-solidModelName        string required Name of the solid model.                    
-===================== ====== ======== =========================================== 
+============================ ====== ======== =========================================== 
+Name                         Type   Default  Description                                 
+============================ ====== ======== =========================================== 
+name                         string required A name is required for any non-unique nodes 
+permeabilityModelName        string required Name of the permeability model.             
+porosityModelName            string required Name of the porosity model.                 
+solidInternalEnergyModelName string          Name of the solid internal energy model.    
+solidModelName               string required Name of the solid model.                    
+============================ ====== ======== =========================================== 
 
 

--- a/src/coreComponents/schema/docs/PorousElasticTransverseIsotropic.rst
+++ b/src/coreComponents/schema/docs/PorousElasticTransverseIsotropic.rst
@@ -1,12 +1,13 @@
 
 
-===================== ====== ======== =========================================== 
-Name                  Type   Default  Description                                 
-===================== ====== ======== =========================================== 
-name                  string required A name is required for any non-unique nodes 
-permeabilityModelName string required Name of the permeability model.             
-porosityModelName     string required Name of the porosity model.                 
-solidModelName        string required Name of the solid model.                    
-===================== ====== ======== =========================================== 
+============================ ====== ======== =========================================== 
+Name                         Type   Default  Description                                 
+============================ ====== ======== =========================================== 
+name                         string required A name is required for any non-unique nodes 
+permeabilityModelName        string required Name of the permeability model.             
+porosityModelName            string required Name of the porosity model.                 
+solidInternalEnergyModelName string          Name of the solid internal energy model.    
+solidModelName               string required Name of the solid model.                    
+============================ ====== ======== =========================================== 
 
 

--- a/src/coreComponents/schema/docs/PorousExtendedDruckerPrager.rst
+++ b/src/coreComponents/schema/docs/PorousExtendedDruckerPrager.rst
@@ -1,12 +1,13 @@
 
 
-===================== ====== ======== =========================================== 
-Name                  Type   Default  Description                                 
-===================== ====== ======== =========================================== 
-name                  string required A name is required for any non-unique nodes 
-permeabilityModelName string required Name of the permeability model.             
-porosityModelName     string required Name of the porosity model.                 
-solidModelName        string required Name of the solid model.                    
-===================== ====== ======== =========================================== 
+============================ ====== ======== =========================================== 
+Name                         Type   Default  Description                                 
+============================ ====== ======== =========================================== 
+name                         string required A name is required for any non-unique nodes 
+permeabilityModelName        string required Name of the permeability model.             
+porosityModelName            string required Name of the porosity model.                 
+solidInternalEnergyModelName string          Name of the solid internal energy model.    
+solidModelName               string required Name of the solid model.                    
+============================ ====== ======== =========================================== 
 
 

--- a/src/coreComponents/schema/docs/ProppantSolidProppantPermeability.rst
+++ b/src/coreComponents/schema/docs/ProppantSolidProppantPermeability.rst
@@ -1,12 +1,13 @@
 
 
-===================== ====== ======== =========================================== 
-Name                  Type   Default  Description                                 
-===================== ====== ======== =========================================== 
-name                  string required A name is required for any non-unique nodes 
-permeabilityModelName string required Name of the permeability model.             
-porosityModelName     string required Name of the porosity model.                 
-solidModelName        string required Name of the solid model.                    
-===================== ====== ======== =========================================== 
+============================ ====== ======== =========================================== 
+Name                         Type   Default  Description                                 
+============================ ====== ======== =========================================== 
+name                         string required A name is required for any non-unique nodes 
+permeabilityModelName        string required Name of the permeability model.             
+porosityModelName            string required Name of the porosity model.                 
+solidInternalEnergyModelName string          Name of the solid internal energy model.    
+solidModelName               string required Name of the solid model.                    
+============================ ====== ======== =========================================== 
 
 

--- a/src/coreComponents/schema/schema.xsd
+++ b/src/coreComponents/schema/schema.xsd
@@ -2104,6 +2104,8 @@ The expected format is "{ waterMax, oilMax }", in that order-->
 		<xsd:attribute name="permeabilityModelName" type="string" use="required" />
 		<!--porosityModelName => Name of the porosity model.-->
 		<xsd:attribute name="porosityModelName" type="string" use="required" />
+		<!--solidInternalEnergyModelName => Name of the solid internal energy model.-->
+		<xsd:attribute name="solidInternalEnergyModelName" type="string" default="" />
 		<!--solidModelName => Name of the solid model.-->
 		<xsd:attribute name="solidModelName" type="string" use="required" />
 		<!--name => A name is required for any non-unique nodes-->
@@ -2114,6 +2116,8 @@ The expected format is "{ waterMax, oilMax }", in that order-->
 		<xsd:attribute name="permeabilityModelName" type="string" use="required" />
 		<!--porosityModelName => Name of the porosity model.-->
 		<xsd:attribute name="porosityModelName" type="string" use="required" />
+		<!--solidInternalEnergyModelName => Name of the solid internal energy model.-->
+		<xsd:attribute name="solidInternalEnergyModelName" type="string" default="" />
 		<!--solidModelName => Name of the solid model.-->
 		<xsd:attribute name="solidModelName" type="string" use="required" />
 		<!--name => A name is required for any non-unique nodes-->
@@ -2124,6 +2128,8 @@ The expected format is "{ waterMax, oilMax }", in that order-->
 		<xsd:attribute name="permeabilityModelName" type="string" use="required" />
 		<!--porosityModelName => Name of the porosity model.-->
 		<xsd:attribute name="porosityModelName" type="string" use="required" />
+		<!--solidInternalEnergyModelName => Name of the solid internal energy model.-->
+		<xsd:attribute name="solidInternalEnergyModelName" type="string" default="" />
 		<!--solidModelName => Name of the solid model.-->
 		<xsd:attribute name="solidModelName" type="string" use="required" />
 		<!--name => A name is required for any non-unique nodes-->
@@ -2484,6 +2490,8 @@ For instance, if "oil" is before "gas" in "phaseNames", the table order should b
 		<xsd:attribute name="permeabilityModelName" type="string" use="required" />
 		<!--porosityModelName => Name of the porosity model.-->
 		<xsd:attribute name="porosityModelName" type="string" use="required" />
+		<!--solidInternalEnergyModelName => Name of the solid internal energy model.-->
+		<xsd:attribute name="solidInternalEnergyModelName" type="string" default="" />
 		<!--solidModelName => Name of the solid model.-->
 		<xsd:attribute name="solidModelName" type="string" use="required" />
 		<!--name => A name is required for any non-unique nodes-->
@@ -2494,6 +2502,8 @@ For instance, if "oil" is before "gas" in "phaseNames", the table order should b
 		<xsd:attribute name="permeabilityModelName" type="string" use="required" />
 		<!--porosityModelName => Name of the porosity model.-->
 		<xsd:attribute name="porosityModelName" type="string" use="required" />
+		<!--solidInternalEnergyModelName => Name of the solid internal energy model.-->
+		<xsd:attribute name="solidInternalEnergyModelName" type="string" default="" />
 		<!--solidModelName => Name of the solid model.-->
 		<xsd:attribute name="solidModelName" type="string" use="required" />
 		<!--name => A name is required for any non-unique nodes-->
@@ -2504,6 +2514,8 @@ For instance, if "oil" is before "gas" in "phaseNames", the table order should b
 		<xsd:attribute name="permeabilityModelName" type="string" use="required" />
 		<!--porosityModelName => Name of the porosity model.-->
 		<xsd:attribute name="porosityModelName" type="string" use="required" />
+		<!--solidInternalEnergyModelName => Name of the solid internal energy model.-->
+		<xsd:attribute name="solidInternalEnergyModelName" type="string" default="" />
 		<!--solidModelName => Name of the solid model.-->
 		<xsd:attribute name="solidModelName" type="string" use="required" />
 		<!--name => A name is required for any non-unique nodes-->
@@ -2514,6 +2526,8 @@ For instance, if "oil" is before "gas" in "phaseNames", the table order should b
 		<xsd:attribute name="permeabilityModelName" type="string" use="required" />
 		<!--porosityModelName => Name of the porosity model.-->
 		<xsd:attribute name="porosityModelName" type="string" use="required" />
+		<!--solidInternalEnergyModelName => Name of the solid internal energy model.-->
+		<xsd:attribute name="solidInternalEnergyModelName" type="string" default="" />
 		<!--solidModelName => Name of the solid model.-->
 		<xsd:attribute name="solidModelName" type="string" use="required" />
 		<!--name => A name is required for any non-unique nodes-->
@@ -2524,6 +2538,8 @@ For instance, if "oil" is before "gas" in "phaseNames", the table order should b
 		<xsd:attribute name="permeabilityModelName" type="string" use="required" />
 		<!--porosityModelName => Name of the porosity model.-->
 		<xsd:attribute name="porosityModelName" type="string" use="required" />
+		<!--solidInternalEnergyModelName => Name of the solid internal energy model.-->
+		<xsd:attribute name="solidInternalEnergyModelName" type="string" default="" />
 		<!--solidModelName => Name of the solid model.-->
 		<xsd:attribute name="solidModelName" type="string" use="required" />
 		<!--name => A name is required for any non-unique nodes-->
@@ -2588,6 +2604,8 @@ For instance, if "oil" is before "gas" in "phaseNames", the table order should b
 		<xsd:attribute name="permeabilityModelName" type="string" use="required" />
 		<!--porosityModelName => Name of the porosity model.-->
 		<xsd:attribute name="porosityModelName" type="string" use="required" />
+		<!--solidInternalEnergyModelName => Name of the solid internal energy model.-->
+		<xsd:attribute name="solidInternalEnergyModelName" type="string" default="" />
 		<!--solidModelName => Name of the solid model.-->
 		<xsd:attribute name="solidModelName" type="string" use="required" />
 		<!--name => A name is required for any non-unique nodes-->

--- a/src/coreComponents/unitTests/fluidFlowTests/testCompMultiphaseFlow.cpp
+++ b/src/coreComponents/unitTests/fluidFlowTests/testCompMultiphaseFlow.cpp
@@ -615,8 +615,8 @@ protected:
     solver->setupSystem( domain,
                          solver->getDofManager(),
                          solver->getLocalMatrix(),
-                         solver->getLocalRhs(),
-                         solver->getLocalSolution() );
+                         solver->getSystemRhs(),
+                         solver->getSystemSolution() );
 
     solver->implicitStepSetup( time, dt, domain );
   }

--- a/src/coreComponents/unitTests/fluidFlowTests/testCompMultiphaseFlow.cpp
+++ b/src/coreComponents/unitTests/fluidFlowTests/testCompMultiphaseFlow.cpp
@@ -473,7 +473,7 @@ void testNumericalJacobian( CompositionalMultiphaseFVM & solver,
   localIndex const NC = solver.numFluidComponents();
 
   CRSMatrix< real64, globalIndex > const & jacobian = solver.getLocalMatrix();
-  array1d< real64 > const & residual = solver.getLocalRhs();
+  array1d< real64 > residual( jacobian.numRows() );
   DofManager const & dofManager = solver.getDofManager();
 
   MeshLevel & mesh = domain.getMeshBody( 0 ).getMeshLevel( 0 );

--- a/src/coreComponents/unitTests/fluidFlowTests/testCompMultiphaseFlowHybrid.cpp
+++ b/src/coreComponents/unitTests/fluidFlowTests/testCompMultiphaseFlowHybrid.cpp
@@ -167,7 +167,7 @@ void testNumericalJacobian( CompositionalMultiphaseHybridFVM & solver,
   localIndex const NC = solver.numFluidComponents();
 
   CRSMatrix< real64, globalIndex > const & jacobian = solver.getLocalMatrix();
-  array1d< real64 > const & residual = solver.getLocalRhs();
+  array1d< real64 > residual( jacobian.numRows() );
   DofManager const & dofManager = solver.getDofManager();
 
   MeshLevel & mesh = domain.getMeshBody( 0 ).getMeshLevel( 0 );
@@ -348,8 +348,8 @@ protected:
     solver->setupSystem( domain,
                          solver->getDofManager(),
                          solver->getLocalMatrix(),
-                         solver->getLocalRhs(),
-                         solver->getLocalSolution() );
+                         solver->getSystemRhs(),
+                         solver->getSystemSolution() );
 
     solver->implicitStepSetup( time, dt, domain );
   }

--- a/src/coreComponents/unitTests/linearAlgebraTests/testDofManager.cpp
+++ b/src/coreComponents/unitTests/linearAlgebraTests/testDofManager.cpp
@@ -796,8 +796,8 @@ void DofManagerRestrictorTest< LAI >::test( std::vector< FieldDesc > fields,
 
   // Create prolongation and restriction to 2 out of 3 components
   Matrix R, P;
-  dofManager.makeRestrictor( selection, A.getComm(), false, R );
-  dofManager.makeRestrictor( selection, A.getComm(), true, P );
+  dofManager.makeRestrictor( selection, A.comm(), false, R );
+  dofManager.makeRestrictor( selection, A.comm(), true, P );
 
   // Compute the sub-matrix via PtAP
   Matrix Asub_PtAP;

--- a/src/coreComponents/unitTests/wellsTests/testReservoirCompositionalMultiphaseMSWells.cpp
+++ b/src/coreComponents/unitTests/wellsTests/testReservoirCompositionalMultiphaseMSWells.cpp
@@ -216,7 +216,7 @@ void testNumericalJacobian( CompositionalMultiphaseReservoir & solver,
   localIndex const NC = flowSolver.numFluidComponents();
 
   CRSMatrix< real64, globalIndex > const & jacobian = solver.getLocalMatrix();
-  array1d< real64 > const & residual = solver.getLocalRhs();
+  array1d< real64 > residual( jacobian.numRows() );
   DofManager const & dofManager = solver.getDofManager();
 
   MeshLevel & mesh = domain.getMeshBody( 0 ).getMeshLevel( 0 );
@@ -480,8 +480,8 @@ protected:
     solver->setupSystem( domain,
                          solver->getDofManager(),
                          solver->getLocalMatrix(),
-                         solver->getLocalRhs(),
-                         solver->getLocalSolution() );
+                         solver->getSystemRhs(),
+                         solver->getSystemSolution() );
 
     solver->implicitStepSetup( time, dt, domain );
   }

--- a/src/coreComponents/unitTests/wellsTests/testReservoirSinglePhaseMSWells.cpp
+++ b/src/coreComponents/unitTests/wellsTests/testReservoirSinglePhaseMSWells.cpp
@@ -166,7 +166,7 @@ void testNumericalJacobian( SinglePhaseReservoir & solver,
   SinglePhaseFVM< SinglePhaseBase > & flowSolver = dynamicCast< SinglePhaseFVM< SinglePhaseBase > & >( *solver.getFlowSolver() );
 
   CRSMatrix< real64, globalIndex > const & jacobian = solver.getLocalMatrix();
-  array1d< real64 > const & residual = solver.getLocalRhs();
+  array1d< real64 > residual( jacobian.numRows() );
   DofManager const & dofManager = solver.getDofManager();
 
   MeshLevel & mesh = domain.getMeshBody( 0 ).getMeshLevel( 0 );
@@ -363,8 +363,8 @@ protected:
     solver->setupSystem( domain,
                          solver->getDofManager(),
                          solver->getLocalMatrix(),
-                         solver->getLocalRhs(),
-                         solver->getLocalSolution() );
+                         solver->getSystemRhs(),
+                         solver->getSystemSolution() );
 
     solver->implicitStepSetup( time, dt, domain );
   }


### PR DESCRIPTION
This PR is a step towards https://github.com/GEOSX/GEOSX/issues/1675
Before addressing matrices, I'm taking a stab at a much easier problem - vectors.

This PR has 3 goals:
1. Remove all element-wise methods from vector classes (add/set/insert/get)
2. Zero-copy assembly interface (LA packages wrap and operate directly on GEOSX-managed memory)
3. Clean up implementation of `HypreVector` by removing `IJVector` object and always operate directly on the `ParVector` object.

The new vector API functions as follows:
* All vector objects contain an `array1d< real64 > m_values;` which replaces `m_localRhs` and `m_localSolution`
* The physics solver calls `rhs.create( localSize, comm );` (now the only creation method) which allocates the array and creates the internal LA object wrapping array's memory in the correct space (i.e. device pointer in case of hypre-gpu, host pointer for all other)
* The physics solver calls `arrayView1d< real64 > const localRhs = rhs.open();` which returns a mutable view that can be used in assembly kernels as before
* The physics solver calls `rhs.close();`, which moves the assembled values to the correct memory space if needed
* The linear solver solves the system, operating directly on the rhs/solution pointers in the appropriate space
* The linear solver calls `solution.touch()` which calls `m_values.registerTouch( space )` and notifies it of value changes
* The physics solver gets a const view to solution values by calling `arrayView1d< real64 const > localSol = solution.values();` and proceeds to apply them as before

This PR passes unit tests and integrated tests, including in hypre-gpu builds (with the usual diffs for int32/int64 types).

I also ran a couple benchmark inputs that use Krylov solvers and AMG (`beamBending_benchmark.xml` and `SSLE-QS-small.xml`) with hypre-gpu build. They seem to run fine without segfaulting (and without any ATS magic involved). This means that at least for rhs/solution vectors hypre does not seem to require UM, though it still needs more verification - I'd welcome more cases that I can run with hypre-gpu, especially using MGR - the ones I tried like SPE10 and Egg all fail similarly with FP exceptions on `develop` and this PR.

I wasn't able to measure any statistically significant speedup/slowdown compared to `develop`, but I don't think much speedup should've been expected - the linear solve time dwarfs everything else, including memory transfers, even on my PCI-E machine.