### PR TITLE
Check that PR is assigned

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -185,7 +185,7 @@ jobs:
     script: scripts/test_submodule_updated.sh
   - stage: checks
     name: check_pr_is_assigned
-    <<: *assign_script
+    <<: *assigned_script
   - stage: builds
     name: Ubuntu18.04_clang8.0.0_cuda10.1.243_debug
     <<: *geosx_linux_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,7 @@ draft_script: &draft_script
 
 # PR must be assigned to be merged.
 # This script will fail if this is not the case.
-assign_script: &assign_script
+assigned_script: &assigned_script
   script:
   # TRAVIS_PULL_REQUEST is false if job is not from a PR
   - if [[ $TRAVIS_PULL_REQUEST == false ]]; then exit 0; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,6 +127,18 @@ draft_script: &draft_script
       exit 0
     fi
 
+# PR must be assigned to be merged.
+# This script will fail if this is not the case.
+assign_script: &assign_script
+  script:
+  # TRAVIS_PULL_REQUEST is false if job is not from a PR
+  - if [[ $TRAVIS_PULL_REQUEST == false ]]; then exit 0; fi;
+  - |
+    is_assigned=$(curl -H "Accept: application/vnd.github.v3+json" \
+        https://api.github.com/repos/$TRAVIS_PULL_REQUEST_SLUG/pulls/$TRAVIS_PULL_REQUEST | \
+        jq ".assignees|length")
+  - if [[ $is_assigned == 0 ]]; then exit 1; else exit 0; fi
+
 return_script: &return_script
   script:
   # Verifies if all the "checks" jobs passed
@@ -149,6 +161,7 @@ jobs:
   - name: code_style
   - name: documentation
   - name: check_submodules
+  - name: check_pr_is_assigned
   include:
   - stage: checks
     name: check_pr_is_not_a_draft
@@ -170,6 +183,9 @@ jobs:
   - stage: checks
     name: check_submodules
     script: scripts/test_submodule_updated.sh
+  - stage: checks
+    name: check_pr_is_assigned
+    <<: *assign_script
   - stage: builds
     name: Ubuntu18.04_clang8.0.0_cuda10.1.243_debug
     <<: *geosx_linux_build


### PR DESCRIPTION
Defines a `check` step that fails (at end) if the PR is assigned to no one (like we do for the `documentation` or `code_style` for instance).
This patch is meant to enforce part of or merge policy.
 
I've checked that it works by assigning and unassigning myself (on this PR).
It is enough to assign anyone and run again the proper steps (2 times 20 seconds) in order to get the global validation to green (no need of a full replay).