### PR TITLE
Fix #1694

### DIFF
--- a/src/coreComponents/linearAlgebra/interfaces/petsc/PetscVector.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/petsc/PetscVector.cpp
@@ -127,6 +127,8 @@ void PetscVector::close()
   GEOSX_LAI_ASSERT( !closed() );
   m_values.move( LvArray::MemorySpace::host, false );
   m_closed = true;
+  GEOSX_LAI_CHECK_ERROR( VecAssemblyBegin( m_vec ) );
+  GEOSX_LAI_CHECK_ERROR( VecAssemblyEnd( m_vec ) );
 }
 
 void PetscVector::touch()


### PR DESCRIPTION
Resolves https://github.com/GEOSX/GEOSX/issues/1694

PETSc caches previously computed norm values, so it needs a little hint to drop them after we've modified the values externally.