### PR TITLE
Add host-configs for Sherlock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: minimal
 
 env:
   global:
-  - GEOSX_TPL_TAG=168-693
+  - GEOSX_TPL_TAG=170-701
   - secure: CGs2uH6efq1Me6xJWRr0BnwtwxoujzlowC4FHXHdWbNOkPsXf7nCgdaW5vthfD3bhnOeEUQSrfxdhTRtyU/NfcKLmKgGBnZOdUG4/JJK4gDSJ2Wp8LZ/mB0QEoODKVxbh+YtoAiHe3y4M9PGCs+wkNDw/3eEU00cK12DZ6gad0RbLjI3xkhEr/ZEZDZkcYg9yHAhl5bmpqoh/6QGnIg8mxIqdAtGDw+6tT0EgUqjeqc5bG5WwsamKzJItHSXD5zx8IJAlgDk4EzEGjZe0m56YnNfb9iwqqUsmL3Cuwgs7ByVDYw78JC5Kv42YqoxA5BxMT2mFsEe37TpYNXlzofU7ma2Duw9DGXWQd4IkTCcBxlyR0I0bfo0TmgO+y7PYG9lIyHPUkENemdozsZcWamqqkqegiEdRhDVYlSRo3mu7iCwTS6ZTALliVyEYjYxYb7oAnR3cNywXjblTCI8oKfgLSY+8WijM9SRl57JruIHLkLMCjmRI+cZBfv5tS2tYQTBPkygGrigrrN77ZiC7/TGyfggSN0+y0oYtOAgqEnBcKcreiibMW7tKcV2Z1RFD9ZvIkSc1EXLUPDP8FX1oyhmqBMqVo8LksrYLDJHQ05+F3YNgl2taSt7uMjQ4e8iZ3/IjFeMnbylDw+cj/RbS520HXsFPbWFm2Pb9pceA9n6GnY=
 
 # The integrated test repository contains large data (using git lfs) and we do not use them here.

--- a/host-configs/Stanford/sherlock-base.cmake
+++ b/host-configs/Stanford/sherlock-base.cmake
@@ -1,0 +1,51 @@
+site_name(HOST_NAME)
+
+# Compilers
+set(CMAKE_C_COMPILER       "${GCC_ROOT}/bin/gcc"      CACHE PATH "")
+set(CMAKE_CXX_COMPILER     "${GCC_ROOT}/bin/g++"      CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "${GCC_ROOT}/bin/gfortran" CACHE PATH "")
+
+# OpenMP options
+set(ENABLE_OPENMP ON CACHE BOOL "")
+
+# MPI options
+set(ENABLE_MPI ON CACHE PATH "" FORCE)
+set(MPI_C_COMPILER       "${MPI_ROOT}/bin/mpicc"   CACHE PATH "")
+set(MPI_CXX_COMPILER     "${MPI_ROOT}/bin/mpic++"  CACHE PATH "")
+set(MPI_Fortran_COMPILER "${MPI_ROOT}/bin/mpifort" CACHE PATH "")
+set(MPIEXEC              "${MPI_ROOT}/bin/mpirun"  CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
+set(ENABLE_WRAP_ALL_TESTS_WITH_MPIEXEC ON CACHE BOOL "")
+
+# CUDA options
+if(ENABLE_CUDA)
+  set(CMAKE_CUDA_HOST_COMPILER ${MPI_CXX_COMPILER} CACHE STRING "") 
+  set(CMAKE_CUDA_COMPILER ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc CACHE STRING "") 
+  set(CMAKE_CUDA_STANDARD 14 CACHE STRING "") 
+  set(CMAKE_CUDA_FLAGS "-restrict -arch ${CUDA_ARCH} --expt-extended-lambda --expt-relaxed-constexpr -Werror cross-execution-space-call,reorder,deprecated-declarations" CACHE STRING "") 
+  set(CMAKE_CUDA_FLAGS_RELEASE "-O3 -DNDEBUG -Xcompiler -DNDEBUG -Xcompiler -O3" CACHE STRING "") 
+  set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-g -lineinfo ${CMAKE_CUDA_FLAGS_RELEASE}" CACHE STRING "") 
+  set(CMAKE_CUDA_FLAGS_DEBUG "-g -G -O0 -Xcompiler -O0" CACHE STRING "") 
+endif()
+
+# Blas/Lapack options
+set(BLAS_LIBRARIES "/share/software/user/open/openblas/0.3.10/lib/libblas.so" CACHE STRING "")
+set(LAPACK_LIBRARIES "/share/software/user/open/openblas/0.3.10/lib/liblapack.so" CACHE STRING "")
+
+# Python options
+#set(ENABLE_PYLVARRAY ON CACHE BOOL "")
+#set(ENABLE_PYGEOSX ON CACHE BOOL "")
+#set(PYTHON_DIR "/share/software/user/open/python/3.6.1" CACHE PATH "")
+#set(Python3_EXECUTABLE "/share/software/user/open/python/3.6.1/bin/python3" CACHE PATH "")
+
+set(ENABLE_VALGRIND OFF CACHE BOOL "")
+set(ENABLE_CALIPER ON CACHE BOOL "")
+
+if(ENABLE_HYPRE_CUDA)
+  set(ENABLE_PETSC OFF CACHE BOOL "") 
+  set(ENABLE_TRILINOS OFF CACHE BOOL "") 
+  set(GEOSX_LA_INTERFACE "Hypre" CACHE STRING "") 
+endif()
+
+set(GEOSX_TPL_DIR /home/groups/tchelepi/geosx/thirdPartyLibs/install-${CONFIG_NAME}-release CACHE PATH "")
+include(/home/groups/tchelepi/geosx/GEOSX/host-configs/tpls.cmake)

--- a/host-configs/Stanford/sherlock-gcc10-cuda11-ampere.cmake
+++ b/host-configs/Stanford/sherlock-gcc10-cuda11-ampere.cmake
@@ -1,0 +1,13 @@
+set(CONFIG_NAME "sherlock-gcc10-cuda11-ampere" CACHE PATH "") 
+
+set(GCC_ROOT "/share/software/user/open/gcc/10.1.0" CACHE PATH "")
+set(MPI_ROOT "/share/software/user/open/openmpi/4.1.0" CACHE PATH "")
+
+set(ENABLE_CUDA ON CACHE BOOL "" FORCE)
+set(ENABLE_HYPRE_CUDA ON CACHE BOOL "" FORCE)
+set(CUDA_ARCH "sm_80" CACHE STRING "") 
+set(CMAKE_CUDA_ARCHITECTURES "80" CACHE STRING "")
+set(CUDA_TOOLKIT_ROOT_DIR "/share/software/user/open/cuda/11.2.0" CACHE STRING "") 
+
+include(/home/groups/tchelepi/geosx/host-configs/sherlock-base.cmake)
+

--- a/host-configs/Stanford/sherlock-gcc10-cuda11-volta.cmake
+++ b/host-configs/Stanford/sherlock-gcc10-cuda11-volta.cmake
@@ -1,0 +1,13 @@
+set(CONFIG_NAME "sherlock-gcc10-cuda11-volta" CACHE PATH "") 
+
+set(GCC_ROOT "/share/software/user/open/gcc/10.1.0" CACHE PATH "")
+set(MPI_ROOT "/share/software/user/open/openmpi/4.1.0" CACHE PATH "")
+
+set(ENABLE_CUDA ON CACHE BOOL "" FORCE)
+set(ENABLE_HYPRE_CUDA ON CACHE BOOL "" FORCE)
+set(CUDA_ARCH "sm_70" CACHE STRING "") 
+set(CMAKE_CUDA_ARCHITECTURES "70" CACHE STRING "")
+set(CUDA_TOOLKIT_ROOT_DIR "/share/software/user/open/cuda/11.2.0" CACHE STRING "") 
+
+include(/home/groups/tchelepi/geosx/host-configs/sherlock-base.cmake)
+

--- a/host-configs/Stanford/sherlock-gcc10.cmake
+++ b/host-configs/Stanford/sherlock-gcc10.cmake
@@ -1,0 +1,7 @@
+set(CONFIG_NAME "sherlock-gcc10" CACHE PATH "") 
+
+set(GCC_ROOT "/share/software/user/open/gcc/10.1.0" CACHE PATH "")
+set(MPI_ROOT "/share/software/user/open/openmpi/4.1.0" CACHE PATH "")
+
+include(/home/groups/tchelepi/geosx/host-configs/sherlock-base.cmake)
+

--- a/host-configs/Stanford/sherlock-gcc8-cuda10-volta.cmake
+++ b/host-configs/Stanford/sherlock-gcc8-cuda10-volta.cmake
@@ -1,0 +1,13 @@
+set(CONFIG_NAME "sherlock-gcc8-cuda10-volta" CACHE PATH "") 
+
+set(GCC_ROOT "/share/software/user/open/gcc/8.1.0" CACHE PATH "")
+set(MPI_ROOT "/share/software/user/open/openmpi/4.0.3" CACHE PATH "")
+
+set(ENABLE_CUDA ON CACHE BOOL "" FORCE)
+set(ENABLE_HYPRE_CUDA ON CACHE BOOL "" FORCE)
+set(CUDA_ARCH "sm_70" CACHE STRING "") 
+set(CMAKE_CUDA_ARCHITECTURES "70" CACHE STRING "")
+set(CUDA_TOOLKIT_ROOT_DIR "/share/software/user/open/cuda/10.2.89" CACHE STRING "") 
+
+include(/home/groups/tchelepi/geosx/host-configs/sherlock-base.cmake)
+

--- a/host-configs/Stanford/sherlock-modules.sh
+++ b/host-configs/Stanford/sherlock-modules.sh
@@ -1,0 +1,11 @@
+module load system
+module load git/2.12.2
+module load git-lfs/2.4.0
+module load cmake/3.20.3
+module load ninja/1.9.0
+module load py-mpi4py/3.0.3_py36
+module load py-h5py/2.10.0_py36
+module load gcc/10.1.0
+module load openmpi/4.1.0
+module load cuda/11.2.0
+module load libevent/2.1.12 # needed for silo


### PR DESCRIPTION
Adds 4 host-configs for Sherlock cluster:
  * gcc-10.1.0 (CPU nodes)
  * gcc-8.1.0 + cuda-10.2.89 + sm_70 (V100 nodes)
  * gcc-10.1.0 + cuda-11.2.0 + sm_70 (V100 nodes)
  * gcc-10.1.0 + cuda-11.2.0 + sm_80 (A100 nodes)
 
Also included is a script with recommended modules setup (git, cmake, MPI, mpi4py, h5py, etc.).
Updates TPL tag to include https://github.com/GEOSX/thirdPartyLibs/pull/170