### PR TITLE
Implemented extrinsic data for multiphase constitutive models

### DIFF
--- a/src/coreComponents/constitutive/CMakeLists.txt
+++ b/src/coreComponents/constitutive/CMakeLists.txt
@@ -10,6 +10,7 @@ set( constitutive_headers
      NullModel.hpp
      capillaryPressure/BrooksCoreyCapillaryPressure.hpp
      capillaryPressure/CapillaryPressureBase.hpp
+     capillaryPressure/CapillaryPressureExtrinsicData.hpp     
      capillaryPressure/TableCapillaryPressure.hpp     
      capillaryPressure/VanGenuchtenCapillaryPressure.hpp
      capillaryPressure/capillaryPressureSelector.hpp
@@ -24,6 +25,7 @@ set( constitutive_headers
      fluid/DeadOilFluid.hpp
      fluid/MultiFluidBase.hpp
      fluid/MultiFluidUtils.hpp
+     fluid/MultiFluidExtrinsicData.hpp
      fluid/MultiPhaseMultiComponentFluid.hpp     
      fluid/PVTOData.hpp
      fluid/PVTFunctions/PhillipsBrineDensity.hpp
@@ -58,7 +60,8 @@ set( constitutive_headers
      permeability/ProppantPermeability.hpp     
      relativePermeability/BrooksCoreyBakerRelativePermeability.hpp
      relativePermeability/BrooksCoreyRelativePermeability.hpp
-     relativePermeability/RelativePermeabilityBase.hpp
+     relativePermeability/RelativePermeabilityBase.hpp 
+     relativePermeability/RelativePermeabilityExtrinsicData.hpp    
      relativePermeability/RelativePermeabilityInterpolators.hpp
      relativePermeability/TableRelativePermeability.hpp
      relativePermeability/VanGenuchtenBakerRelativePermeability.hpp

--- a/src/coreComponents/constitutive/ConstitutiveBase.hpp
+++ b/src/coreComponents/constitutive/ConstitutiveBase.hpp
@@ -116,18 +116,44 @@ public:
    * @param[in] extrinsicData the extrinsic data struct corresponding to the object being registered
    * @param[in] newObject a pointer to the object that is being registered
    * @return A reference to the newly registered/created Wrapper
+   * TODO: move up to Group
    */
   template< typename TRAIT >
   dataRepository::Wrapper< typename TRAIT::type > & registerExtrinsicData( TRAIT const & extrinsicDataTrait,
                                                                            typename TRAIT::type * newObject )
   {
     return registerWrapper( extrinsicDataTrait.key(), newObject ).
-             setApplyDefaultValue( TRAIT::defaultValue ).
+             setApplyDefaultValue( extrinsicDataTrait.defaultValue() ).
              setPlotLevel( TRAIT::plotLevel ).
              setRestartFlags( TRAIT::restartFlag ).
              setDescription( TRAIT::description );
   }
 
+  /**
+   * @brief Get a wrapper associated with a trait from the constitutive model
+   * @tparam TRAIT The trait that holds the type and key of the data
+   *   to be retrieved from this constitutive model
+   * @return A const reference to a view to const wrapper.
+   * TODO: move up to Group
+   */
+  template< typename TRAIT >
+  dataRepository::Wrapper< typename TRAIT::type > const & getExtrinsicData() const
+  {
+    return this->getWrapper< typename TRAIT::type >( TRAIT::key() );
+  }
+
+  /**
+   * @brief Get a wrapper associated with a trait from the constitutive model
+   * @tparam TRAIT The trait that holds the type and key of the data
+   *   to be retrieved from this constitutive model
+   * @return A reference to the wrapper.
+   * TODO: move up to Group
+   */
+  template< typename TRAIT >
+  dataRepository::Wrapper< typename TRAIT::type > & getExtrinsicData()
+  {
+    return this->getWrapper< typename TRAIT::type >( TRAIT::key() );
+  }
 
 protected:
 

--- a/src/coreComponents/constitutive/ConstitutiveBase.hpp
+++ b/src/coreComponents/constitutive/ConstitutiveBase.hpp
@@ -110,6 +110,25 @@ public:
 
   virtual std::vector< string > getSubRelationNames() const { return {}; }
 
+  /**
+   * @brief Helper function to register extrinsic data on a constitutive model
+   * @tparam TRAIT the type of extrinsic data
+   * @param[in] extrinsicData the extrinsic data struct corresponding to the object being registered
+   * @param[in] newObject a pointer to the object that is being registered
+   * @return A reference to the newly registered/created Wrapper
+   */
+  template< typename TRAIT >
+  dataRepository::Wrapper< typename TRAIT::type > & registerExtrinsicData( TRAIT const & extrinsicDataTrait,
+                                                                           typename TRAIT::type * newObject )
+  {
+    return registerWrapper( extrinsicDataTrait.key(), newObject ).
+             setApplyDefaultValue( TRAIT::defaultValue ).
+             setPlotLevel( TRAIT::plotLevel ).
+             setRestartFlags( TRAIT::restartFlag ).
+             setDescription( TRAIT::description );
+  }
+
+
 protected:
 
 private:

--- a/src/coreComponents/constitutive/capillaryPressure/CapillaryPressureBase.cpp
+++ b/src/coreComponents/constitutive/capillaryPressure/CapillaryPressureBase.cpp
@@ -97,7 +97,7 @@ void CapillaryPressureBase::resizeFields( localIndex const size,
 
 void CapillaryPressureBase::setLabels()
 {
-  getWrapper< extrinsicMeshData::cappres::phaseCapPressure::type >( extrinsicMeshData::cappres::phaseCapPressure::key() ).
+  getExtrinsicData< extrinsicMeshData::cappres::phaseCapPressure >().
     setDimLabels( 2, m_phaseNames );
 }
 

--- a/src/coreComponents/constitutive/capillaryPressure/CapillaryPressureBase.cpp
+++ b/src/coreComponents/constitutive/capillaryPressure/CapillaryPressureBase.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "CapillaryPressureBase.hpp"
+#include "CapillaryPressureExtrinsicData.hpp"
 
 namespace geosx
 {
@@ -41,10 +42,9 @@ CapillaryPressureBase::CapillaryPressureBase( string const & name,
   registerWrapper( viewKeyStruct::phaseOrderString(), &m_phaseOrder ).
     setSizedFromParent( 0 );
 
-  registerWrapper( viewKeyStruct::phaseCapPressureString(), &m_phaseCapPressure ).
-    setPlotLevel( PlotLevel::LEVEL_0 );
+  registerExtrinsicData( extrinsicMeshData::cappres::phaseCapPressure{}, &m_phaseCapPressure );
+  registerExtrinsicData( extrinsicMeshData::cappres::dPhaseCapPressure_dPhaseVolFraction{}, &m_dPhaseCapPressure_dPhaseVolFrac );
 
-  registerWrapper( viewKeyStruct::dPhaseCapPressure_dPhaseVolFractionString(), &m_dPhaseCapPressure_dPhaseVolFrac );
 }
 
 void CapillaryPressureBase::postProcessInput()
@@ -97,7 +97,7 @@ void CapillaryPressureBase::resizeFields( localIndex const size,
 
 void CapillaryPressureBase::setLabels()
 {
-  getWrapper< array3d< real64, cappres::LAYOUT_CAPPRES > >( viewKeyStruct::phaseCapPressureString() ).
+  getWrapper< extrinsicMeshData::cappres::phaseCapPressure::type >( extrinsicMeshData::cappres::phaseCapPressure::key() ).
     setDimLabels( 2, m_phaseNames );
 }
 

--- a/src/coreComponents/constitutive/capillaryPressure/CapillaryPressureBase.hpp
+++ b/src/coreComponents/constitutive/capillaryPressure/CapillaryPressureBase.hpp
@@ -123,9 +123,6 @@ public:
     static constexpr char const * phaseNamesString() { return "phaseNames"; }
     static constexpr char const * phaseTypesString() { return "phaseTypes"; }
     static constexpr char const * phaseOrderString() { return "phaseOrder"; }
-
-    static constexpr char const * phaseCapPressureString() { return "phaseCapPressure"; }
-    static constexpr char const * dPhaseCapPressure_dPhaseVolFractionString() { return "dPhaseCapPressure_dPhaseVolFraction"; }
   };
 
 private:

--- a/src/coreComponents/constitutive/capillaryPressure/CapillaryPressureExtrinsicData.hpp
+++ b/src/coreComponents/constitutive/capillaryPressure/CapillaryPressureExtrinsicData.hpp
@@ -19,7 +19,6 @@
 #ifndef GEOSX_CONSTITUTIVE_CAPILLARYPRESSURE_CAPILLARYPRESSUREEXTRINSICDATA_HPP_
 #define GEOSX_CONSTITUTIVE_CAPILLARYPRESSURE_CAPILLARYPRESSUREEXTRINSICDATA_HPP_
 
-#include "common/DataLayouts.hpp"
 #include "constitutive/capillaryPressure/layouts.hpp"
 #include "mesh/ExtrinsicMeshData.hpp"
 

--- a/src/coreComponents/constitutive/capillaryPressure/CapillaryPressureExtrinsicData.hpp
+++ b/src/coreComponents/constitutive/capillaryPressure/CapillaryPressureExtrinsicData.hpp
@@ -1,0 +1,60 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file CapillaryPressureExtrinsicData.hpp
+ */
+
+#ifndef GEOSX_CONSTITUTIVE_CAPILLARYPRESSURE_CAPILLARYPRESSUREEXTRINSICDATA_HPP_
+#define GEOSX_CONSTITUTIVE_CAPILLARYPRESSURE_CAPILLARYPRESSUREEXTRINSICDATA_HPP_
+
+#include "common/DataLayouts.hpp"
+#include "constitutive/capillaryPressure/layouts.hpp"
+#include "mesh/ExtrinsicMeshData.hpp"
+
+namespace geosx
+{
+
+namespace extrinsicMeshData
+{
+
+namespace cappres
+{
+
+using array3dLayoutCapPressure = array3d< real64, constitutive::cappres::LAYOUT_CAPPRES >;
+using array4dLayoutCapPressure_dS = array4d< real64, constitutive::cappres::LAYOUT_CAPPRES_DS >;
+
+EXTRINSIC_MESH_DATA_TRAIT( phaseCapPressure,
+                           "phaseCapPressure",
+                           array3dLayoutCapPressure,
+                           0,
+                           LEVEL_0,
+                           WRITE_AND_READ,
+                           "Phase capillary pressure" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dPhaseCapPressure_dPhaseVolFraction,
+                           "dPhaseCapPressure_dPhaseVolFraction",
+                           array4dLayoutCapPressure_dS,
+                           0,
+                           NOPLOT,
+                           WRITE_AND_READ,
+                           "Derivative of phase capillary pressure with respect to phase volume fraction" );
+
+}
+
+}
+
+}
+
+#endif // GEOSX_CONSTITUTIVE_CAPILLARYPRESSURE_CAPILLARYPRESSUREEXTRINSICDATA_HPP_

--- a/src/coreComponents/constitutive/fluid/MultiFluidBase.cpp
+++ b/src/coreComponents/constitutive/fluid/MultiFluidBase.cpp
@@ -16,7 +16,9 @@
  * @file MultiFluidBase.cpp
  */
 
+
 #include "MultiFluidBase.hpp"
+#include "MultiFluidExtrinsicData.hpp"
 
 namespace geosx
 {
@@ -45,64 +47,40 @@ MultiFluidBase::MultiFluidBase( string const & name, Group * const parent )
     setInputFlag( InputFlags::OPTIONAL ).
     setDescription( "List of fluid phases" );
 
-  registerWrapper( viewKeyStruct::phaseFractionString(), &m_phaseFraction.value ).
-    setPlotLevel( PlotLevel::LEVEL_0 );
-  registerWrapper( viewKeyStruct::dPhaseFraction_dPressureString(), &m_phaseFraction.dPres ).
-    setRestartFlags( RestartFlags::NO_WRITE );
-  registerWrapper( viewKeyStruct::dPhaseFraction_dTemperatureString(), &m_phaseFraction.dTemp ).
-    setRestartFlags( RestartFlags::NO_WRITE );
-  registerWrapper( viewKeyStruct::dPhaseFraction_dGlobalCompFractionString(), &m_phaseFraction.dComp ).
-    setRestartFlags( RestartFlags::NO_WRITE );
-
-  registerWrapper( viewKeyStruct::phaseDensityString(), &m_phaseDensity.value ).
-    setPlotLevel( PlotLevel::LEVEL_0 );
-  registerWrapper( viewKeyStruct::dPhaseDensity_dPressureString(), &m_phaseDensity.dPres ).
-    setRestartFlags( RestartFlags::NO_WRITE );
-  registerWrapper( viewKeyStruct::dPhaseDensity_dTemperatureString(), &m_phaseDensity.dTemp ).
-    setRestartFlags( RestartFlags::NO_WRITE );
-  registerWrapper( viewKeyStruct::dPhaseDensity_dGlobalCompFractionString(), &m_phaseDensity.dComp ).
-    setRestartFlags( RestartFlags::NO_WRITE );
-
-  registerWrapper( viewKeyStruct::phaseMassDensityString(), &m_phaseMassDensity.value ).
-    setPlotLevel( PlotLevel::LEVEL_0 );
-  registerWrapper( viewKeyStruct::dPhaseMassDensity_dPressureString(), &m_phaseMassDensity.dPres ).
-    setRestartFlags( RestartFlags::NO_WRITE );
-  registerWrapper( viewKeyStruct::dPhaseMassDensity_dTemperatureString(), &m_phaseMassDensity.dTemp ).
-    setRestartFlags( RestartFlags::NO_WRITE );
-  registerWrapper( viewKeyStruct::dPhaseMassDensity_dGlobalCompFractionString(), &m_phaseMassDensity.dComp ).
-    setRestartFlags( RestartFlags::NO_WRITE );
-
-  registerWrapper( viewKeyStruct::phaseViscosityString(), &m_phaseViscosity.value ).
-    setPlotLevel( PlotLevel::LEVEL_0 );
-  registerWrapper( viewKeyStruct::dPhaseViscosity_dPressureString(), &m_phaseViscosity.dPres ).
-    setRestartFlags( RestartFlags::NO_WRITE );
-  registerWrapper( viewKeyStruct::dPhaseViscosity_dTemperatureString(), &m_phaseViscosity.dTemp ).
-    setRestartFlags( RestartFlags::NO_WRITE );
-  registerWrapper( viewKeyStruct::dPhaseViscosity_dGlobalCompFractionString(), &m_phaseViscosity.dComp ).
-    setRestartFlags( RestartFlags::NO_WRITE );
-
-  registerWrapper( viewKeyStruct::phaseCompFractionString(), &m_phaseCompFraction.value ).
-    setPlotLevel( PlotLevel::LEVEL_0 );
-  registerWrapper( viewKeyStruct::dPhaseCompFraction_dPressureString(), &m_phaseCompFraction.dPres ).
-    setRestartFlags( RestartFlags::NO_WRITE );
-  registerWrapper( viewKeyStruct::dPhaseCompFraction_dTemperatureString(), &m_phaseCompFraction.dTemp ).
-    setRestartFlags( RestartFlags::NO_WRITE );
-  registerWrapper( viewKeyStruct::dPhaseCompFraction_dGlobalCompFractionString(), &m_phaseCompFraction.dComp ).
-    setRestartFlags( RestartFlags::NO_WRITE );
-
-  registerWrapper( viewKeyStruct::totalDensityString(), &m_totalDensity.value )
-    .setPlotLevel( PlotLevel::LEVEL_0 );
-  registerWrapper( viewKeyStruct::dTotalDensity_dPressureString(), &m_totalDensity.dPres ).
-    setRestartFlags( RestartFlags::NO_WRITE );
-  registerWrapper( viewKeyStruct::dTotalDensity_dTemperatureString(), &m_totalDensity.dTemp ).
-    setRestartFlags( RestartFlags::NO_WRITE );
-  registerWrapper( viewKeyStruct::dTotalDensity_dGlobalCompFractionString(), &m_totalDensity.dComp ).
-    setRestartFlags( RestartFlags::NO_WRITE );
-
-  registerWrapper( viewKeyStruct::initialTotalMassDensityString(), &m_initialTotalMassDensity );
-
   registerWrapper( viewKeyStruct::useMassString(), &m_useMass ).
     setRestartFlags( RestartFlags::NO_WRITE );
+
+  registerExtrinsicData( extrinsicMeshData::multifluid::phaseFraction{}, &m_phaseFraction.value );
+  registerExtrinsicData( extrinsicMeshData::multifluid::dPhaseFraction_dPressure{}, &m_phaseFraction.dPres );
+  registerExtrinsicData( extrinsicMeshData::multifluid::dPhaseFraction_dTemperature{}, &m_phaseFraction.dTemp );
+  registerExtrinsicData( extrinsicMeshData::multifluid::dPhaseFraction_dGlobalCompFraction{}, &m_phaseFraction.dComp );
+
+  registerExtrinsicData( extrinsicMeshData::multifluid::phaseDensity{}, &m_phaseDensity.value );
+  registerExtrinsicData( extrinsicMeshData::multifluid::dPhaseDensity_dPressure{}, &m_phaseDensity.dPres );
+  registerExtrinsicData( extrinsicMeshData::multifluid::dPhaseDensity_dTemperature{}, &m_phaseDensity.dTemp );
+  registerExtrinsicData( extrinsicMeshData::multifluid::dPhaseDensity_dGlobalCompFraction{}, &m_phaseDensity.dComp );
+
+  registerExtrinsicData( extrinsicMeshData::multifluid::phaseMassDensity{}, &m_phaseMassDensity.value );
+  registerExtrinsicData( extrinsicMeshData::multifluid::dPhaseMassDensity_dPressure{}, &m_phaseMassDensity.dPres );
+  registerExtrinsicData( extrinsicMeshData::multifluid::dPhaseMassDensity_dTemperature{}, &m_phaseMassDensity.dTemp );
+  registerExtrinsicData( extrinsicMeshData::multifluid::dPhaseMassDensity_dGlobalCompFraction{}, &m_phaseMassDensity.dComp );
+
+  registerExtrinsicData( extrinsicMeshData::multifluid::phaseViscosity{}, &m_phaseViscosity.value );
+  registerExtrinsicData( extrinsicMeshData::multifluid::dPhaseViscosity_dPressure{}, &m_phaseViscosity.dPres );
+  registerExtrinsicData( extrinsicMeshData::multifluid::dPhaseViscosity_dTemperature{}, &m_phaseViscosity.dTemp );
+  registerExtrinsicData( extrinsicMeshData::multifluid::dPhaseViscosity_dGlobalCompFraction{}, &m_phaseViscosity.dComp );
+
+  registerExtrinsicData( extrinsicMeshData::multifluid::phaseCompFraction{}, &m_phaseCompFraction.value );
+  registerExtrinsicData( extrinsicMeshData::multifluid::dPhaseCompFraction_dPressure{}, &m_phaseCompFraction.dPres );
+  registerExtrinsicData( extrinsicMeshData::multifluid::dPhaseCompFraction_dTemperature{}, &m_phaseCompFraction.dTemp );
+  registerExtrinsicData( extrinsicMeshData::multifluid::dPhaseCompFraction_dGlobalCompFraction{}, &m_phaseCompFraction.dComp );
+
+  registerExtrinsicData( extrinsicMeshData::multifluid::totalDensity{}, &m_totalDensity.value );
+  registerExtrinsicData( extrinsicMeshData::multifluid::dTotalDensity_dPressure{}, &m_totalDensity.dPres );
+  registerExtrinsicData( extrinsicMeshData::multifluid::dTotalDensity_dTemperature{}, &m_totalDensity.dTemp );
+  registerExtrinsicData( extrinsicMeshData::multifluid::dTotalDensity_dGlobalCompFraction{}, &m_totalDensity.dComp );
+
+  registerExtrinsicData( extrinsicMeshData::multifluid::initialTotalMassDensity{}, &m_initialTotalMassDensity );
 
 }
 
@@ -146,19 +124,21 @@ void MultiFluidBase::resizeFields( localIndex const size, localIndex const numPt
 
 void MultiFluidBase::setLabels()
 {
-  getWrapper< array3d< real64, multifluid::LAYOUT_PHASE > >( viewKeyStruct::phaseFractionString() ).
+  using namespace extrinsicMeshData::multifluid;
+
+  getWrapper< phaseFraction::type >( phaseFraction::key() ).
     setDimLabels( 2, m_phaseNames );
 
-  getWrapper< array3d< real64, multifluid::LAYOUT_PHASE > >( viewKeyStruct::phaseDensityString() ).
+  getWrapper< phaseDensity::type >( phaseDensity::key() ).
     setDimLabels( 2, m_phaseNames );
 
-  getWrapper< array3d< real64, multifluid::LAYOUT_PHASE > >( viewKeyStruct::phaseMassDensityString() ).
+  getWrapper< phaseMassDensity::type >( phaseMassDensity::key() ).
     setDimLabels( 2, m_phaseNames );
 
-  getWrapper< array3d< real64, multifluid::LAYOUT_PHASE > >( viewKeyStruct::phaseViscosityString() ).
+  getWrapper< phaseViscosity::type >( phaseViscosity::key() ).
     setDimLabels( 2, m_phaseNames );
 
-  getWrapper< array4d< real64, multifluid::LAYOUT_PHASE_COMP > >( viewKeyStruct::phaseCompFractionString() ).
+  getWrapper< phaseCompFraction::type >( phaseCompFraction::key() ).
     setDimLabels( 2, m_phaseNames ).
     setDimLabels( 3, m_componentNames );
 }

--- a/src/coreComponents/constitutive/fluid/MultiFluidBase.cpp
+++ b/src/coreComponents/constitutive/fluid/MultiFluidBase.cpp
@@ -124,21 +124,19 @@ void MultiFluidBase::resizeFields( localIndex const size, localIndex const numPt
 
 void MultiFluidBase::setLabels()
 {
-  using namespace extrinsicMeshData::multifluid;
-
-  getWrapper< phaseFraction::type >( phaseFraction::key() ).
+  getExtrinsicData< extrinsicMeshData::multifluid::phaseFraction >().
     setDimLabels( 2, m_phaseNames );
 
-  getWrapper< phaseDensity::type >( phaseDensity::key() ).
+  getExtrinsicData< extrinsicMeshData::multifluid::phaseDensity >().
     setDimLabels( 2, m_phaseNames );
 
-  getWrapper< phaseMassDensity::type >( phaseMassDensity::key() ).
+  getExtrinsicData< extrinsicMeshData::multifluid::phaseMassDensity >().
     setDimLabels( 2, m_phaseNames );
 
-  getWrapper< phaseViscosity::type >( phaseViscosity::key() ).
+  getExtrinsicData< extrinsicMeshData::multifluid::phaseViscosity >().
     setDimLabels( 2, m_phaseNames );
 
-  getWrapper< phaseCompFraction::type >( phaseCompFraction::key() ).
+  getExtrinsicData< extrinsicMeshData::multifluid::phaseCompFraction >().
     setDimLabels( 2, m_phaseNames ).
     setDimLabels( 3, m_componentNames );
 }

--- a/src/coreComponents/constitutive/fluid/MultiFluidBase.hpp
+++ b/src/coreComponents/constitutive/fluid/MultiFluidBase.hpp
@@ -178,41 +178,7 @@ public:
   {
     static constexpr char const * componentNamesString() { return "componentNames"; }
     static constexpr char const * componentMolarWeightString() { return "componentMolarWeight"; }
-
     static constexpr char const * phaseNamesString() { return "phaseNames"; }
-
-    static constexpr char const * phaseFractionString() { return "phaseFraction"; } // xi_p
-    static constexpr char const * dPhaseFraction_dPressureString() { return "dPhaseFraction_dPressure"; } // dXi_p/dP
-    static constexpr char const * dPhaseFraction_dTemperatureString() { return "dPhaseFraction_dTemperature"; } // dXi_p/dT
-    static constexpr char const * dPhaseFraction_dGlobalCompFractionString() { return "dPhaseFraction_dGlobalCompFraction"; } // dXi_p/dz
-
-    static constexpr char const * phaseDensityString() { return "phaseDensity"; } // rho_p
-    static constexpr char const * dPhaseDensity_dPressureString() { return "dPhaseDensity_dPressure"; } // dRho_p/dP
-    static constexpr char const * dPhaseDensity_dTemperatureString() { return "dPhaseDensity_dTemperature"; } // dRho_p/dT
-    static constexpr char const * dPhaseDensity_dGlobalCompFractionString() { return "dPhaseDensity_dGlobalCompFraction"; } // dRho_p/dz
-
-    static constexpr char const * phaseMassDensityString() { return "phaseMassDensity"; } // rho_p
-    static constexpr char const * dPhaseMassDensity_dPressureString() { return "dPhaseMassDensity_dPressure"; } // dRho_p/dP
-    static constexpr char const * dPhaseMassDensity_dTemperatureString() { return "dPhaseMassDensity_dTemperature"; } // dRho_p/dT
-    static constexpr char const * dPhaseMassDensity_dGlobalCompFractionString() { return "dPhaseMassDensity_dGlobalCompFraction"; } // dRho_p/dz
-
-    static constexpr char const * phaseViscosityString() { return "phaseViscosity"; } // mu_p
-    static constexpr char const * dPhaseViscosity_dPressureString() { return "dPhaseViscosity_dPressure"; } // dMu_p/dP
-    static constexpr char const * dPhaseViscosity_dTemperatureString() { return "dPhaseViscosity_dTemperature"; } // dMu_p/dT
-    static constexpr char const * dPhaseViscosity_dGlobalCompFractionString() { return "dPhaseViscosity_dGlobalCompFraction"; } // dMu_p/dz
-
-    static constexpr char const * phaseCompFractionString() { return "phaseCompFraction"; } // x_cp
-    static constexpr char const * dPhaseCompFraction_dPressureString() { return "dPhaseCompFraction_dPressure"; } // dx_cp/dP
-    static constexpr char const * dPhaseCompFraction_dTemperatureString() { return "dPhaseCompFraction_dTemperature"; } // dx_cp/dT
-    static constexpr char const * dPhaseCompFraction_dGlobalCompFractionString() { return "dPhaseCompFraction_dGlobalCompFraction"; } // dx_cp/dz
-
-    static constexpr char const * totalDensityString() { return "totalDensity"; } // rho_t
-    static constexpr char const * dTotalDensity_dPressureString() { return "dTotalDensity_dPressure"; } // dRho_t/dP
-    static constexpr char const * dTotalDensity_dTemperatureString() { return "dTotalDensity_dTemperature"; } // dRho_t/dT
-    static constexpr char const * dTotalDensity_dGlobalCompFractionString() { return "dTotalDensity_dGlobalCompFraction"; } // dRho_t/dz
-
-    static constexpr char const * initialTotalMassDensityString() { return "initialTotalMassDensity"; } // rho^int_t
-
     static constexpr char const * useMassString() { return "useMass"; }
   };
 

--- a/src/coreComponents/constitutive/fluid/MultiFluidExtrinsicData.hpp
+++ b/src/coreComponents/constitutive/fluid/MultiFluidExtrinsicData.hpp
@@ -1,0 +1,249 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file MultiFluidExtrinsicData.hpp
+ */
+
+#ifndef GEOSX_CONSTITUTIVE_FLUID_MULTIFLUIDEXTRINSICDATA_HPP_
+#define GEOSX_CONSTITUTIVE_FLUID_MULTIFLUIDEXTRINSICDATA_HPP_
+
+#include "common/DataLayouts.hpp"
+#include "constitutive/fluid/layouts.hpp"
+#include "mesh/ExtrinsicMeshData.hpp"
+
+namespace geosx
+{
+
+namespace extrinsicMeshData
+{
+
+namespace multifluid
+{
+
+using array2dLayoutFluid = array2d< real64, constitutive::multifluid::LAYOUT_FLUID >;
+using array3dLayoutFluid_dC = array3d< real64, constitutive::multifluid::LAYOUT_FLUID_DC >;
+using array3dLayoutPhase = array3d< real64, constitutive::multifluid::LAYOUT_PHASE >;
+using array4dLayoutPhase_dC = array4d< real64, constitutive::multifluid::LAYOUT_PHASE_DC >;
+using array4dLayoutPhaseComp = array4d< real64, constitutive::multifluid::LAYOUT_PHASE_COMP >;
+using array5dLayoutPhaseComp_dC = array5d< real64, constitutive::multifluid::LAYOUT_PHASE_COMP_DC >;
+
+EXTRINSIC_MESH_DATA_TRAIT( phaseFraction,
+                           "phaseFraction",
+                           array3dLayoutPhase,
+                           0,
+                           LEVEL_0,
+                           WRITE_AND_READ,
+                           "Phase fraction" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dPhaseFraction_dPressure,
+                           "dPhaseFraction_dPressure",
+                           array3dLayoutPhase,
+                           0,
+                           NOPLOT,
+                           NO_WRITE,
+                           "Derivative of phase fraction with respect to pressure" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dPhaseFraction_dTemperature,
+                           "dPhaseFraction_dTemperature",
+                           array3dLayoutPhase,
+                           0,
+                           NOPLOT,
+                           NO_WRITE,
+                           "Derivative of phase fraction with respect to temperature" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dPhaseFraction_dGlobalCompFraction,
+                           "dPhaseFraction_dGlobalCompFraction",
+                           array4dLayoutPhase_dC,
+                           0,
+                           NOPLOT,
+                           NO_WRITE,
+                           "Derivative of phase fraction with respect to global component fraction" );
+
+EXTRINSIC_MESH_DATA_TRAIT( phaseDensity,
+                           "phaseDensity",
+                           array3dLayoutPhase,
+                           0,
+                           LEVEL_0,
+                           WRITE_AND_READ,
+                           "Phase density" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dPhaseDensity_dPressure,
+                           "dPhaseDensity_dPressure",
+                           array3dLayoutPhase,
+                           0,
+                           NOPLOT,
+                           NO_WRITE,
+                           "Derivative of phase density with respect to pressure" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dPhaseDensity_dTemperature,
+                           "dPhaseDensity_dTemperature",
+                           array3dLayoutPhase,
+                           0,
+                           NOPLOT,
+                           NO_WRITE,
+                           "Derivative of phase density with respect to temperature" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dPhaseDensity_dGlobalCompFraction,
+                           "dPhaseDensity_dGlobalCompFraction",
+                           array4dLayoutPhase_dC,
+                           0,
+                           NOPLOT,
+                           NO_WRITE,
+                           "Derivative of phase density with respect to global component fraction" );
+
+EXTRINSIC_MESH_DATA_TRAIT( phaseMassDensity,
+                           "phaseMassDensity",
+                           array3dLayoutPhase,
+                           0,
+                           LEVEL_0,
+                           WRITE_AND_READ,
+                           "Phase mass density" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dPhaseMassDensity_dPressure,
+                           "dPhaseMassDensity_dPressure",
+                           array3dLayoutPhase,
+                           0,
+                           NOPLOT,
+                           NO_WRITE,
+                           "Derivative of phase mass density with respect to pressure" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dPhaseMassDensity_dTemperature,
+                           "dPhaseMassDensity_dTemperature",
+                           array3dLayoutPhase,
+                           0,
+                           NOPLOT,
+                           NO_WRITE,
+                           "Derivative of phase mass density with respect to temperature" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dPhaseMassDensity_dGlobalCompFraction,
+                           "dPhaseMassDensity_dGlobalCompFraction",
+                           array4dLayoutPhase_dC,
+                           0,
+                           NOPLOT,
+                           NO_WRITE,
+                           "Derivative of phase mass density with respect to global component fraction" );
+
+EXTRINSIC_MESH_DATA_TRAIT( phaseViscosity,
+                           "phaseViscosity",
+                           array3dLayoutPhase,
+                           0,
+                           LEVEL_0,
+                           WRITE_AND_READ,
+                           "Phase viscosity" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dPhaseViscosity_dPressure,
+                           "dPhaseViscosity_dPressure",
+                           array3dLayoutPhase,
+                           0,
+                           NOPLOT,
+                           NO_WRITE,
+                           "Derivative of phase viscosity with respect to pressure" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dPhaseViscosity_dTemperature,
+                           "dPhaseViscosity_dTemperature",
+                           array3dLayoutPhase,
+                           0,
+                           NOPLOT,
+                           NO_WRITE,
+                           "Derivative of phase viscosity with respect to temperature" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dPhaseViscosity_dGlobalCompFraction,
+                           "dPhaseViscosity_dGlobalCompFraction",
+                           array4dLayoutPhase_dC,
+                           0,
+                           NOPLOT,
+                           NO_WRITE,
+                           "Derivative of phase viscosity with respect to global component fraction" );
+
+EXTRINSIC_MESH_DATA_TRAIT( phaseCompFraction,
+                           "phaseCompFraction",
+                           array4dLayoutPhaseComp,
+                           0,
+                           LEVEL_0,
+                           WRITE_AND_READ,
+                           "Phase component fraction" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dPhaseCompFraction_dPressure,
+                           "dPhaseCompFraction_dPressure",
+                           array4dLayoutPhaseComp,
+                           0,
+                           NOPLOT,
+                           NO_WRITE,
+                           "Derivative of phase component fraction with respect to pressure" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dPhaseCompFraction_dTemperature,
+                           "dPhaseCompFraction_dTemperature",
+                           array4dLayoutPhaseComp,
+                           0,
+                           NOPLOT,
+                           NO_WRITE,
+                           "Derivative of phase component fraction with respect to temperature" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dPhaseCompFraction_dGlobalCompFraction,
+                           "dPhaseCompFraction_dGlobalCompFraction",
+                           array5dLayoutPhaseComp_dC,
+                           0,
+                           NOPLOT,
+                           NO_WRITE,
+                           "Derivative of phase component fraction with respect to global component fraction" );
+
+EXTRINSIC_MESH_DATA_TRAIT( totalDensity,
+                           "totalDensity",
+                           array2dLayoutFluid,
+                           0,
+                           LEVEL_0,
+                           WRITE_AND_READ,
+                           "Total density" );
+
+EXTRINSIC_MESH_DATA_TRAIT( initialTotalMassDensity,
+                           "initialTotalMassDensity",
+                           array2dLayoutFluid,
+                           0,
+                           LEVEL_0,
+                           WRITE_AND_READ,
+                           "Initial total mass density" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dTotalDensity_dPressure,
+                           "dTotalDensity_dPressure",
+                           array2dLayoutFluid,
+                           0,
+                           NOPLOT,
+                           NO_WRITE,
+                           "Derivative of total density with respect to pressure" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dTotalDensity_dTemperature,
+                           "dTotalDensity_dTemperature",
+                           array2dLayoutFluid,
+                           0,
+                           NOPLOT,
+                           NO_WRITE,
+                           "Derivative of total density with respect to temperature" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dTotalDensity_dGlobalCompFraction,
+                           "dTotalDensity_dGlobalCompFraction",
+                           array3dLayoutFluid_dC,
+                           0,
+                           NOPLOT,
+                           NO_WRITE,
+                           "Derivative of total density with respect to global component fraction" );
+
+
+}
+
+}
+
+}
+
+#endif // GEOSX_CONSTITUTIVE_FLUID_MULTIFLUIDEXTRINSICDATA_HPP_

--- a/src/coreComponents/constitutive/fluid/MultiFluidExtrinsicData.hpp
+++ b/src/coreComponents/constitutive/fluid/MultiFluidExtrinsicData.hpp
@@ -19,7 +19,6 @@
 #ifndef GEOSX_CONSTITUTIVE_FLUID_MULTIFLUIDEXTRINSICDATA_HPP_
 #define GEOSX_CONSTITUTIVE_FLUID_MULTIFLUIDEXTRINSICDATA_HPP_
 
-#include "common/DataLayouts.hpp"
 #include "constitutive/fluid/layouts.hpp"
 #include "mesh/ExtrinsicMeshData.hpp"
 

--- a/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityBase.cpp
+++ b/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityBase.cpp
@@ -94,7 +94,7 @@ void RelativePermeabilityBase::resizeFields( localIndex const size, localIndex c
 
 void RelativePermeabilityBase::setLabels()
 {
-  getWrapper< extrinsicMeshData::relperm::phaseRelPerm::type >( extrinsicMeshData::relperm::phaseRelPerm::key() ).
+  getExtrinsicData< extrinsicMeshData::relperm::phaseRelPerm >().
     setDimLabels( 2, m_phaseNames );
 }
 

--- a/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityBase.cpp
+++ b/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityBase.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "RelativePermeabilityBase.hpp"
+#include "RelativePermeabilityExtrinsicData.hpp"
 
 namespace geosx
 {
@@ -39,8 +40,9 @@ RelativePermeabilityBase::RelativePermeabilityBase( string const & name, Group *
   registerWrapper( viewKeyStruct::phaseOrderString(), &m_phaseOrder ).
     setSizedFromParent( 0 );
 
-  registerWrapper( viewKeyStruct::phaseRelPermString(), &m_phaseRelPerm ).setPlotLevel( PlotLevel::LEVEL_0 );
-  registerWrapper( viewKeyStruct::dPhaseRelPerm_dPhaseVolFractionString(), &m_dPhaseRelPerm_dPhaseVolFrac );
+  registerExtrinsicData( extrinsicMeshData::relperm::phaseRelPerm{}, &m_phaseRelPerm );
+  registerExtrinsicData( extrinsicMeshData::relperm::dPhaseRelPerm_dPhaseVolFraction{}, &m_dPhaseRelPerm_dPhaseVolFrac );
+
 }
 
 void RelativePermeabilityBase::postProcessInput()
@@ -92,7 +94,7 @@ void RelativePermeabilityBase::resizeFields( localIndex const size, localIndex c
 
 void RelativePermeabilityBase::setLabels()
 {
-  getWrapper< array3d< real64, relperm::LAYOUT_RELPERM > >( viewKeyStruct::phaseRelPermString() ).
+  getWrapper< extrinsicMeshData::relperm::phaseRelPerm::type >( extrinsicMeshData::relperm::phaseRelPerm::key() ).
     setDimLabels( 2, m_phaseNames );
 }
 

--- a/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityBase.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityBase.hpp
@@ -26,6 +26,7 @@
 
 namespace geosx
 {
+
 namespace constitutive
 {
 
@@ -138,9 +139,6 @@ public:
     static constexpr char const * phaseNamesString() { return "phaseNames"; }
     static constexpr char const * phaseTypesString() { return "phaseTypes"; }
     static constexpr char const * phaseOrderString() { return "phaseOrder"; }
-
-    static constexpr char const * phaseRelPermString() { return "phaseRelPerm"; }                                       // Kr
-    static constexpr char const * dPhaseRelPerm_dPhaseVolFractionString() { return "dPhaseRelPerm_dPhaseVolFraction"; } // dKr_p/dS_p
   };
 
 private:

--- a/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityExtrinsicData.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityExtrinsicData.hpp
@@ -19,7 +19,6 @@
 #ifndef GEOSX_CONSTITUTIVE_RELATIVEPERMEABILITY_RELATIVEPERMEABILITYEXTRINSICDATA_HPP_
 #define GEOSX_CONSTITUTIVE_RELATIVEPERMEABILITY_RELATIVEPERMEABILITYEXTRINSICDATA_HPP_
 
-#include "common/DataLayouts.hpp"
 #include "constitutive/relativePermeability/layouts.hpp"
 #include "mesh/ExtrinsicMeshData.hpp"
 

--- a/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityExtrinsicData.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityExtrinsicData.hpp
@@ -1,0 +1,60 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file RelativePermeabilityExtrinsicData.hpp
+ */
+
+#ifndef GEOSX_CONSTITUTIVE_RELATIVEPERMEABILITY_RELATIVEPERMEABILITYEXTRINSICDATA_HPP_
+#define GEOSX_CONSTITUTIVE_RELATIVEPERMEABILITY_RELATIVEPERMEABILITYEXTRINSICDATA_HPP_
+
+#include "common/DataLayouts.hpp"
+#include "constitutive/relativePermeability/layouts.hpp"
+#include "mesh/ExtrinsicMeshData.hpp"
+
+namespace geosx
+{
+
+namespace extrinsicMeshData
+{
+
+namespace relperm
+{
+
+using array3dLayoutRelPerm = array3d< real64, constitutive::relperm::LAYOUT_RELPERM >;
+using array4dLayoutRelPerm_dS = array4d< real64, constitutive::relperm::LAYOUT_RELPERM_DS >;
+
+EXTRINSIC_MESH_DATA_TRAIT( phaseRelPerm,
+                           "phaseRelPerm",
+                           array3dLayoutRelPerm,
+                           0,
+                           LEVEL_0,
+                           WRITE_AND_READ,
+                           "Phase relative permeability" );
+
+EXTRINSIC_MESH_DATA_TRAIT( dPhaseRelPerm_dPhaseVolFraction,
+                           "dPhaseRelPerm_dPhaseVolFraction",
+                           array4dLayoutRelPerm_dS,
+                           0,
+                           NOPLOT,
+                           WRITE_AND_READ,
+                           "Derivative of phase relative permeability with respect to phase volume fraction" );
+
+}
+
+}
+
+}
+
+#endif // GEOSX_CONSTITUTIVE_RELATIVEPERMEABILITY_RELATIVEPERMEABILITYEXTRINSICDATA_HPP_

--- a/src/coreComponents/mesh/ElementRegionManager.hpp
+++ b/src/coreComponents/mesh/ElementRegionManager.hpp
@@ -822,6 +822,23 @@ public:
   /**
    * @brief This is a const function to construct a MaterialViewAccessor to access the material data for specified
    * regions/materials.
+   * @tparam TRAIT mesh data trait
+   * @param regionNames list of region names
+   * @param materialNames list of corresponding material names
+   * @param allowMissingViews flag to indicate whether it is allowed to miss the specified material data in material
+   * list
+   * @return ElementViewAccessor that contains traits::ViewTypeConst< typename TRAIT::type > data
+   */
+  template< typename TRAIT >
+  ElementViewAccessor< traits::ViewTypeConst< typename TRAIT::type > >
+  constructMaterialExtrinsicAccessor( arrayView1d< string const > const & regionNames,
+                                      arrayView1d< string const > const & materialNames,
+                                      bool const allowMissingViews = false ) const;
+
+
+  /**
+   * @brief This is a const function to construct a MaterialViewAccessor to access the material data for specified
+   * regions/materials.
    * @tparam VIEWTYPE data type
    * @param viewName view name of the data
    * @param regionNames list of region names
@@ -1412,6 +1429,21 @@ ElementRegionManager::constructMaterialViewAccessor( string const & viewName,
   }
   return accessor;
 }
+
+template< typename TRAIT >
+ElementRegionManager::ElementViewAccessor< traits::ViewTypeConst< typename TRAIT::type > >
+ElementRegionManager::
+  constructMaterialExtrinsicAccessor( arrayView1d< string const > const & regionNames,
+                                      arrayView1d< string const > const & materialNames,
+                                      bool const allowMissingViews ) const
+{
+  return constructMaterialViewAccessor< typename TRAIT::type,
+                                        traits::ViewTypeConst< typename TRAIT::type > >( TRAIT::key(),
+                                                                                         regionNames,
+                                                                                         materialNames,
+                                                                                         allowMissingViews );
+}
+
 
 template< typename T, int NDIM, typename PERM >
 ElementRegionManager::ElementViewAccessor< ArrayView< T const, NDIM, getUSD< PERM > > >

--- a/src/coreComponents/mesh/ExtrinsicMeshData.hpp
+++ b/src/coreComponents/mesh/ExtrinsicMeshData.hpp
@@ -53,8 +53,9 @@
     using type = TYPE; \
     /** The template type T for registration of a container<T>. */ \
     using dataType = internal::typeHelper_t< TYPE >; \
-    /** The dataRepository::DefaultValue for NAME. */ \
-    static constexpr dataType defaultValue = DEFAULT; \
+    /** @brief @return The default data value for NAME. */ \
+    static constexpr dataType defaultValue() \
+    { return DEFAULT; } \
     /** The default dataRepository::PlotLevel for NAME. */ \
     static constexpr dataRepository::PlotLevel plotLevel = dataRepository::PlotLevel::PLOTLEVEL; \
     /** The default dataRepository::RestartFlags for NAME. */ \

--- a/src/coreComponents/mesh/ObjectManagerBase.hpp
+++ b/src/coreComponents/mesh/ObjectManagerBase.hpp
@@ -578,7 +578,7 @@ public:
 
     //constexpr typename MESH_DATA_TRAIT::DataType defaultValue = MESH_DATA_TRAIT::defaultValue;
     // This is required for the Tensor classes.
-    typename MESH_DATA_TRAIT::dataType defaultValue( MESH_DATA_TRAIT::defaultValue );
+    typename MESH_DATA_TRAIT::dataType defaultValue( MESH_DATA_TRAIT::defaultValue() );
 
     return this->registerWrapper< typename MESH_DATA_TRAIT::type >( MESH_DATA_TRAIT::key() ).
              setApplyDefaultValue( defaultValue ).
@@ -659,7 +659,7 @@ public:
     string const description = MESH_DATA_TRAIT::description;
 
     // This is required for the Tensor classes.
-    typename MESH_DATA_TRAIT::DataType defaultValue( MESH_DATA_TRAIT::defaultValue );
+    typename MESH_DATA_TRAIT::DataType defaultValue( MESH_DATA_TRAIT::defaultValue() );
 
     return *(this->registerWrapper< typename MESH_DATA_TRAIT::type >( extrinsicDataTrait.key() ).
                setApplyDefaultValue( defaultValue ).

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.cpp
@@ -1569,95 +1569,79 @@ void CompositionalMultiphaseBase::resetViews( MeshLevel & mesh )
   }
 
   {
-    using namespace constitutive::multifluid;
     using namespace extrinsicMeshData::multifluid;
 
     m_phaseVisc.clear();
-    m_phaseVisc = elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( phaseViscosity::key(),
-                                                                                             targetRegionNames(),
-                                                                                             fluidModelNames() );
+    m_phaseVisc = elemManager.constructMaterialExtrinsicAccessor< phaseViscosity >( targetRegionNames(),
+                                                                                    fluidModelNames() );
     m_phaseVisc.setName( getName() + "/accessors/" + phaseViscosity::key() );
     m_phaseDens.clear();
-    m_phaseDens = elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( phaseDensity::key(),
-                                                                                             targetRegionNames(),
-                                                                                             fluidModelNames() );
+    m_phaseDens = elemManager.constructMaterialExtrinsicAccessor< phaseDensity >( targetRegionNames(),
+                                                                                  fluidModelNames() );
     m_phaseDens.setName( getName() + "/accessors/" + phaseDensity::key() );
 
     m_dPhaseDens_dPres.clear();
-    m_dPhaseDens_dPres = elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( dPhaseDensity_dPressure::key(),
-                                                                                                    targetRegionNames(),
+    m_dPhaseDens_dPres = elemManager.constructMaterialExtrinsicAccessor< dPhaseDensity_dPressure >( targetRegionNames(),
                                                                                                     fluidModelNames() );
     m_dPhaseDens_dPres.setName( getName() + "/accessors/" + dPhaseDensity_dPressure::key() );
 
     m_dPhaseDens_dComp.clear();
-    m_dPhaseDens_dComp = elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_DC >( dPhaseDensity_dGlobalCompFraction::key(),
-                                                                                                       targetRegionNames(),
-                                                                                                       fluidModelNames() );
+    m_dPhaseDens_dComp = elemManager.constructMaterialExtrinsicAccessor< dPhaseDensity_dGlobalCompFraction >( targetRegionNames(),
+                                                                                                              fluidModelNames() );
     m_dPhaseDens_dComp.setName( getName() + "/accessors/" + dPhaseDensity_dGlobalCompFraction::key() );
 
     m_phaseMassDens.clear();
-    m_phaseMassDens = elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( phaseMassDensity::key(),
-                                                                                                 targetRegionNames(),
-                                                                                                 fluidModelNames() );
+    m_phaseMassDens = elemManager.constructMaterialExtrinsicAccessor< phaseMassDensity >( targetRegionNames(),
+                                                                                          fluidModelNames() );
     m_phaseMassDens.setName( getName() + "/accessors/" + phaseMassDensity::key() );
 
     m_dPhaseMassDens_dPres.clear();
-    m_dPhaseMassDens_dPres = elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( dPhaseMassDensity_dPressure::key(),
-                                                                                                        targetRegionNames(),
-                                                                                                        fluidModelNames() );
+    m_dPhaseMassDens_dPres = elemManager.constructMaterialExtrinsicAccessor< dPhaseMassDensity_dPressure >( targetRegionNames(),
+                                                                                                            fluidModelNames() );
     m_dPhaseMassDens_dPres.setName( getName() + "/accessors/" + dPhaseMassDensity_dPressure::key() );
 
     m_dPhaseMassDens_dComp.clear();
-    m_dPhaseMassDens_dComp = elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_DC >( dPhaseMassDensity_dGlobalCompFraction::key(),
-                                                                                                           targetRegionNames(),
-                                                                                                           fluidModelNames() );
+    m_dPhaseMassDens_dComp = elemManager.constructMaterialExtrinsicAccessor< dPhaseMassDensity_dGlobalCompFraction >( targetRegionNames(),
+                                                                                                                      fluidModelNames() );
     m_dPhaseMassDens_dComp.setName( getName() + "/accessors/" + dPhaseMassDensity_dGlobalCompFraction::key() );
 
     m_phaseCompFrac.clear();
-    m_phaseCompFrac = elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_COMP >( phaseCompFraction::key(),
-                                                                                                      targetRegionNames(),
-                                                                                                      fluidModelNames() );
+    m_phaseCompFrac = elemManager.constructMaterialExtrinsicAccessor< phaseCompFraction >( targetRegionNames(),
+                                                                                           fluidModelNames() );
     m_phaseCompFrac.setName( getName() + "/accessors/" + phaseCompFraction::key() );
 
     m_dPhaseCompFrac_dPres.clear();
-    m_dPhaseCompFrac_dPres = elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_COMP >( dPhaseCompFraction_dPressure::key(),
-                                                                                                             targetRegionNames(),
+    m_dPhaseCompFrac_dPres = elemManager.constructMaterialExtrinsicAccessor< dPhaseCompFraction_dPressure >( targetRegionNames(),
                                                                                                              fluidModelNames() );
     m_dPhaseCompFrac_dPres.setName( getName() + "/accessors/" + dPhaseCompFraction_dPressure::key() );
 
     m_dPhaseCompFrac_dComp.clear();
-    m_dPhaseCompFrac_dComp = elemManager.constructMaterialArrayViewAccessor< real64, 5, LAYOUT_PHASE_COMP_DC >( dPhaseCompFraction_dGlobalCompFraction::key(),
-                                                                                                                targetRegionNames(),
-                                                                                                                fluidModelNames() );
+    m_dPhaseCompFrac_dComp = elemManager.constructMaterialExtrinsicAccessor< dPhaseCompFraction_dGlobalCompFraction >( targetRegionNames(),
+                                                                                                                       fluidModelNames() );
     m_dPhaseCompFrac_dComp.setName( getName() + "/accessors/" + dPhaseCompFraction_dGlobalCompFraction::key() );
   }
   {
-    using namespace constitutive::relperm;
     using namespace extrinsicMeshData::relperm;
 
     m_phaseRelPerm.clear();
-    m_phaseRelPerm = elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_RELPERM >( phaseRelPerm::key(),
-                                                                                                  targetRegionNames(),
-                                                                                                  relPermModelNames() );
+    m_phaseRelPerm = elemManager.constructMaterialExtrinsicAccessor< phaseRelPerm >( targetRegionNames(),
+                                                                                     relPermModelNames() );
     m_phaseRelPerm.setName( getName() + "/accessors/" + phaseRelPerm::key() );
   }
   if( m_capPressureFlag )
   {
-    using namespace constitutive::cappres;
     using namespace extrinsicMeshData::cappres;
 
     m_phaseCapPressure.clear();
     m_phaseCapPressure =
-      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_CAPPRES >( phaseCapPressure::key(),
-                                                                                   targetRegionNames(),
-                                                                                   capPresModelNames() );
+      elemManager.constructMaterialExtrinsicAccessor< phaseCapPressure >( targetRegionNames(),
+                                                                          capPresModelNames() );
     m_phaseCapPressure.setName( getName() + "/accessors/" + phaseCapPressure::key() );
 
     m_dPhaseCapPressure_dPhaseVolFrac.clear();
     m_dPhaseCapPressure_dPhaseVolFrac =
-      elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_CAPPRES_DS >( dPhaseCapPressure_dPhaseVolFraction::key(),
-                                                                                      targetRegionNames(),
-                                                                                      capPresModelNames() );
+      elemManager.constructMaterialExtrinsicAccessor< dPhaseCapPressure_dPhaseVolFraction >( targetRegionNames(),
+                                                                                             capPresModelNames() );
     m_dPhaseCapPressure_dPhaseVolFrac.setName( getName() + "/accessors/" + dPhaseCapPressure_dPhaseVolFraction::key() );
   }
 }

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.cpp
@@ -21,9 +21,12 @@
 #include "common/DataTypes.hpp"
 #include "common/TimingMacros.hpp"
 #include "constitutive/ConstitutiveManager.hpp"
+#include "constitutive/capillaryPressure/CapillaryPressureExtrinsicData.hpp"
 #include "constitutive/capillaryPressure/capillaryPressureSelector.hpp"
 #include "constitutive/ConstitutivePassThru.hpp"
+#include "constitutive/fluid/MultiFluidExtrinsicData.hpp"
 #include "constitutive/fluid/multiFluidSelector.hpp"
+#include "constitutive/relativePermeability/RelativePermeabilityExtrinsicData.hpp"
 #include "constitutive/relativePermeability/relativePermeabilitySelector.hpp"
 #include "fieldSpecification/AquiferBoundaryCondition.hpp"
 #include "fieldSpecification/EquilibriumInitialCondition.hpp"
@@ -572,14 +575,14 @@ void CompositionalMultiphaseBase::initializeFluidState( MeshLevel & mesh )
   {
     arrayView1d< real64 const > const pres = subRegion.getExtrinsicData< extrinsicMeshData::flow::pressure >();
     arrayView1d< real64 > const initPres = subRegion.getExtrinsicData< extrinsicMeshData::flow::initialPressure >();
-
-    MultiFluidBase & fluid = getConstitutiveModel< MultiFluidBase >( subRegion, fluidModelNames()[targetIndex] );
-    arrayView3d< real64 const, multifluid::USD_PHASE > const phaseMassDens = fluid.phaseMassDensity();
     arrayView2d< real64 const, compflow::USD_PHASE > const phaseVolFrac =
       subRegion.getExtrinsicData< extrinsicMeshData::flow::phaseVolumeFraction >();
 
+
+    MultiFluidBase & fluid = getConstitutiveModel< MultiFluidBase >( subRegion, fluidModelNames()[targetIndex] );
+    arrayView3d< real64 const, multifluid::USD_PHASE > const phaseMassDens = fluid.phaseMassDensity();
     arrayView2d< real64, multifluid::USD_FLUID > const initTotalMassDens =
-      fluid.getReference< array2d< real64, multifluid::LAYOUT_FLUID > >( MultiFluidBase::viewKeyStruct::initialTotalMassDensityString() );
+      fluid.getReference< extrinsicMeshData::multifluid::initialTotalMassDensity::type >( extrinsicMeshData::multifluid::initialTotalMassDensity::key() );
 
     forAll< parallelDevicePolicy<> >( subRegion.size(), [=] GEOSX_HOST_DEVICE ( localIndex const ei )
     {
@@ -1566,96 +1569,96 @@ void CompositionalMultiphaseBase::resetViews( MeshLevel & mesh )
   }
 
   {
-    using keys = MultiFluidBase::viewKeyStruct;
     using namespace constitutive::multifluid;
+    using namespace extrinsicMeshData::multifluid;
 
     m_phaseVisc.clear();
-    m_phaseVisc = elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( keys::phaseViscosityString(),
+    m_phaseVisc = elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( phaseViscosity::key(),
                                                                                              targetRegionNames(),
                                                                                              fluidModelNames() );
-    m_phaseVisc.setName( getName() + "/accessors/" + keys::phaseViscosityString() );
+    m_phaseVisc.setName( getName() + "/accessors/" + phaseViscosity::key() );
     m_phaseDens.clear();
-    m_phaseDens = elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( keys::phaseDensityString(),
+    m_phaseDens = elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( phaseDensity::key(),
                                                                                              targetRegionNames(),
                                                                                              fluidModelNames() );
-    m_phaseDens.setName( getName() + "/accessors/" + keys::phaseDensityString() );
+    m_phaseDens.setName( getName() + "/accessors/" + phaseDensity::key() );
 
     m_dPhaseDens_dPres.clear();
-    m_dPhaseDens_dPres = elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( keys::dPhaseDensity_dPressureString(),
+    m_dPhaseDens_dPres = elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( dPhaseDensity_dPressure::key(),
                                                                                                     targetRegionNames(),
                                                                                                     fluidModelNames() );
-    m_dPhaseDens_dPres.setName( getName() + "/accessors/" + keys::dPhaseDensity_dPressureString() );
+    m_dPhaseDens_dPres.setName( getName() + "/accessors/" + dPhaseDensity_dPressure::key() );
 
     m_dPhaseDens_dComp.clear();
-    m_dPhaseDens_dComp = elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_DC >( keys::dPhaseDensity_dGlobalCompFractionString(),
+    m_dPhaseDens_dComp = elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_DC >( dPhaseDensity_dGlobalCompFraction::key(),
                                                                                                        targetRegionNames(),
                                                                                                        fluidModelNames() );
-    m_dPhaseDens_dComp.setName( getName() + "/accessors/" + keys::dPhaseDensity_dGlobalCompFractionString() );
+    m_dPhaseDens_dComp.setName( getName() + "/accessors/" + dPhaseDensity_dGlobalCompFraction::key() );
 
     m_phaseMassDens.clear();
-    m_phaseMassDens = elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( keys::phaseMassDensityString(),
+    m_phaseMassDens = elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( phaseMassDensity::key(),
                                                                                                  targetRegionNames(),
                                                                                                  fluidModelNames() );
-    m_phaseMassDens.setName( getName() + "/accessors/" + keys::phaseMassDensityString() );
+    m_phaseMassDens.setName( getName() + "/accessors/" + phaseMassDensity::key() );
 
     m_dPhaseMassDens_dPres.clear();
-    m_dPhaseMassDens_dPres = elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( keys::dPhaseMassDensity_dPressureString(),
+    m_dPhaseMassDens_dPres = elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( dPhaseMassDensity_dPressure::key(),
                                                                                                         targetRegionNames(),
                                                                                                         fluidModelNames() );
-    m_dPhaseMassDens_dPres.setName( getName() + "/accessors/" + keys::dPhaseMassDensity_dPressureString() );
+    m_dPhaseMassDens_dPres.setName( getName() + "/accessors/" + dPhaseMassDensity_dPressure::key() );
 
     m_dPhaseMassDens_dComp.clear();
-    m_dPhaseMassDens_dComp = elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_DC >( keys::dPhaseMassDensity_dGlobalCompFractionString(),
+    m_dPhaseMassDens_dComp = elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_DC >( dPhaseMassDensity_dGlobalCompFraction::key(),
                                                                                                            targetRegionNames(),
                                                                                                            fluidModelNames() );
-    m_dPhaseMassDens_dComp.setName( getName() + "/accessors/" + keys::dPhaseMassDensity_dGlobalCompFractionString() );
+    m_dPhaseMassDens_dComp.setName( getName() + "/accessors/" + dPhaseMassDensity_dGlobalCompFraction::key() );
 
     m_phaseCompFrac.clear();
-    m_phaseCompFrac = elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_COMP >( keys::phaseCompFractionString(),
+    m_phaseCompFrac = elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_COMP >( phaseCompFraction::key(),
                                                                                                       targetRegionNames(),
                                                                                                       fluidModelNames() );
-    m_phaseCompFrac.setName( getName() + "/accessors/" + keys::phaseCompFractionString() );
+    m_phaseCompFrac.setName( getName() + "/accessors/" + phaseCompFraction::key() );
 
     m_dPhaseCompFrac_dPres.clear();
-    m_dPhaseCompFrac_dPres = elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_COMP >( keys::dPhaseCompFraction_dPressureString(),
+    m_dPhaseCompFrac_dPres = elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_COMP >( dPhaseCompFraction_dPressure::key(),
                                                                                                              targetRegionNames(),
                                                                                                              fluidModelNames() );
-    m_dPhaseCompFrac_dPres.setName( getName() + "/accessors/" + keys::dPhaseCompFraction_dPressureString() );
+    m_dPhaseCompFrac_dPres.setName( getName() + "/accessors/" + dPhaseCompFraction_dPressure::key() );
 
     m_dPhaseCompFrac_dComp.clear();
-    m_dPhaseCompFrac_dComp = elemManager.constructMaterialArrayViewAccessor< real64, 5, LAYOUT_PHASE_COMP_DC >( keys::dPhaseCompFraction_dGlobalCompFractionString(),
+    m_dPhaseCompFrac_dComp = elemManager.constructMaterialArrayViewAccessor< real64, 5, LAYOUT_PHASE_COMP_DC >( dPhaseCompFraction_dGlobalCompFraction::key(),
                                                                                                                 targetRegionNames(),
                                                                                                                 fluidModelNames() );
-    m_dPhaseCompFrac_dComp.setName( getName() + "/accessors/" + keys::dPhaseCompFraction_dGlobalCompFractionString() );
+    m_dPhaseCompFrac_dComp.setName( getName() + "/accessors/" + dPhaseCompFraction_dGlobalCompFraction::key() );
   }
   {
-    using keys = RelativePermeabilityBase::viewKeyStruct;
     using namespace constitutive::relperm;
+    using namespace extrinsicMeshData::relperm;
 
     m_phaseRelPerm.clear();
-    m_phaseRelPerm = elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_RELPERM >( keys::phaseRelPermString(),
+    m_phaseRelPerm = elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_RELPERM >( phaseRelPerm::key(),
                                                                                                   targetRegionNames(),
                                                                                                   relPermModelNames() );
-    m_phaseRelPerm.setName( getName() + "/accessors/" + keys::phaseRelPermString() );
+    m_phaseRelPerm.setName( getName() + "/accessors/" + phaseRelPerm::key() );
   }
   if( m_capPressureFlag )
   {
-    using keys = CapillaryPressureBase::viewKeyStruct;
     using namespace constitutive::cappres;
+    using namespace extrinsicMeshData::cappres;
 
     m_phaseCapPressure.clear();
     m_phaseCapPressure =
-      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_CAPPRES >( keys::phaseCapPressureString(),
+      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_CAPPRES >( phaseCapPressure::key(),
                                                                                    targetRegionNames(),
                                                                                    capPresModelNames() );
-    m_phaseCapPressure.setName( getName() + "/accessors/" + keys::phaseCapPressureString() );
+    m_phaseCapPressure.setName( getName() + "/accessors/" + phaseCapPressure::key() );
 
     m_dPhaseCapPressure_dPhaseVolFrac.clear();
     m_dPhaseCapPressure_dPhaseVolFrac =
-      elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_CAPPRES_DS >( keys::dPhaseCapPressure_dPhaseVolFractionString(),
+      elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_CAPPRES_DS >( dPhaseCapPressure_dPhaseVolFraction::key(),
                                                                                       targetRegionNames(),
                                                                                       capPresModelNames() );
-    m_dPhaseCapPressure_dPhaseVolFrac.setName( getName() + "/accessors/" + keys::dPhaseCapPressure_dPhaseVolFractionString() );
+    m_dPhaseCapPressure_dPhaseVolFrac.setName( getName() + "/accessors/" + dPhaseCapPressure_dPhaseVolFraction::key() );
   }
 }
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
@@ -1652,97 +1652,70 @@ void CompositionalMultiphaseWell::resetViews( DomainPartition & domain )
 
   }
   {
-    using namespace multifluid;
     using namespace extrinsicMeshData::multifluid;
 
     m_resPhaseDens.clear();
-    m_resPhaseDens =
-      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( phaseDensity::key(),
-                                                                                 flowSolver.targetRegionNames(),
-                                                                                 flowSolver.fluidModelNames() );
+    m_resPhaseDens = elemManager.constructMaterialExtrinsicAccessor< phaseDensity >( flowSolver.targetRegionNames(),
+                                                                                     flowSolver.fluidModelNames() );
     m_resPhaseDens.setName( getName() + "/accessors/" + phaseDensity::key() );
 
     m_dResPhaseDens_dPres.clear();
-    m_dResPhaseDens_dPres =
-      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( dPhaseDensity_dPressure::key(),
-                                                                                 flowSolver.targetRegionNames(),
-                                                                                 flowSolver.fluidModelNames() );
+    m_dResPhaseDens_dPres = elemManager.constructMaterialExtrinsicAccessor< dPhaseDensity_dPressure >( flowSolver.targetRegionNames(),
+                                                                                                       flowSolver.fluidModelNames() );
     m_dResPhaseDens_dPres.setName( getName() + "/accessors/" + dPhaseDensity_dPressure::key() );
 
     m_dResPhaseDens_dComp.clear();
-    m_dResPhaseDens_dComp =
-      elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_DC >( dPhaseDensity_dGlobalCompFraction::key(),
-                                                                                    flowSolver.targetRegionNames(),
-                                                                                    flowSolver.fluidModelNames() );
+    m_dResPhaseDens_dComp = elemManager.constructMaterialExtrinsicAccessor< dPhaseDensity_dGlobalCompFraction >( flowSolver.targetRegionNames(),
+                                                                                                                 flowSolver.fluidModelNames() );
     m_dResPhaseDens_dComp.setName( getName() + "/accessors/" + dPhaseDensity_dGlobalCompFraction::key() );
 
-
     m_resPhaseMassDens.clear();
-    m_resPhaseMassDens =
-      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( phaseMassDensity::key(),
-                                                                                 flowSolver.targetRegionNames(),
-                                                                                 flowSolver.fluidModelNames() );
+    m_resPhaseMassDens = elemManager.constructMaterialExtrinsicAccessor< phaseMassDensity >( flowSolver.targetRegionNames(),
+                                                                                             flowSolver.fluidModelNames() );
     m_resPhaseMassDens.setName( getName() + "/accessors/" + phaseMassDensity::key() );
 
     m_resPhaseVisc.clear();
-    m_resPhaseVisc =
-      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( phaseViscosity::key(),
-                                                                                 flowSolver.targetRegionNames(),
-                                                                                 flowSolver.fluidModelNames() );
+    m_resPhaseVisc = elemManager.constructMaterialExtrinsicAccessor< phaseViscosity >( flowSolver.targetRegionNames(),
+                                                                                       flowSolver.fluidModelNames() );
     m_resPhaseVisc.setName( getName() + "/accessors/" + phaseViscosity::key() );
 
     m_dResPhaseVisc_dPres.clear();
-    m_dResPhaseVisc_dPres =
-      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( dPhaseViscosity_dPressure::key(),
-                                                                                 flowSolver.targetRegionNames(),
-                                                                                 flowSolver.fluidModelNames() );
+    m_dResPhaseVisc_dPres = elemManager.constructMaterialExtrinsicAccessor< dPhaseViscosity_dPressure >( flowSolver.targetRegionNames(),
+                                                                                                         flowSolver.fluidModelNames() );
     m_dResPhaseVisc_dPres.setName( getName() + "/accessors/" + dPhaseViscosity_dPressure::key() );
 
     m_dResPhaseVisc_dComp.clear();
-    m_dResPhaseVisc_dComp =
-      elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_DC >( dPhaseViscosity_dGlobalCompFraction::key(),
-                                                                                    flowSolver.targetRegionNames(),
-                                                                                    flowSolver.fluidModelNames() );
+    m_dResPhaseVisc_dComp = elemManager.constructMaterialExtrinsicAccessor< dPhaseViscosity_dGlobalCompFraction >( flowSolver.targetRegionNames(),
+                                                                                                                   flowSolver.fluidModelNames() );
     m_dResPhaseVisc_dComp.setName( getName() + "/accessors/" + dPhaseViscosity_dGlobalCompFraction::key() );
 
     m_resPhaseCompFrac.clear();
-    m_resPhaseCompFrac =
-      elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_COMP >( phaseCompFraction::key(),
-                                                                                      flowSolver.targetRegionNames(),
-                                                                                      flowSolver.fluidModelNames() );
+    m_resPhaseCompFrac = elemManager.constructMaterialExtrinsicAccessor< phaseCompFraction >( flowSolver.targetRegionNames(),
+                                                                                              flowSolver.fluidModelNames() );
     m_resPhaseCompFrac.setName( getName() + "/accessors/" + phaseCompFraction::key() );
 
     m_dResPhaseCompFrac_dPres.clear();
-    m_dResPhaseCompFrac_dPres =
-      elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_COMP >( dPhaseCompFraction_dPressure::key(),
-                                                                                      flowSolver.targetRegionNames(),
-                                                                                      flowSolver.fluidModelNames() );
+    m_dResPhaseCompFrac_dPres = elemManager.constructMaterialExtrinsicAccessor< dPhaseCompFraction_dPressure >( flowSolver.targetRegionNames(),
+                                                                                                                flowSolver.fluidModelNames() );
     m_dResPhaseCompFrac_dPres.setName( getName() + "/accessors/" + dPhaseCompFraction_dPressure::key() );
 
     m_dResPhaseCompFrac_dComp.clear();
-    m_dResPhaseCompFrac_dComp =
-      elemManager.constructMaterialArrayViewAccessor< real64, 5, LAYOUT_PHASE_COMP_DC >( dPhaseCompFraction_dGlobalCompFraction::key(),
-                                                                                         flowSolver.targetRegionNames(),
-                                                                                         flowSolver.fluidModelNames() );
+    m_dResPhaseCompFrac_dComp = elemManager.constructMaterialExtrinsicAccessor< dPhaseCompFraction_dGlobalCompFraction >( flowSolver.targetRegionNames(),
+                                                                                                                          flowSolver.fluidModelNames() );
     m_dResPhaseCompFrac_dComp.setName( getName() + "/accessors/" + dPhaseCompFraction_dGlobalCompFraction::key() );
 
   }
   {
-    using namespace relperm;
     using namespace extrinsicMeshData::relperm;
 
     m_resPhaseRelPerm.clear();
-    m_resPhaseRelPerm =
-      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_RELPERM >( phaseRelPerm::key(),
-                                                                                   flowSolver.targetRegionNames(),
-                                                                                   flowSolver.relPermModelNames() );
+    m_resPhaseRelPerm = elemManager.constructMaterialExtrinsicAccessor< phaseRelPerm >( flowSolver.targetRegionNames(),
+                                                                                        flowSolver.relPermModelNames() );
     m_resPhaseRelPerm.setName( getName() + "/accessors/" + phaseRelPerm::key() );
 
     m_dResPhaseRelPerm_dPhaseVolFrac.clear();
-    m_dResPhaseRelPerm_dPhaseVolFrac =
-      elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_RELPERM_DS >( dPhaseRelPerm_dPhaseVolFraction::key(),
-                                                                                      flowSolver.targetRegionNames(),
-                                                                                      flowSolver.relPermModelNames() );
+    m_dResPhaseRelPerm_dPhaseVolFrac = elemManager.constructMaterialExtrinsicAccessor< dPhaseRelPerm_dPhaseVolFraction >( flowSolver.targetRegionNames(),
+                                                                                                                          flowSolver.relPermModelNames() );
     m_dResPhaseRelPerm_dPhaseVolFrac.setName( getName() + "/accessors/" + dPhaseRelPerm_dPhaseVolFraction::key() );
 
   }

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
@@ -25,8 +25,10 @@
 #include "common/TimingMacros.hpp"
 #include "constitutive/ConstitutiveManager.hpp"
 #include "constitutive/fluid/MultiFluidBase.hpp"
+#include "constitutive/fluid/MultiFluidExtrinsicData.hpp"
 #include "constitutive/fluid/multiFluidSelector.hpp"
 #include "constitutive/relativePermeability/RelativePermeabilityBase.hpp"
+#include "constitutive/relativePermeability/RelativePermeabilityExtrinsicData.hpp"
 #include "mesh/DomainPartition.hpp"
 #include "mesh/WellElementSubRegion.hpp"
 #include "mesh/PerforationData.hpp"
@@ -1650,98 +1652,98 @@ void CompositionalMultiphaseWell::resetViews( DomainPartition & domain )
 
   }
   {
-    using keys = MultiFluidBase::viewKeyStruct;
     using namespace multifluid;
+    using namespace extrinsicMeshData::multifluid;
 
     m_resPhaseDens.clear();
     m_resPhaseDens =
-      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( keys::phaseDensityString(),
+      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( phaseDensity::key(),
                                                                                  flowSolver.targetRegionNames(),
                                                                                  flowSolver.fluidModelNames() );
-    m_resPhaseDens.setName( getName() + "/accessors/" + keys::phaseDensityString() );
+    m_resPhaseDens.setName( getName() + "/accessors/" + phaseDensity::key() );
 
     m_dResPhaseDens_dPres.clear();
     m_dResPhaseDens_dPres =
-      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( keys::dPhaseDensity_dPressureString(),
+      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( dPhaseDensity_dPressure::key(),
                                                                                  flowSolver.targetRegionNames(),
                                                                                  flowSolver.fluidModelNames() );
-    m_dResPhaseDens_dPres.setName( getName() + "/accessors/" + keys::dPhaseDensity_dPressureString() );
+    m_dResPhaseDens_dPres.setName( getName() + "/accessors/" + dPhaseDensity_dPressure::key() );
 
     m_dResPhaseDens_dComp.clear();
     m_dResPhaseDens_dComp =
-      elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_DC >( keys::dPhaseDensity_dGlobalCompFractionString(),
+      elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_DC >( dPhaseDensity_dGlobalCompFraction::key(),
                                                                                     flowSolver.targetRegionNames(),
                                                                                     flowSolver.fluidModelNames() );
-    m_dResPhaseDens_dComp.setName( getName() + "/accessors/" + keys::dPhaseDensity_dGlobalCompFractionString() );
+    m_dResPhaseDens_dComp.setName( getName() + "/accessors/" + dPhaseDensity_dGlobalCompFraction::key() );
 
 
     m_resPhaseMassDens.clear();
     m_resPhaseMassDens =
-      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( keys::phaseMassDensityString(),
+      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( phaseMassDensity::key(),
                                                                                  flowSolver.targetRegionNames(),
                                                                                  flowSolver.fluidModelNames() );
-    m_resPhaseMassDens.setName( getName() + "/accessors/" + keys::phaseMassDensityString() );
+    m_resPhaseMassDens.setName( getName() + "/accessors/" + phaseMassDensity::key() );
 
     m_resPhaseVisc.clear();
     m_resPhaseVisc =
-      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( keys::phaseViscosityString(),
+      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( phaseViscosity::key(),
                                                                                  flowSolver.targetRegionNames(),
                                                                                  flowSolver.fluidModelNames() );
-    m_resPhaseVisc.setName( getName() + "/accessors/" + keys::phaseViscosityString() );
+    m_resPhaseVisc.setName( getName() + "/accessors/" + phaseViscosity::key() );
 
     m_dResPhaseVisc_dPres.clear();
     m_dResPhaseVisc_dPres =
-      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( keys::dPhaseViscosity_dPressureString(),
+      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_PHASE >( dPhaseViscosity_dPressure::key(),
                                                                                  flowSolver.targetRegionNames(),
                                                                                  flowSolver.fluidModelNames() );
-    m_dResPhaseVisc_dPres.setName( getName() + "/accessors/" + keys::dPhaseViscosity_dPressureString() );
+    m_dResPhaseVisc_dPres.setName( getName() + "/accessors/" + dPhaseViscosity_dPressure::key() );
 
     m_dResPhaseVisc_dComp.clear();
     m_dResPhaseVisc_dComp =
-      elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_DC >( keys::dPhaseViscosity_dGlobalCompFractionString(),
+      elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_DC >( dPhaseViscosity_dGlobalCompFraction::key(),
                                                                                     flowSolver.targetRegionNames(),
                                                                                     flowSolver.fluidModelNames() );
-    m_dResPhaseVisc_dComp.setName( getName() + "/accessors/" + keys::dPhaseViscosity_dGlobalCompFractionString() );
+    m_dResPhaseVisc_dComp.setName( getName() + "/accessors/" + dPhaseViscosity_dGlobalCompFraction::key() );
 
     m_resPhaseCompFrac.clear();
     m_resPhaseCompFrac =
-      elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_COMP >( keys::phaseCompFractionString(),
+      elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_COMP >( phaseCompFraction::key(),
                                                                                       flowSolver.targetRegionNames(),
                                                                                       flowSolver.fluidModelNames() );
-    m_resPhaseCompFrac.setName( getName() + "/accessors/" + keys::phaseCompFractionString() );
+    m_resPhaseCompFrac.setName( getName() + "/accessors/" + phaseCompFraction::key() );
 
     m_dResPhaseCompFrac_dPres.clear();
     m_dResPhaseCompFrac_dPres =
-      elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_COMP >( keys::dPhaseCompFraction_dPressureString(),
+      elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_PHASE_COMP >( dPhaseCompFraction_dPressure::key(),
                                                                                       flowSolver.targetRegionNames(),
                                                                                       flowSolver.fluidModelNames() );
-    m_dResPhaseCompFrac_dPres.setName( getName() + "/accessors/" + keys::dPhaseCompFraction_dPressureString() );
+    m_dResPhaseCompFrac_dPres.setName( getName() + "/accessors/" + dPhaseCompFraction_dPressure::key() );
 
     m_dResPhaseCompFrac_dComp.clear();
     m_dResPhaseCompFrac_dComp =
-      elemManager.constructMaterialArrayViewAccessor< real64, 5, LAYOUT_PHASE_COMP_DC >( keys::dPhaseCompFraction_dGlobalCompFractionString(),
+      elemManager.constructMaterialArrayViewAccessor< real64, 5, LAYOUT_PHASE_COMP_DC >( dPhaseCompFraction_dGlobalCompFraction::key(),
                                                                                          flowSolver.targetRegionNames(),
                                                                                          flowSolver.fluidModelNames() );
-    m_dResPhaseCompFrac_dComp.setName( getName() + "/accessors/" + keys::dPhaseCompFraction_dGlobalCompFractionString() );
+    m_dResPhaseCompFrac_dComp.setName( getName() + "/accessors/" + dPhaseCompFraction_dGlobalCompFraction::key() );
 
   }
   {
-    using keys = RelativePermeabilityBase::viewKeyStruct;
     using namespace relperm;
+    using namespace extrinsicMeshData::relperm;
 
     m_resPhaseRelPerm.clear();
     m_resPhaseRelPerm =
-      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_RELPERM >( keys::phaseRelPermString(),
+      elemManager.constructMaterialArrayViewAccessor< real64, 3, LAYOUT_RELPERM >( phaseRelPerm::key(),
                                                                                    flowSolver.targetRegionNames(),
                                                                                    flowSolver.relPermModelNames() );
-    m_resPhaseRelPerm.setName( getName() + "/accessors/" + keys::phaseRelPermString() );
+    m_resPhaseRelPerm.setName( getName() + "/accessors/" + phaseRelPerm::key() );
 
     m_dResPhaseRelPerm_dPhaseVolFrac.clear();
     m_dResPhaseRelPerm_dPhaseVolFrac =
-      elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_RELPERM_DS >( keys::dPhaseRelPerm_dPhaseVolFractionString(),
+      elemManager.constructMaterialArrayViewAccessor< real64, 4, LAYOUT_RELPERM_DS >( dPhaseRelPerm_dPhaseVolFraction::key(),
                                                                                       flowSolver.targetRegionNames(),
                                                                                       flowSolver.relPermModelNames() );
-    m_dResPhaseRelPerm_dPhaseVolFrac.setName( getName() + "/accessors/" + keys::dPhaseRelPerm_dPhaseVolFractionString() );
+    m_dResPhaseRelPerm_dPhaseVolFrac.setName( getName() + "/accessors/" + dPhaseRelPerm_dPhaseVolFraction::key() );
 
   }
 }

--- a/src/coreComponents/schema/docs/BlackOilFluid_other.rst
+++ b/src/coreComponents/schema/docs/BlackOilFluid_other.rst
@@ -1,40 +1,40 @@
 
 
-====================================== ========================================================================================================= ========================== 
-Name                                   Type                                                                                                      Description                
-====================================== ========================================================================================================= ========================== 
-PVTO                                   geosx_constitutive_PVTOData                                                                               (no description available) 
-dPhaseCompFraction_dGlobalCompFraction LvArray_Array< double, 5, camp_int_seq< long, 0l, 1l, 2l, 3l, 4l >, long, LvArray_ChaiBuffer >            (no description available) 
-dPhaseCompFraction_dPressure           real64_array4d                                                                                            (no description available) 
-dPhaseCompFraction_dTemperature        real64_array4d                                                                                            (no description available) 
-dPhaseDensity_dGlobalCompFraction      real64_array4d                                                                                            (no description available) 
-dPhaseDensity_dPressure                real64_array3d                                                                                            (no description available) 
-dPhaseDensity_dTemperature             real64_array3d                                                                                            (no description available) 
-dPhaseFraction_dGlobalCompFraction     real64_array4d                                                                                            (no description available) 
-dPhaseFraction_dPressure               real64_array3d                                                                                            (no description available) 
-dPhaseFraction_dTemperature            real64_array3d                                                                                            (no description available) 
-dPhaseMassDensity_dGlobalCompFraction  real64_array4d                                                                                            (no description available) 
-dPhaseMassDensity_dPressure            real64_array3d                                                                                            (no description available) 
-dPhaseMassDensity_dTemperature         real64_array3d                                                                                            (no description available) 
-dPhaseViscosity_dGlobalCompFraction    real64_array4d                                                                                            (no description available) 
-dPhaseViscosity_dPressure              real64_array3d                                                                                            (no description available) 
-dPhaseViscosity_dTemperature           real64_array3d                                                                                            (no description available) 
-dTotalDensity_dGlobalCompFraction      real64_array3d                                                                                            (no description available) 
-dTotalDensity_dPressure                real64_array2d                                                                                            (no description available) 
-dTotalDensity_dTemperature             real64_array2d                                                                                            (no description available) 
-formationVolFactorTableWrappers        LvArray_Array< geosx_TableFunction_KernelWrapper, 1, camp_int_seq< long, 0l >, long, LvArray_ChaiBuffer > (no description available) 
-hydrocarbonPhaseOrder                  integer_array                                                                                             (no description available) 
-initialTotalMassDensity                real64_array2d                                                                                            (no description available) 
-phaseCompFraction                      real64_array4d                                                                                            (no description available) 
-phaseDensity                           real64_array3d                                                                                            (no description available) 
-phaseFraction                          real64_array3d                                                                                            (no description available) 
-phaseMassDensity                       real64_array3d                                                                                            (no description available) 
-phaseOrder                             integer_array                                                                                             (no description available) 
-phaseTypes                             integer_array                                                                                             (no description available) 
-phaseViscosity                         real64_array3d                                                                                            (no description available) 
-totalDensity                           real64_array2d                                                                                            (no description available) 
-useMass                                integer                                                                                                   (no description available) 
-viscosityTableWrappers                 LvArray_Array< geosx_TableFunction_KernelWrapper, 1, camp_int_seq< long, 0l >, long, LvArray_ChaiBuffer > (no description available) 
-====================================== ========================================================================================================= ========================== 
+====================================== ========================================================================================================= ================================================================================ 
+Name                                   Type                                                                                                      Description                                                                      
+====================================== ========================================================================================================= ================================================================================ 
+PVTO                                   geosx_constitutive_PVTOData                                                                               (no description available)                                                       
+dPhaseCompFraction_dGlobalCompFraction LvArray_Array< double, 5, camp_int_seq< long, 0l, 1l, 2l, 3l, 4l >, long, LvArray_ChaiBuffer >            Derivative of phase component fraction with respect to global component fraction 
+dPhaseCompFraction_dPressure           real64_array4d                                                                                            Derivative of phase component fraction with respect to pressure                  
+dPhaseCompFraction_dTemperature        real64_array4d                                                                                            Derivative of phase component fraction with respect to temperature               
+dPhaseDensity_dGlobalCompFraction      real64_array4d                                                                                            Derivative of phase density with respect to global component fraction            
+dPhaseDensity_dPressure                real64_array3d                                                                                            Derivative of phase density with respect to pressure                             
+dPhaseDensity_dTemperature             real64_array3d                                                                                            Derivative of phase density with respect to temperature                          
+dPhaseFraction_dGlobalCompFraction     real64_array4d                                                                                            Derivative of phase fraction with respect to global component fraction           
+dPhaseFraction_dPressure               real64_array3d                                                                                            Derivative of phase fraction with respect to pressure                            
+dPhaseFraction_dTemperature            real64_array3d                                                                                            Derivative of phase fraction with respect to temperature                         
+dPhaseMassDensity_dGlobalCompFraction  real64_array4d                                                                                            Derivative of phase mass density with respect to global component fraction       
+dPhaseMassDensity_dPressure            real64_array3d                                                                                            Derivative of phase mass density with respect to pressure                        
+dPhaseMassDensity_dTemperature         real64_array3d                                                                                            Derivative of phase mass density with respect to temperature                     
+dPhaseViscosity_dGlobalCompFraction    real64_array4d                                                                                            Derivative of phase viscosity with respect to global component fraction          
+dPhaseViscosity_dPressure              real64_array3d                                                                                            Derivative of phase viscosity with respect to pressure                           
+dPhaseViscosity_dTemperature           real64_array3d                                                                                            Derivative of phase viscosity with respect to temperature                        
+dTotalDensity_dGlobalCompFraction      real64_array3d                                                                                            Derivative of total density with respect to global component fraction            
+dTotalDensity_dPressure                real64_array2d                                                                                            Derivative of total density with respect to pressure                             
+dTotalDensity_dTemperature             real64_array2d                                                                                            Derivative of total density with respect to temperature                          
+formationVolFactorTableWrappers        LvArray_Array< geosx_TableFunction_KernelWrapper, 1, camp_int_seq< long, 0l >, long, LvArray_ChaiBuffer > (no description available)                                                       
+hydrocarbonPhaseOrder                  integer_array                                                                                             (no description available)                                                       
+initialTotalMassDensity                real64_array2d                                                                                            Initial total mass density                                                       
+phaseCompFraction                      real64_array4d                                                                                            Phase component fraction                                                         
+phaseDensity                           real64_array3d                                                                                            Phase density                                                                    
+phaseFraction                          real64_array3d                                                                                            Phase fraction                                                                   
+phaseMassDensity                       real64_array3d                                                                                            Phase mass density                                                               
+phaseOrder                             integer_array                                                                                             (no description available)                                                       
+phaseTypes                             integer_array                                                                                             (no description available)                                                       
+phaseViscosity                         real64_array3d                                                                                            Phase viscosity                                                                  
+totalDensity                           real64_array2d                                                                                            Total density                                                                    
+useMass                                integer                                                                                                   (no description available)                                                       
+viscosityTableWrappers                 LvArray_Array< geosx_TableFunction_KernelWrapper, 1, camp_int_seq< long, 0l >, long, LvArray_ChaiBuffer > (no description available)                                                       
+====================================== ========================================================================================================= ================================================================================ 
 
 

--- a/src/coreComponents/schema/docs/BrooksCoreyBakerRelativePermeability_other.rst
+++ b/src/coreComponents/schema/docs/BrooksCoreyBakerRelativePermeability_other.rst
@@ -3,9 +3,9 @@
 =============================== ============== ======================================================================================================================= 
 Name                            Type           Description                                                                                                             
 =============================== ============== ======================================================================================================================= 
-dPhaseRelPerm_dPhaseVolFraction real64_array4d (no description available)                                                                                              
+dPhaseRelPerm_dPhaseVolFraction real64_array4d Derivative of phase relative permeability with respect to phase volume fraction                                         
 phaseOrder                      integer_array  (no description available)                                                                                              
-phaseRelPerm                    real64_array3d (no description available)                                                                                              
+phaseRelPerm                    real64_array3d Phase relative permeability                                                                                             
 phaseTypes                      integer_array  (no description available)                                                                                              
 volFracScale                    real64         Factor used to scale the phase capillary pressure, defined as: one minus the sum of the phase minimum volume fractions. 
 =============================== ============== ======================================================================================================================= 

--- a/src/coreComponents/schema/docs/BrooksCoreyCapillaryPressure_other.rst
+++ b/src/coreComponents/schema/docs/BrooksCoreyCapillaryPressure_other.rst
@@ -3,8 +3,8 @@
 =================================== ============== ======================================================================================================================= 
 Name                                Type           Description                                                                                                             
 =================================== ============== ======================================================================================================================= 
-dPhaseCapPressure_dPhaseVolFraction real64_array4d (no description available)                                                                                              
-phaseCapPressure                    real64_array3d (no description available)                                                                                              
+dPhaseCapPressure_dPhaseVolFraction real64_array4d Derivative of phase capillary pressure with respect to phase volume fraction                                            
+phaseCapPressure                    real64_array3d Phase capillary pressure                                                                                                
 phaseOrder                          integer_array  (no description available)                                                                                              
 phaseTypes                          integer_array  (no description available)                                                                                              
 volFracScale                        real64         Factor used to scale the phase capillary pressure, defined as: one minus the sum of the phase minimum volume fractions. 

--- a/src/coreComponents/schema/docs/BrooksCoreyRelativePermeability_other.rst
+++ b/src/coreComponents/schema/docs/BrooksCoreyRelativePermeability_other.rst
@@ -3,9 +3,9 @@
 =============================== ============== ========================================================================================================================== 
 Name                            Type           Description                                                                                                                
 =============================== ============== ========================================================================================================================== 
-dPhaseRelPerm_dPhaseVolFraction real64_array4d (no description available)                                                                                                 
+dPhaseRelPerm_dPhaseVolFraction real64_array4d Derivative of phase relative permeability with respect to phase volume fraction                                            
 phaseOrder                      integer_array  (no description available)                                                                                                 
-phaseRelPerm                    real64_array3d (no description available)                                                                                                 
+phaseRelPerm                    real64_array3d Phase relative permeability                                                                                                
 phaseTypes                      integer_array  (no description available)                                                                                                 
 volFracScale                    real64         Factor used to scale the phase relative permeability, defined as: one minus the sum of the phase minimum volume fractions. 
 =============================== ============== ========================================================================================================================== 

--- a/src/coreComponents/schema/docs/CO2BrineEzrokhiFluid_other.rst
+++ b/src/coreComponents/schema/docs/CO2BrineEzrokhiFluid_other.rst
@@ -1,34 +1,34 @@
 
 
-====================================== ============================================================================================== ========================== 
-Name                                   Type                                                                                           Description                
-====================================== ============================================================================================== ========================== 
-dPhaseCompFraction_dGlobalCompFraction LvArray_Array< double, 5, camp_int_seq< long, 0l, 1l, 2l, 3l, 4l >, long, LvArray_ChaiBuffer > (no description available) 
-dPhaseCompFraction_dPressure           real64_array4d                                                                                 (no description available) 
-dPhaseCompFraction_dTemperature        real64_array4d                                                                                 (no description available) 
-dPhaseDensity_dGlobalCompFraction      real64_array4d                                                                                 (no description available) 
-dPhaseDensity_dPressure                real64_array3d                                                                                 (no description available) 
-dPhaseDensity_dTemperature             real64_array3d                                                                                 (no description available) 
-dPhaseFraction_dGlobalCompFraction     real64_array4d                                                                                 (no description available) 
-dPhaseFraction_dPressure               real64_array3d                                                                                 (no description available) 
-dPhaseFraction_dTemperature            real64_array3d                                                                                 (no description available) 
-dPhaseMassDensity_dGlobalCompFraction  real64_array4d                                                                                 (no description available) 
-dPhaseMassDensity_dPressure            real64_array3d                                                                                 (no description available) 
-dPhaseMassDensity_dTemperature         real64_array3d                                                                                 (no description available) 
-dPhaseViscosity_dGlobalCompFraction    real64_array4d                                                                                 (no description available) 
-dPhaseViscosity_dPressure              real64_array3d                                                                                 (no description available) 
-dPhaseViscosity_dTemperature           real64_array3d                                                                                 (no description available) 
-dTotalDensity_dGlobalCompFraction      real64_array3d                                                                                 (no description available) 
-dTotalDensity_dPressure                real64_array2d                                                                                 (no description available) 
-dTotalDensity_dTemperature             real64_array2d                                                                                 (no description available) 
-initialTotalMassDensity                real64_array2d                                                                                 (no description available) 
-phaseCompFraction                      real64_array4d                                                                                 (no description available) 
-phaseDensity                           real64_array3d                                                                                 (no description available) 
-phaseFraction                          real64_array3d                                                                                 (no description available) 
-phaseMassDensity                       real64_array3d                                                                                 (no description available) 
-phaseViscosity                         real64_array3d                                                                                 (no description available) 
-totalDensity                           real64_array2d                                                                                 (no description available) 
-useMass                                integer                                                                                        (no description available) 
-====================================== ============================================================================================== ========================== 
+====================================== ============================================================================================== ================================================================================ 
+Name                                   Type                                                                                           Description                                                                      
+====================================== ============================================================================================== ================================================================================ 
+dPhaseCompFraction_dGlobalCompFraction LvArray_Array< double, 5, camp_int_seq< long, 0l, 1l, 2l, 3l, 4l >, long, LvArray_ChaiBuffer > Derivative of phase component fraction with respect to global component fraction 
+dPhaseCompFraction_dPressure           real64_array4d                                                                                 Derivative of phase component fraction with respect to pressure                  
+dPhaseCompFraction_dTemperature        real64_array4d                                                                                 Derivative of phase component fraction with respect to temperature               
+dPhaseDensity_dGlobalCompFraction      real64_array4d                                                                                 Derivative of phase density with respect to global component fraction            
+dPhaseDensity_dPressure                real64_array3d                                                                                 Derivative of phase density with respect to pressure                             
+dPhaseDensity_dTemperature             real64_array3d                                                                                 Derivative of phase density with respect to temperature                          
+dPhaseFraction_dGlobalCompFraction     real64_array4d                                                                                 Derivative of phase fraction with respect to global component fraction           
+dPhaseFraction_dPressure               real64_array3d                                                                                 Derivative of phase fraction with respect to pressure                            
+dPhaseFraction_dTemperature            real64_array3d                                                                                 Derivative of phase fraction with respect to temperature                         
+dPhaseMassDensity_dGlobalCompFraction  real64_array4d                                                                                 Derivative of phase mass density with respect to global component fraction       
+dPhaseMassDensity_dPressure            real64_array3d                                                                                 Derivative of phase mass density with respect to pressure                        
+dPhaseMassDensity_dTemperature         real64_array3d                                                                                 Derivative of phase mass density with respect to temperature                     
+dPhaseViscosity_dGlobalCompFraction    real64_array4d                                                                                 Derivative of phase viscosity with respect to global component fraction          
+dPhaseViscosity_dPressure              real64_array3d                                                                                 Derivative of phase viscosity with respect to pressure                           
+dPhaseViscosity_dTemperature           real64_array3d                                                                                 Derivative of phase viscosity with respect to temperature                        
+dTotalDensity_dGlobalCompFraction      real64_array3d                                                                                 Derivative of total density with respect to global component fraction            
+dTotalDensity_dPressure                real64_array2d                                                                                 Derivative of total density with respect to pressure                             
+dTotalDensity_dTemperature             real64_array2d                                                                                 Derivative of total density with respect to temperature                          
+initialTotalMassDensity                real64_array2d                                                                                 Initial total mass density                                                       
+phaseCompFraction                      real64_array4d                                                                                 Phase component fraction                                                         
+phaseDensity                           real64_array3d                                                                                 Phase density                                                                    
+phaseFraction                          real64_array3d                                                                                 Phase fraction                                                                   
+phaseMassDensity                       real64_array3d                                                                                 Phase mass density                                                               
+phaseViscosity                         real64_array3d                                                                                 Phase viscosity                                                                  
+totalDensity                           real64_array2d                                                                                 Total density                                                                    
+useMass                                integer                                                                                        (no description available)                                                       
+====================================== ============================================================================================== ================================================================================ 
 
 

--- a/src/coreComponents/schema/docs/CO2BrinePhillipsFluid_other.rst
+++ b/src/coreComponents/schema/docs/CO2BrinePhillipsFluid_other.rst
@@ -1,34 +1,34 @@
 
 
-====================================== ============================================================================================== ========================== 
-Name                                   Type                                                                                           Description                
-====================================== ============================================================================================== ========================== 
-dPhaseCompFraction_dGlobalCompFraction LvArray_Array< double, 5, camp_int_seq< long, 0l, 1l, 2l, 3l, 4l >, long, LvArray_ChaiBuffer > (no description available) 
-dPhaseCompFraction_dPressure           real64_array4d                                                                                 (no description available) 
-dPhaseCompFraction_dTemperature        real64_array4d                                                                                 (no description available) 
-dPhaseDensity_dGlobalCompFraction      real64_array4d                                                                                 (no description available) 
-dPhaseDensity_dPressure                real64_array3d                                                                                 (no description available) 
-dPhaseDensity_dTemperature             real64_array3d                                                                                 (no description available) 
-dPhaseFraction_dGlobalCompFraction     real64_array4d                                                                                 (no description available) 
-dPhaseFraction_dPressure               real64_array3d                                                                                 (no description available) 
-dPhaseFraction_dTemperature            real64_array3d                                                                                 (no description available) 
-dPhaseMassDensity_dGlobalCompFraction  real64_array4d                                                                                 (no description available) 
-dPhaseMassDensity_dPressure            real64_array3d                                                                                 (no description available) 
-dPhaseMassDensity_dTemperature         real64_array3d                                                                                 (no description available) 
-dPhaseViscosity_dGlobalCompFraction    real64_array4d                                                                                 (no description available) 
-dPhaseViscosity_dPressure              real64_array3d                                                                                 (no description available) 
-dPhaseViscosity_dTemperature           real64_array3d                                                                                 (no description available) 
-dTotalDensity_dGlobalCompFraction      real64_array3d                                                                                 (no description available) 
-dTotalDensity_dPressure                real64_array2d                                                                                 (no description available) 
-dTotalDensity_dTemperature             real64_array2d                                                                                 (no description available) 
-initialTotalMassDensity                real64_array2d                                                                                 (no description available) 
-phaseCompFraction                      real64_array4d                                                                                 (no description available) 
-phaseDensity                           real64_array3d                                                                                 (no description available) 
-phaseFraction                          real64_array3d                                                                                 (no description available) 
-phaseMassDensity                       real64_array3d                                                                                 (no description available) 
-phaseViscosity                         real64_array3d                                                                                 (no description available) 
-totalDensity                           real64_array2d                                                                                 (no description available) 
-useMass                                integer                                                                                        (no description available) 
-====================================== ============================================================================================== ========================== 
+====================================== ============================================================================================== ================================================================================ 
+Name                                   Type                                                                                           Description                                                                      
+====================================== ============================================================================================== ================================================================================ 
+dPhaseCompFraction_dGlobalCompFraction LvArray_Array< double, 5, camp_int_seq< long, 0l, 1l, 2l, 3l, 4l >, long, LvArray_ChaiBuffer > Derivative of phase component fraction with respect to global component fraction 
+dPhaseCompFraction_dPressure           real64_array4d                                                                                 Derivative of phase component fraction with respect to pressure                  
+dPhaseCompFraction_dTemperature        real64_array4d                                                                                 Derivative of phase component fraction with respect to temperature               
+dPhaseDensity_dGlobalCompFraction      real64_array4d                                                                                 Derivative of phase density with respect to global component fraction            
+dPhaseDensity_dPressure                real64_array3d                                                                                 Derivative of phase density with respect to pressure                             
+dPhaseDensity_dTemperature             real64_array3d                                                                                 Derivative of phase density with respect to temperature                          
+dPhaseFraction_dGlobalCompFraction     real64_array4d                                                                                 Derivative of phase fraction with respect to global component fraction           
+dPhaseFraction_dPressure               real64_array3d                                                                                 Derivative of phase fraction with respect to pressure                            
+dPhaseFraction_dTemperature            real64_array3d                                                                                 Derivative of phase fraction with respect to temperature                         
+dPhaseMassDensity_dGlobalCompFraction  real64_array4d                                                                                 Derivative of phase mass density with respect to global component fraction       
+dPhaseMassDensity_dPressure            real64_array3d                                                                                 Derivative of phase mass density with respect to pressure                        
+dPhaseMassDensity_dTemperature         real64_array3d                                                                                 Derivative of phase mass density with respect to temperature                     
+dPhaseViscosity_dGlobalCompFraction    real64_array4d                                                                                 Derivative of phase viscosity with respect to global component fraction          
+dPhaseViscosity_dPressure              real64_array3d                                                                                 Derivative of phase viscosity with respect to pressure                           
+dPhaseViscosity_dTemperature           real64_array3d                                                                                 Derivative of phase viscosity with respect to temperature                        
+dTotalDensity_dGlobalCompFraction      real64_array3d                                                                                 Derivative of total density with respect to global component fraction            
+dTotalDensity_dPressure                real64_array2d                                                                                 Derivative of total density with respect to pressure                             
+dTotalDensity_dTemperature             real64_array2d                                                                                 Derivative of total density with respect to temperature                          
+initialTotalMassDensity                real64_array2d                                                                                 Initial total mass density                                                       
+phaseCompFraction                      real64_array4d                                                                                 Phase component fraction                                                         
+phaseDensity                           real64_array3d                                                                                 Phase density                                                                    
+phaseFraction                          real64_array3d                                                                                 Phase fraction                                                                   
+phaseMassDensity                       real64_array3d                                                                                 Phase mass density                                                               
+phaseViscosity                         real64_array3d                                                                                 Phase viscosity                                                                  
+totalDensity                           real64_array2d                                                                                 Total density                                                                    
+useMass                                integer                                                                                        (no description available)                                                       
+====================================== ============================================================================================== ================================================================================ 
 
 

--- a/src/coreComponents/schema/docs/CompositionalMultiphaseFluid_other.rst
+++ b/src/coreComponents/schema/docs/CompositionalMultiphaseFluid_other.rst
@@ -1,34 +1,34 @@
 
 
-====================================== ============================================================================================== ========================== 
-Name                                   Type                                                                                           Description                
-====================================== ============================================================================================== ========================== 
-dPhaseCompFraction_dGlobalCompFraction LvArray_Array< double, 5, camp_int_seq< long, 0l, 1l, 2l, 3l, 4l >, long, LvArray_ChaiBuffer > (no description available) 
-dPhaseCompFraction_dPressure           real64_array4d                                                                                 (no description available) 
-dPhaseCompFraction_dTemperature        real64_array4d                                                                                 (no description available) 
-dPhaseDensity_dGlobalCompFraction      real64_array4d                                                                                 (no description available) 
-dPhaseDensity_dPressure                real64_array3d                                                                                 (no description available) 
-dPhaseDensity_dTemperature             real64_array3d                                                                                 (no description available) 
-dPhaseFraction_dGlobalCompFraction     real64_array4d                                                                                 (no description available) 
-dPhaseFraction_dPressure               real64_array3d                                                                                 (no description available) 
-dPhaseFraction_dTemperature            real64_array3d                                                                                 (no description available) 
-dPhaseMassDensity_dGlobalCompFraction  real64_array4d                                                                                 (no description available) 
-dPhaseMassDensity_dPressure            real64_array3d                                                                                 (no description available) 
-dPhaseMassDensity_dTemperature         real64_array3d                                                                                 (no description available) 
-dPhaseViscosity_dGlobalCompFraction    real64_array4d                                                                                 (no description available) 
-dPhaseViscosity_dPressure              real64_array3d                                                                                 (no description available) 
-dPhaseViscosity_dTemperature           real64_array3d                                                                                 (no description available) 
-dTotalDensity_dGlobalCompFraction      real64_array3d                                                                                 (no description available) 
-dTotalDensity_dPressure                real64_array2d                                                                                 (no description available) 
-dTotalDensity_dTemperature             real64_array2d                                                                                 (no description available) 
-initialTotalMassDensity                real64_array2d                                                                                 (no description available) 
-phaseCompFraction                      real64_array4d                                                                                 (no description available) 
-phaseDensity                           real64_array3d                                                                                 (no description available) 
-phaseFraction                          real64_array3d                                                                                 (no description available) 
-phaseMassDensity                       real64_array3d                                                                                 (no description available) 
-phaseViscosity                         real64_array3d                                                                                 (no description available) 
-totalDensity                           real64_array2d                                                                                 (no description available) 
-useMass                                integer                                                                                        (no description available) 
-====================================== ============================================================================================== ========================== 
+====================================== ============================================================================================== ================================================================================ 
+Name                                   Type                                                                                           Description                                                                      
+====================================== ============================================================================================== ================================================================================ 
+dPhaseCompFraction_dGlobalCompFraction LvArray_Array< double, 5, camp_int_seq< long, 0l, 1l, 2l, 3l, 4l >, long, LvArray_ChaiBuffer > Derivative of phase component fraction with respect to global component fraction 
+dPhaseCompFraction_dPressure           real64_array4d                                                                                 Derivative of phase component fraction with respect to pressure                  
+dPhaseCompFraction_dTemperature        real64_array4d                                                                                 Derivative of phase component fraction with respect to temperature               
+dPhaseDensity_dGlobalCompFraction      real64_array4d                                                                                 Derivative of phase density with respect to global component fraction            
+dPhaseDensity_dPressure                real64_array3d                                                                                 Derivative of phase density with respect to pressure                             
+dPhaseDensity_dTemperature             real64_array3d                                                                                 Derivative of phase density with respect to temperature                          
+dPhaseFraction_dGlobalCompFraction     real64_array4d                                                                                 Derivative of phase fraction with respect to global component fraction           
+dPhaseFraction_dPressure               real64_array3d                                                                                 Derivative of phase fraction with respect to pressure                            
+dPhaseFraction_dTemperature            real64_array3d                                                                                 Derivative of phase fraction with respect to temperature                         
+dPhaseMassDensity_dGlobalCompFraction  real64_array4d                                                                                 Derivative of phase mass density with respect to global component fraction       
+dPhaseMassDensity_dPressure            real64_array3d                                                                                 Derivative of phase mass density with respect to pressure                        
+dPhaseMassDensity_dTemperature         real64_array3d                                                                                 Derivative of phase mass density with respect to temperature                     
+dPhaseViscosity_dGlobalCompFraction    real64_array4d                                                                                 Derivative of phase viscosity with respect to global component fraction          
+dPhaseViscosity_dPressure              real64_array3d                                                                                 Derivative of phase viscosity with respect to pressure                           
+dPhaseViscosity_dTemperature           real64_array3d                                                                                 Derivative of phase viscosity with respect to temperature                        
+dTotalDensity_dGlobalCompFraction      real64_array3d                                                                                 Derivative of total density with respect to global component fraction            
+dTotalDensity_dPressure                real64_array2d                                                                                 Derivative of total density with respect to pressure                             
+dTotalDensity_dTemperature             real64_array2d                                                                                 Derivative of total density with respect to temperature                          
+initialTotalMassDensity                real64_array2d                                                                                 Initial total mass density                                                       
+phaseCompFraction                      real64_array4d                                                                                 Phase component fraction                                                         
+phaseDensity                           real64_array3d                                                                                 Phase density                                                                    
+phaseFraction                          real64_array3d                                                                                 Phase fraction                                                                   
+phaseMassDensity                       real64_array3d                                                                                 Phase mass density                                                               
+phaseViscosity                         real64_array3d                                                                                 Phase viscosity                                                                  
+totalDensity                           real64_array2d                                                                                 Total density                                                                    
+useMass                                integer                                                                                        (no description available)                                                       
+====================================== ============================================================================================== ================================================================================ 
 
 

--- a/src/coreComponents/schema/docs/DeadOilFluid_other.rst
+++ b/src/coreComponents/schema/docs/DeadOilFluid_other.rst
@@ -1,39 +1,39 @@
 
 
-====================================== ========================================================================================================= ========================== 
-Name                                   Type                                                                                                      Description                
-====================================== ========================================================================================================= ========================== 
-dPhaseCompFraction_dGlobalCompFraction LvArray_Array< double, 5, camp_int_seq< long, 0l, 1l, 2l, 3l, 4l >, long, LvArray_ChaiBuffer >            (no description available) 
-dPhaseCompFraction_dPressure           real64_array4d                                                                                            (no description available) 
-dPhaseCompFraction_dTemperature        real64_array4d                                                                                            (no description available) 
-dPhaseDensity_dGlobalCompFraction      real64_array4d                                                                                            (no description available) 
-dPhaseDensity_dPressure                real64_array3d                                                                                            (no description available) 
-dPhaseDensity_dTemperature             real64_array3d                                                                                            (no description available) 
-dPhaseFraction_dGlobalCompFraction     real64_array4d                                                                                            (no description available) 
-dPhaseFraction_dPressure               real64_array3d                                                                                            (no description available) 
-dPhaseFraction_dTemperature            real64_array3d                                                                                            (no description available) 
-dPhaseMassDensity_dGlobalCompFraction  real64_array4d                                                                                            (no description available) 
-dPhaseMassDensity_dPressure            real64_array3d                                                                                            (no description available) 
-dPhaseMassDensity_dTemperature         real64_array3d                                                                                            (no description available) 
-dPhaseViscosity_dGlobalCompFraction    real64_array4d                                                                                            (no description available) 
-dPhaseViscosity_dPressure              real64_array3d                                                                                            (no description available) 
-dPhaseViscosity_dTemperature           real64_array3d                                                                                            (no description available) 
-dTotalDensity_dGlobalCompFraction      real64_array3d                                                                                            (no description available) 
-dTotalDensity_dPressure                real64_array2d                                                                                            (no description available) 
-dTotalDensity_dTemperature             real64_array2d                                                                                            (no description available) 
-formationVolFactorTableWrappers        LvArray_Array< geosx_TableFunction_KernelWrapper, 1, camp_int_seq< long, 0l >, long, LvArray_ChaiBuffer > (no description available) 
-hydrocarbonPhaseOrder                  integer_array                                                                                             (no description available) 
-initialTotalMassDensity                real64_array2d                                                                                            (no description available) 
-phaseCompFraction                      real64_array4d                                                                                            (no description available) 
-phaseDensity                           real64_array3d                                                                                            (no description available) 
-phaseFraction                          real64_array3d                                                                                            (no description available) 
-phaseMassDensity                       real64_array3d                                                                                            (no description available) 
-phaseOrder                             integer_array                                                                                             (no description available) 
-phaseTypes                             integer_array                                                                                             (no description available) 
-phaseViscosity                         real64_array3d                                                                                            (no description available) 
-totalDensity                           real64_array2d                                                                                            (no description available) 
-useMass                                integer                                                                                                   (no description available) 
-viscosityTableWrappers                 LvArray_Array< geosx_TableFunction_KernelWrapper, 1, camp_int_seq< long, 0l >, long, LvArray_ChaiBuffer > (no description available) 
-====================================== ========================================================================================================= ========================== 
+====================================== ========================================================================================================= ================================================================================ 
+Name                                   Type                                                                                                      Description                                                                      
+====================================== ========================================================================================================= ================================================================================ 
+dPhaseCompFraction_dGlobalCompFraction LvArray_Array< double, 5, camp_int_seq< long, 0l, 1l, 2l, 3l, 4l >, long, LvArray_ChaiBuffer >            Derivative of phase component fraction with respect to global component fraction 
+dPhaseCompFraction_dPressure           real64_array4d                                                                                            Derivative of phase component fraction with respect to pressure                  
+dPhaseCompFraction_dTemperature        real64_array4d                                                                                            Derivative of phase component fraction with respect to temperature               
+dPhaseDensity_dGlobalCompFraction      real64_array4d                                                                                            Derivative of phase density with respect to global component fraction            
+dPhaseDensity_dPressure                real64_array3d                                                                                            Derivative of phase density with respect to pressure                             
+dPhaseDensity_dTemperature             real64_array3d                                                                                            Derivative of phase density with respect to temperature                          
+dPhaseFraction_dGlobalCompFraction     real64_array4d                                                                                            Derivative of phase fraction with respect to global component fraction           
+dPhaseFraction_dPressure               real64_array3d                                                                                            Derivative of phase fraction with respect to pressure                            
+dPhaseFraction_dTemperature            real64_array3d                                                                                            Derivative of phase fraction with respect to temperature                         
+dPhaseMassDensity_dGlobalCompFraction  real64_array4d                                                                                            Derivative of phase mass density with respect to global component fraction       
+dPhaseMassDensity_dPressure            real64_array3d                                                                                            Derivative of phase mass density with respect to pressure                        
+dPhaseMassDensity_dTemperature         real64_array3d                                                                                            Derivative of phase mass density with respect to temperature                     
+dPhaseViscosity_dGlobalCompFraction    real64_array4d                                                                                            Derivative of phase viscosity with respect to global component fraction          
+dPhaseViscosity_dPressure              real64_array3d                                                                                            Derivative of phase viscosity with respect to pressure                           
+dPhaseViscosity_dTemperature           real64_array3d                                                                                            Derivative of phase viscosity with respect to temperature                        
+dTotalDensity_dGlobalCompFraction      real64_array3d                                                                                            Derivative of total density with respect to global component fraction            
+dTotalDensity_dPressure                real64_array2d                                                                                            Derivative of total density with respect to pressure                             
+dTotalDensity_dTemperature             real64_array2d                                                                                            Derivative of total density with respect to temperature                          
+formationVolFactorTableWrappers        LvArray_Array< geosx_TableFunction_KernelWrapper, 1, camp_int_seq< long, 0l >, long, LvArray_ChaiBuffer > (no description available)                                                       
+hydrocarbonPhaseOrder                  integer_array                                                                                             (no description available)                                                       
+initialTotalMassDensity                real64_array2d                                                                                            Initial total mass density                                                       
+phaseCompFraction                      real64_array4d                                                                                            Phase component fraction                                                         
+phaseDensity                           real64_array3d                                                                                            Phase density                                                                    
+phaseFraction                          real64_array3d                                                                                            Phase fraction                                                                   
+phaseMassDensity                       real64_array3d                                                                                            Phase mass density                                                               
+phaseOrder                             integer_array                                                                                             (no description available)                                                       
+phaseTypes                             integer_array                                                                                             (no description available)                                                       
+phaseViscosity                         real64_array3d                                                                                            Phase viscosity                                                                  
+totalDensity                           real64_array2d                                                                                            Total density                                                                    
+useMass                                integer                                                                                                   (no description available)                                                       
+viscosityTableWrappers                 LvArray_Array< geosx_TableFunction_KernelWrapper, 1, camp_int_seq< long, 0l >, long, LvArray_ChaiBuffer > (no description available)                                                       
+====================================== ========================================================================================================= ================================================================================ 
 
 

--- a/src/coreComponents/schema/docs/TableCapillaryPressure_other.rst
+++ b/src/coreComponents/schema/docs/TableCapillaryPressure_other.rst
@@ -1,13 +1,13 @@
 
 
-=================================== ========================================================================================================= ========================== 
-Name                                Type                                                                                                      Description                
-=================================== ========================================================================================================= ========================== 
-capPresWrappers                     LvArray_Array< geosx_TableFunction_KernelWrapper, 1, camp_int_seq< long, 0l >, long, LvArray_ChaiBuffer > (no description available) 
-dPhaseCapPressure_dPhaseVolFraction real64_array4d                                                                                            (no description available) 
-phaseCapPressure                    real64_array3d                                                                                            (no description available) 
-phaseOrder                          integer_array                                                                                             (no description available) 
-phaseTypes                          integer_array                                                                                             (no description available) 
-=================================== ========================================================================================================= ========================== 
+=================================== ========================================================================================================= ============================================================================ 
+Name                                Type                                                                                                      Description                                                                  
+=================================== ========================================================================================================= ============================================================================ 
+capPresWrappers                     LvArray_Array< geosx_TableFunction_KernelWrapper, 1, camp_int_seq< long, 0l >, long, LvArray_ChaiBuffer > (no description available)                                                   
+dPhaseCapPressure_dPhaseVolFraction real64_array4d                                                                                            Derivative of phase capillary pressure with respect to phase volume fraction 
+phaseCapPressure                    real64_array3d                                                                                            Phase capillary pressure                                                     
+phaseOrder                          integer_array                                                                                             (no description available)                                                   
+phaseTypes                          integer_array                                                                                             (no description available)                                                   
+=================================== ========================================================================================================= ============================================================================ 
 
 

--- a/src/coreComponents/schema/docs/TableRelativePermeability_other.rst
+++ b/src/coreComponents/schema/docs/TableRelativePermeability_other.rst
@@ -1,14 +1,14 @@
 
 
-=============================== ========================================================================================================= ========================== 
-Name                            Type                                                                                                      Description                
-=============================== ========================================================================================================= ========================== 
-dPhaseRelPerm_dPhaseVolFraction real64_array4d                                                                                            (no description available) 
-phaseMinVolumeFraction          real64_array                                                                                              (no description available) 
-phaseOrder                      integer_array                                                                                             (no description available) 
-phaseRelPerm                    real64_array3d                                                                                            (no description available) 
-phaseTypes                      integer_array                                                                                             (no description available) 
-relPermWrappers                 LvArray_Array< geosx_TableFunction_KernelWrapper, 1, camp_int_seq< long, 0l >, long, LvArray_ChaiBuffer > (no description available) 
-=============================== ========================================================================================================= ========================== 
+=============================== ========================================================================================================= =============================================================================== 
+Name                            Type                                                                                                      Description                                                                     
+=============================== ========================================================================================================= =============================================================================== 
+dPhaseRelPerm_dPhaseVolFraction real64_array4d                                                                                            Derivative of phase relative permeability with respect to phase volume fraction 
+phaseMinVolumeFraction          real64_array                                                                                              (no description available)                                                      
+phaseOrder                      integer_array                                                                                             (no description available)                                                      
+phaseRelPerm                    real64_array3d                                                                                            Phase relative permeability                                                     
+phaseTypes                      integer_array                                                                                             (no description available)                                                      
+relPermWrappers                 LvArray_Array< geosx_TableFunction_KernelWrapper, 1, camp_int_seq< long, 0l >, long, LvArray_ChaiBuffer > (no description available)                                                      
+=============================== ========================================================================================================= =============================================================================== 
 
 

--- a/src/coreComponents/schema/docs/VanGenuchtenBakerRelativePermeability_other.rst
+++ b/src/coreComponents/schema/docs/VanGenuchtenBakerRelativePermeability_other.rst
@@ -3,9 +3,9 @@
 =============================== ============== ======================================================================================================================= 
 Name                            Type           Description                                                                                                             
 =============================== ============== ======================================================================================================================= 
-dPhaseRelPerm_dPhaseVolFraction real64_array4d (no description available)                                                                                              
+dPhaseRelPerm_dPhaseVolFraction real64_array4d Derivative of phase relative permeability with respect to phase volume fraction                                         
 phaseOrder                      integer_array  (no description available)                                                                                              
-phaseRelPerm                    real64_array3d (no description available)                                                                                              
+phaseRelPerm                    real64_array3d Phase relative permeability                                                                                             
 phaseTypes                      integer_array  (no description available)                                                                                              
 volFracScale                    real64         Factor used to scale the phase capillary pressure, defined as: one minus the sum of the phase minimum volume fractions. 
 =============================== ============== ======================================================================================================================= 

--- a/src/coreComponents/schema/docs/VanGenuchtenCapillaryPressure_other.rst
+++ b/src/coreComponents/schema/docs/VanGenuchtenCapillaryPressure_other.rst
@@ -3,8 +3,8 @@
 =================================== ============== ======================================================================================================================= 
 Name                                Type           Description                                                                                                             
 =================================== ============== ======================================================================================================================= 
-dPhaseCapPressure_dPhaseVolFraction real64_array4d (no description available)                                                                                              
-phaseCapPressure                    real64_array3d (no description available)                                                                                              
+dPhaseCapPressure_dPhaseVolFraction real64_array4d Derivative of phase capillary pressure with respect to phase volume fraction                                            
+phaseCapPressure                    real64_array3d Phase capillary pressure                                                                                                
 phaseOrder                          integer_array  (no description available)                                                                                              
 phaseTypes                          integer_array  (no description available)                                                                                              
 volFracScale                        real64         Factor used to scale the phase capillary pressure, defined as: one minus the sum of the phase minimum volume fractions. 

--- a/src/coreComponents/schema/schema.xsd.other
+++ b/src/coreComponents/schema/schema.xsd.other
@@ -835,63 +835,63 @@
 	<xsd:complexType name="BlackOilFluidType">
 		<!--PVTO => (no description available)-->
 		<xsd:attribute name="PVTO" type="geosx_constitutive_PVTOData" />
-		<!--dPhaseCompFraction_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseCompFraction_dGlobalCompFraction => Derivative of phase component fraction with respect to global component fraction-->
 		<xsd:attribute name="dPhaseCompFraction_dGlobalCompFraction" type="LvArray_Array&lt;double, 5, camp_int_seq&lt;long, 0l, 1l, 2l, 3l, 4l&gt;, long, LvArray_ChaiBuffer&gt;" />
-		<!--dPhaseCompFraction_dPressure => (no description available)-->
+		<!--dPhaseCompFraction_dPressure => Derivative of phase component fraction with respect to pressure-->
 		<xsd:attribute name="dPhaseCompFraction_dPressure" type="real64_array4d" />
-		<!--dPhaseCompFraction_dTemperature => (no description available)-->
+		<!--dPhaseCompFraction_dTemperature => Derivative of phase component fraction with respect to temperature-->
 		<xsd:attribute name="dPhaseCompFraction_dTemperature" type="real64_array4d" />
-		<!--dPhaseDensity_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseDensity_dGlobalCompFraction => Derivative of phase density with respect to global component fraction-->
 		<xsd:attribute name="dPhaseDensity_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseDensity_dPressure => (no description available)-->
+		<!--dPhaseDensity_dPressure => Derivative of phase density with respect to pressure-->
 		<xsd:attribute name="dPhaseDensity_dPressure" type="real64_array3d" />
-		<!--dPhaseDensity_dTemperature => (no description available)-->
+		<!--dPhaseDensity_dTemperature => Derivative of phase density with respect to temperature-->
 		<xsd:attribute name="dPhaseDensity_dTemperature" type="real64_array3d" />
-		<!--dPhaseFraction_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseFraction_dGlobalCompFraction => Derivative of phase fraction with respect to global component fraction-->
 		<xsd:attribute name="dPhaseFraction_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseFraction_dPressure => (no description available)-->
+		<!--dPhaseFraction_dPressure => Derivative of phase fraction with respect to pressure-->
 		<xsd:attribute name="dPhaseFraction_dPressure" type="real64_array3d" />
-		<!--dPhaseFraction_dTemperature => (no description available)-->
+		<!--dPhaseFraction_dTemperature => Derivative of phase fraction with respect to temperature-->
 		<xsd:attribute name="dPhaseFraction_dTemperature" type="real64_array3d" />
-		<!--dPhaseMassDensity_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseMassDensity_dGlobalCompFraction => Derivative of phase mass density with respect to global component fraction-->
 		<xsd:attribute name="dPhaseMassDensity_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseMassDensity_dPressure => (no description available)-->
+		<!--dPhaseMassDensity_dPressure => Derivative of phase mass density with respect to pressure-->
 		<xsd:attribute name="dPhaseMassDensity_dPressure" type="real64_array3d" />
-		<!--dPhaseMassDensity_dTemperature => (no description available)-->
+		<!--dPhaseMassDensity_dTemperature => Derivative of phase mass density with respect to temperature-->
 		<xsd:attribute name="dPhaseMassDensity_dTemperature" type="real64_array3d" />
-		<!--dPhaseViscosity_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseViscosity_dGlobalCompFraction => Derivative of phase viscosity with respect to global component fraction-->
 		<xsd:attribute name="dPhaseViscosity_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseViscosity_dPressure => (no description available)-->
+		<!--dPhaseViscosity_dPressure => Derivative of phase viscosity with respect to pressure-->
 		<xsd:attribute name="dPhaseViscosity_dPressure" type="real64_array3d" />
-		<!--dPhaseViscosity_dTemperature => (no description available)-->
+		<!--dPhaseViscosity_dTemperature => Derivative of phase viscosity with respect to temperature-->
 		<xsd:attribute name="dPhaseViscosity_dTemperature" type="real64_array3d" />
-		<!--dTotalDensity_dGlobalCompFraction => (no description available)-->
+		<!--dTotalDensity_dGlobalCompFraction => Derivative of total density with respect to global component fraction-->
 		<xsd:attribute name="dTotalDensity_dGlobalCompFraction" type="real64_array3d" />
-		<!--dTotalDensity_dPressure => (no description available)-->
+		<!--dTotalDensity_dPressure => Derivative of total density with respect to pressure-->
 		<xsd:attribute name="dTotalDensity_dPressure" type="real64_array2d" />
-		<!--dTotalDensity_dTemperature => (no description available)-->
+		<!--dTotalDensity_dTemperature => Derivative of total density with respect to temperature-->
 		<xsd:attribute name="dTotalDensity_dTemperature" type="real64_array2d" />
 		<!--formationVolFactorTableWrappers => (no description available)-->
 		<xsd:attribute name="formationVolFactorTableWrappers" type="LvArray_Array&lt;geosx_TableFunction_KernelWrapper, 1, camp_int_seq&lt;long, 0l&gt;, long, LvArray_ChaiBuffer&gt;" />
 		<!--hydrocarbonPhaseOrder => (no description available)-->
 		<xsd:attribute name="hydrocarbonPhaseOrder" type="integer_array" />
-		<!--initialTotalMassDensity => (no description available)-->
+		<!--initialTotalMassDensity => Initial total mass density-->
 		<xsd:attribute name="initialTotalMassDensity" type="real64_array2d" />
-		<!--phaseCompFraction => (no description available)-->
+		<!--phaseCompFraction => Phase component fraction-->
 		<xsd:attribute name="phaseCompFraction" type="real64_array4d" />
-		<!--phaseDensity => (no description available)-->
+		<!--phaseDensity => Phase density-->
 		<xsd:attribute name="phaseDensity" type="real64_array3d" />
-		<!--phaseFraction => (no description available)-->
+		<!--phaseFraction => Phase fraction-->
 		<xsd:attribute name="phaseFraction" type="real64_array3d" />
-		<!--phaseMassDensity => (no description available)-->
+		<!--phaseMassDensity => Phase mass density-->
 		<xsd:attribute name="phaseMassDensity" type="real64_array3d" />
 		<!--phaseOrder => (no description available)-->
 		<xsd:attribute name="phaseOrder" type="integer_array" />
 		<!--phaseTypes => (no description available)-->
 		<xsd:attribute name="phaseTypes" type="integer_array" />
-		<!--phaseViscosity => (no description available)-->
+		<!--phaseViscosity => Phase viscosity-->
 		<xsd:attribute name="phaseViscosity" type="real64_array3d" />
-		<!--totalDensity => (no description available)-->
+		<!--totalDensity => Total density-->
 		<xsd:attribute name="totalDensity" type="real64_array2d" />
 		<!--useMass => (no description available)-->
 		<xsd:attribute name="useMass" type="integer" />
@@ -899,11 +899,11 @@
 		<xsd:attribute name="viscosityTableWrappers" type="LvArray_Array&lt;geosx_TableFunction_KernelWrapper, 1, camp_int_seq&lt;long, 0l&gt;, long, LvArray_ChaiBuffer&gt;" />
 	</xsd:complexType>
 	<xsd:complexType name="BrooksCoreyBakerRelativePermeabilityType">
-		<!--dPhaseRelPerm_dPhaseVolFraction => (no description available)-->
+		<!--dPhaseRelPerm_dPhaseVolFraction => Derivative of phase relative permeability with respect to phase volume fraction-->
 		<xsd:attribute name="dPhaseRelPerm_dPhaseVolFraction" type="real64_array4d" />
 		<!--phaseOrder => (no description available)-->
 		<xsd:attribute name="phaseOrder" type="integer_array" />
-		<!--phaseRelPerm => (no description available)-->
+		<!--phaseRelPerm => Phase relative permeability-->
 		<xsd:attribute name="phaseRelPerm" type="real64_array3d" />
 		<!--phaseTypes => (no description available)-->
 		<xsd:attribute name="phaseTypes" type="integer_array" />
@@ -911,9 +911,9 @@
 		<xsd:attribute name="volFracScale" type="real64" />
 	</xsd:complexType>
 	<xsd:complexType name="BrooksCoreyCapillaryPressureType">
-		<!--dPhaseCapPressure_dPhaseVolFraction => (no description available)-->
+		<!--dPhaseCapPressure_dPhaseVolFraction => Derivative of phase capillary pressure with respect to phase volume fraction-->
 		<xsd:attribute name="dPhaseCapPressure_dPhaseVolFraction" type="real64_array4d" />
-		<!--phaseCapPressure => (no description available)-->
+		<!--phaseCapPressure => Phase capillary pressure-->
 		<xsd:attribute name="phaseCapPressure" type="real64_array3d" />
 		<!--phaseOrder => (no description available)-->
 		<xsd:attribute name="phaseOrder" type="integer_array" />
@@ -923,11 +923,11 @@
 		<xsd:attribute name="volFracScale" type="real64" />
 	</xsd:complexType>
 	<xsd:complexType name="BrooksCoreyRelativePermeabilityType">
-		<!--dPhaseRelPerm_dPhaseVolFraction => (no description available)-->
+		<!--dPhaseRelPerm_dPhaseVolFraction => Derivative of phase relative permeability with respect to phase volume fraction-->
 		<xsd:attribute name="dPhaseRelPerm_dPhaseVolFraction" type="real64_array4d" />
 		<!--phaseOrder => (no description available)-->
 		<xsd:attribute name="phaseOrder" type="integer_array" />
-		<!--phaseRelPerm => (no description available)-->
+		<!--phaseRelPerm => Phase relative permeability-->
 		<xsd:attribute name="phaseRelPerm" type="real64_array3d" />
 		<!--phaseTypes => (no description available)-->
 		<xsd:attribute name="phaseTypes" type="integer_array" />
@@ -935,109 +935,109 @@
 		<xsd:attribute name="volFracScale" type="real64" />
 	</xsd:complexType>
 	<xsd:complexType name="CO2BrineEzrokhiFluidType">
-		<!--dPhaseCompFraction_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseCompFraction_dGlobalCompFraction => Derivative of phase component fraction with respect to global component fraction-->
 		<xsd:attribute name="dPhaseCompFraction_dGlobalCompFraction" type="LvArray_Array&lt;double, 5, camp_int_seq&lt;long, 0l, 1l, 2l, 3l, 4l&gt;, long, LvArray_ChaiBuffer&gt;" />
-		<!--dPhaseCompFraction_dPressure => (no description available)-->
+		<!--dPhaseCompFraction_dPressure => Derivative of phase component fraction with respect to pressure-->
 		<xsd:attribute name="dPhaseCompFraction_dPressure" type="real64_array4d" />
-		<!--dPhaseCompFraction_dTemperature => (no description available)-->
+		<!--dPhaseCompFraction_dTemperature => Derivative of phase component fraction with respect to temperature-->
 		<xsd:attribute name="dPhaseCompFraction_dTemperature" type="real64_array4d" />
-		<!--dPhaseDensity_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseDensity_dGlobalCompFraction => Derivative of phase density with respect to global component fraction-->
 		<xsd:attribute name="dPhaseDensity_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseDensity_dPressure => (no description available)-->
+		<!--dPhaseDensity_dPressure => Derivative of phase density with respect to pressure-->
 		<xsd:attribute name="dPhaseDensity_dPressure" type="real64_array3d" />
-		<!--dPhaseDensity_dTemperature => (no description available)-->
+		<!--dPhaseDensity_dTemperature => Derivative of phase density with respect to temperature-->
 		<xsd:attribute name="dPhaseDensity_dTemperature" type="real64_array3d" />
-		<!--dPhaseFraction_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseFraction_dGlobalCompFraction => Derivative of phase fraction with respect to global component fraction-->
 		<xsd:attribute name="dPhaseFraction_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseFraction_dPressure => (no description available)-->
+		<!--dPhaseFraction_dPressure => Derivative of phase fraction with respect to pressure-->
 		<xsd:attribute name="dPhaseFraction_dPressure" type="real64_array3d" />
-		<!--dPhaseFraction_dTemperature => (no description available)-->
+		<!--dPhaseFraction_dTemperature => Derivative of phase fraction with respect to temperature-->
 		<xsd:attribute name="dPhaseFraction_dTemperature" type="real64_array3d" />
-		<!--dPhaseMassDensity_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseMassDensity_dGlobalCompFraction => Derivative of phase mass density with respect to global component fraction-->
 		<xsd:attribute name="dPhaseMassDensity_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseMassDensity_dPressure => (no description available)-->
+		<!--dPhaseMassDensity_dPressure => Derivative of phase mass density with respect to pressure-->
 		<xsd:attribute name="dPhaseMassDensity_dPressure" type="real64_array3d" />
-		<!--dPhaseMassDensity_dTemperature => (no description available)-->
+		<!--dPhaseMassDensity_dTemperature => Derivative of phase mass density with respect to temperature-->
 		<xsd:attribute name="dPhaseMassDensity_dTemperature" type="real64_array3d" />
-		<!--dPhaseViscosity_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseViscosity_dGlobalCompFraction => Derivative of phase viscosity with respect to global component fraction-->
 		<xsd:attribute name="dPhaseViscosity_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseViscosity_dPressure => (no description available)-->
+		<!--dPhaseViscosity_dPressure => Derivative of phase viscosity with respect to pressure-->
 		<xsd:attribute name="dPhaseViscosity_dPressure" type="real64_array3d" />
-		<!--dPhaseViscosity_dTemperature => (no description available)-->
+		<!--dPhaseViscosity_dTemperature => Derivative of phase viscosity with respect to temperature-->
 		<xsd:attribute name="dPhaseViscosity_dTemperature" type="real64_array3d" />
-		<!--dTotalDensity_dGlobalCompFraction => (no description available)-->
+		<!--dTotalDensity_dGlobalCompFraction => Derivative of total density with respect to global component fraction-->
 		<xsd:attribute name="dTotalDensity_dGlobalCompFraction" type="real64_array3d" />
-		<!--dTotalDensity_dPressure => (no description available)-->
+		<!--dTotalDensity_dPressure => Derivative of total density with respect to pressure-->
 		<xsd:attribute name="dTotalDensity_dPressure" type="real64_array2d" />
-		<!--dTotalDensity_dTemperature => (no description available)-->
+		<!--dTotalDensity_dTemperature => Derivative of total density with respect to temperature-->
 		<xsd:attribute name="dTotalDensity_dTemperature" type="real64_array2d" />
-		<!--initialTotalMassDensity => (no description available)-->
+		<!--initialTotalMassDensity => Initial total mass density-->
 		<xsd:attribute name="initialTotalMassDensity" type="real64_array2d" />
-		<!--phaseCompFraction => (no description available)-->
+		<!--phaseCompFraction => Phase component fraction-->
 		<xsd:attribute name="phaseCompFraction" type="real64_array4d" />
-		<!--phaseDensity => (no description available)-->
+		<!--phaseDensity => Phase density-->
 		<xsd:attribute name="phaseDensity" type="real64_array3d" />
-		<!--phaseFraction => (no description available)-->
+		<!--phaseFraction => Phase fraction-->
 		<xsd:attribute name="phaseFraction" type="real64_array3d" />
-		<!--phaseMassDensity => (no description available)-->
+		<!--phaseMassDensity => Phase mass density-->
 		<xsd:attribute name="phaseMassDensity" type="real64_array3d" />
-		<!--phaseViscosity => (no description available)-->
+		<!--phaseViscosity => Phase viscosity-->
 		<xsd:attribute name="phaseViscosity" type="real64_array3d" />
-		<!--totalDensity => (no description available)-->
+		<!--totalDensity => Total density-->
 		<xsd:attribute name="totalDensity" type="real64_array2d" />
 		<!--useMass => (no description available)-->
 		<xsd:attribute name="useMass" type="integer" />
 	</xsd:complexType>
 	<xsd:complexType name="CO2BrinePhillipsFluidType">
-		<!--dPhaseCompFraction_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseCompFraction_dGlobalCompFraction => Derivative of phase component fraction with respect to global component fraction-->
 		<xsd:attribute name="dPhaseCompFraction_dGlobalCompFraction" type="LvArray_Array&lt;double, 5, camp_int_seq&lt;long, 0l, 1l, 2l, 3l, 4l&gt;, long, LvArray_ChaiBuffer&gt;" />
-		<!--dPhaseCompFraction_dPressure => (no description available)-->
+		<!--dPhaseCompFraction_dPressure => Derivative of phase component fraction with respect to pressure-->
 		<xsd:attribute name="dPhaseCompFraction_dPressure" type="real64_array4d" />
-		<!--dPhaseCompFraction_dTemperature => (no description available)-->
+		<!--dPhaseCompFraction_dTemperature => Derivative of phase component fraction with respect to temperature-->
 		<xsd:attribute name="dPhaseCompFraction_dTemperature" type="real64_array4d" />
-		<!--dPhaseDensity_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseDensity_dGlobalCompFraction => Derivative of phase density with respect to global component fraction-->
 		<xsd:attribute name="dPhaseDensity_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseDensity_dPressure => (no description available)-->
+		<!--dPhaseDensity_dPressure => Derivative of phase density with respect to pressure-->
 		<xsd:attribute name="dPhaseDensity_dPressure" type="real64_array3d" />
-		<!--dPhaseDensity_dTemperature => (no description available)-->
+		<!--dPhaseDensity_dTemperature => Derivative of phase density with respect to temperature-->
 		<xsd:attribute name="dPhaseDensity_dTemperature" type="real64_array3d" />
-		<!--dPhaseFraction_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseFraction_dGlobalCompFraction => Derivative of phase fraction with respect to global component fraction-->
 		<xsd:attribute name="dPhaseFraction_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseFraction_dPressure => (no description available)-->
+		<!--dPhaseFraction_dPressure => Derivative of phase fraction with respect to pressure-->
 		<xsd:attribute name="dPhaseFraction_dPressure" type="real64_array3d" />
-		<!--dPhaseFraction_dTemperature => (no description available)-->
+		<!--dPhaseFraction_dTemperature => Derivative of phase fraction with respect to temperature-->
 		<xsd:attribute name="dPhaseFraction_dTemperature" type="real64_array3d" />
-		<!--dPhaseMassDensity_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseMassDensity_dGlobalCompFraction => Derivative of phase mass density with respect to global component fraction-->
 		<xsd:attribute name="dPhaseMassDensity_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseMassDensity_dPressure => (no description available)-->
+		<!--dPhaseMassDensity_dPressure => Derivative of phase mass density with respect to pressure-->
 		<xsd:attribute name="dPhaseMassDensity_dPressure" type="real64_array3d" />
-		<!--dPhaseMassDensity_dTemperature => (no description available)-->
+		<!--dPhaseMassDensity_dTemperature => Derivative of phase mass density with respect to temperature-->
 		<xsd:attribute name="dPhaseMassDensity_dTemperature" type="real64_array3d" />
-		<!--dPhaseViscosity_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseViscosity_dGlobalCompFraction => Derivative of phase viscosity with respect to global component fraction-->
 		<xsd:attribute name="dPhaseViscosity_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseViscosity_dPressure => (no description available)-->
+		<!--dPhaseViscosity_dPressure => Derivative of phase viscosity with respect to pressure-->
 		<xsd:attribute name="dPhaseViscosity_dPressure" type="real64_array3d" />
-		<!--dPhaseViscosity_dTemperature => (no description available)-->
+		<!--dPhaseViscosity_dTemperature => Derivative of phase viscosity with respect to temperature-->
 		<xsd:attribute name="dPhaseViscosity_dTemperature" type="real64_array3d" />
-		<!--dTotalDensity_dGlobalCompFraction => (no description available)-->
+		<!--dTotalDensity_dGlobalCompFraction => Derivative of total density with respect to global component fraction-->
 		<xsd:attribute name="dTotalDensity_dGlobalCompFraction" type="real64_array3d" />
-		<!--dTotalDensity_dPressure => (no description available)-->
+		<!--dTotalDensity_dPressure => Derivative of total density with respect to pressure-->
 		<xsd:attribute name="dTotalDensity_dPressure" type="real64_array2d" />
-		<!--dTotalDensity_dTemperature => (no description available)-->
+		<!--dTotalDensity_dTemperature => Derivative of total density with respect to temperature-->
 		<xsd:attribute name="dTotalDensity_dTemperature" type="real64_array2d" />
-		<!--initialTotalMassDensity => (no description available)-->
+		<!--initialTotalMassDensity => Initial total mass density-->
 		<xsd:attribute name="initialTotalMassDensity" type="real64_array2d" />
-		<!--phaseCompFraction => (no description available)-->
+		<!--phaseCompFraction => Phase component fraction-->
 		<xsd:attribute name="phaseCompFraction" type="real64_array4d" />
-		<!--phaseDensity => (no description available)-->
+		<!--phaseDensity => Phase density-->
 		<xsd:attribute name="phaseDensity" type="real64_array3d" />
-		<!--phaseFraction => (no description available)-->
+		<!--phaseFraction => Phase fraction-->
 		<xsd:attribute name="phaseFraction" type="real64_array3d" />
-		<!--phaseMassDensity => (no description available)-->
+		<!--phaseMassDensity => Phase mass density-->
 		<xsd:attribute name="phaseMassDensity" type="real64_array3d" />
-		<!--phaseViscosity => (no description available)-->
+		<!--phaseViscosity => Phase viscosity-->
 		<xsd:attribute name="phaseViscosity" type="real64_array3d" />
-		<!--totalDensity => (no description available)-->
+		<!--totalDensity => Total density-->
 		<xsd:attribute name="totalDensity" type="real64_array2d" />
 		<!--useMass => (no description available)-->
 		<xsd:attribute name="useMass" type="integer" />
@@ -1051,55 +1051,55 @@
 		<xsd:attribute name="permeability" type="real64_array3d" />
 	</xsd:complexType>
 	<xsd:complexType name="CompositionalMultiphaseFluidType">
-		<!--dPhaseCompFraction_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseCompFraction_dGlobalCompFraction => Derivative of phase component fraction with respect to global component fraction-->
 		<xsd:attribute name="dPhaseCompFraction_dGlobalCompFraction" type="LvArray_Array&lt;double, 5, camp_int_seq&lt;long, 0l, 1l, 2l, 3l, 4l&gt;, long, LvArray_ChaiBuffer&gt;" />
-		<!--dPhaseCompFraction_dPressure => (no description available)-->
+		<!--dPhaseCompFraction_dPressure => Derivative of phase component fraction with respect to pressure-->
 		<xsd:attribute name="dPhaseCompFraction_dPressure" type="real64_array4d" />
-		<!--dPhaseCompFraction_dTemperature => (no description available)-->
+		<!--dPhaseCompFraction_dTemperature => Derivative of phase component fraction with respect to temperature-->
 		<xsd:attribute name="dPhaseCompFraction_dTemperature" type="real64_array4d" />
-		<!--dPhaseDensity_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseDensity_dGlobalCompFraction => Derivative of phase density with respect to global component fraction-->
 		<xsd:attribute name="dPhaseDensity_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseDensity_dPressure => (no description available)-->
+		<!--dPhaseDensity_dPressure => Derivative of phase density with respect to pressure-->
 		<xsd:attribute name="dPhaseDensity_dPressure" type="real64_array3d" />
-		<!--dPhaseDensity_dTemperature => (no description available)-->
+		<!--dPhaseDensity_dTemperature => Derivative of phase density with respect to temperature-->
 		<xsd:attribute name="dPhaseDensity_dTemperature" type="real64_array3d" />
-		<!--dPhaseFraction_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseFraction_dGlobalCompFraction => Derivative of phase fraction with respect to global component fraction-->
 		<xsd:attribute name="dPhaseFraction_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseFraction_dPressure => (no description available)-->
+		<!--dPhaseFraction_dPressure => Derivative of phase fraction with respect to pressure-->
 		<xsd:attribute name="dPhaseFraction_dPressure" type="real64_array3d" />
-		<!--dPhaseFraction_dTemperature => (no description available)-->
+		<!--dPhaseFraction_dTemperature => Derivative of phase fraction with respect to temperature-->
 		<xsd:attribute name="dPhaseFraction_dTemperature" type="real64_array3d" />
-		<!--dPhaseMassDensity_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseMassDensity_dGlobalCompFraction => Derivative of phase mass density with respect to global component fraction-->
 		<xsd:attribute name="dPhaseMassDensity_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseMassDensity_dPressure => (no description available)-->
+		<!--dPhaseMassDensity_dPressure => Derivative of phase mass density with respect to pressure-->
 		<xsd:attribute name="dPhaseMassDensity_dPressure" type="real64_array3d" />
-		<!--dPhaseMassDensity_dTemperature => (no description available)-->
+		<!--dPhaseMassDensity_dTemperature => Derivative of phase mass density with respect to temperature-->
 		<xsd:attribute name="dPhaseMassDensity_dTemperature" type="real64_array3d" />
-		<!--dPhaseViscosity_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseViscosity_dGlobalCompFraction => Derivative of phase viscosity with respect to global component fraction-->
 		<xsd:attribute name="dPhaseViscosity_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseViscosity_dPressure => (no description available)-->
+		<!--dPhaseViscosity_dPressure => Derivative of phase viscosity with respect to pressure-->
 		<xsd:attribute name="dPhaseViscosity_dPressure" type="real64_array3d" />
-		<!--dPhaseViscosity_dTemperature => (no description available)-->
+		<!--dPhaseViscosity_dTemperature => Derivative of phase viscosity with respect to temperature-->
 		<xsd:attribute name="dPhaseViscosity_dTemperature" type="real64_array3d" />
-		<!--dTotalDensity_dGlobalCompFraction => (no description available)-->
+		<!--dTotalDensity_dGlobalCompFraction => Derivative of total density with respect to global component fraction-->
 		<xsd:attribute name="dTotalDensity_dGlobalCompFraction" type="real64_array3d" />
-		<!--dTotalDensity_dPressure => (no description available)-->
+		<!--dTotalDensity_dPressure => Derivative of total density with respect to pressure-->
 		<xsd:attribute name="dTotalDensity_dPressure" type="real64_array2d" />
-		<!--dTotalDensity_dTemperature => (no description available)-->
+		<!--dTotalDensity_dTemperature => Derivative of total density with respect to temperature-->
 		<xsd:attribute name="dTotalDensity_dTemperature" type="real64_array2d" />
-		<!--initialTotalMassDensity => (no description available)-->
+		<!--initialTotalMassDensity => Initial total mass density-->
 		<xsd:attribute name="initialTotalMassDensity" type="real64_array2d" />
-		<!--phaseCompFraction => (no description available)-->
+		<!--phaseCompFraction => Phase component fraction-->
 		<xsd:attribute name="phaseCompFraction" type="real64_array4d" />
-		<!--phaseDensity => (no description available)-->
+		<!--phaseDensity => Phase density-->
 		<xsd:attribute name="phaseDensity" type="real64_array3d" />
-		<!--phaseFraction => (no description available)-->
+		<!--phaseFraction => Phase fraction-->
 		<xsd:attribute name="phaseFraction" type="real64_array3d" />
-		<!--phaseMassDensity => (no description available)-->
+		<!--phaseMassDensity => Phase mass density-->
 		<xsd:attribute name="phaseMassDensity" type="real64_array3d" />
-		<!--phaseViscosity => (no description available)-->
+		<!--phaseViscosity => Phase viscosity-->
 		<xsd:attribute name="phaseViscosity" type="real64_array3d" />
-		<!--totalDensity => (no description available)-->
+		<!--totalDensity => Total density-->
 		<xsd:attribute name="totalDensity" type="real64_array2d" />
 		<!--useMass => (no description available)-->
 		<xsd:attribute name="useMass" type="integer" />
@@ -1178,63 +1178,63 @@
 		<xsd:attribute name="stress" type="real64_array3d" />
 	</xsd:complexType>
 	<xsd:complexType name="DeadOilFluidType">
-		<!--dPhaseCompFraction_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseCompFraction_dGlobalCompFraction => Derivative of phase component fraction with respect to global component fraction-->
 		<xsd:attribute name="dPhaseCompFraction_dGlobalCompFraction" type="LvArray_Array&lt;double, 5, camp_int_seq&lt;long, 0l, 1l, 2l, 3l, 4l&gt;, long, LvArray_ChaiBuffer&gt;" />
-		<!--dPhaseCompFraction_dPressure => (no description available)-->
+		<!--dPhaseCompFraction_dPressure => Derivative of phase component fraction with respect to pressure-->
 		<xsd:attribute name="dPhaseCompFraction_dPressure" type="real64_array4d" />
-		<!--dPhaseCompFraction_dTemperature => (no description available)-->
+		<!--dPhaseCompFraction_dTemperature => Derivative of phase component fraction with respect to temperature-->
 		<xsd:attribute name="dPhaseCompFraction_dTemperature" type="real64_array4d" />
-		<!--dPhaseDensity_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseDensity_dGlobalCompFraction => Derivative of phase density with respect to global component fraction-->
 		<xsd:attribute name="dPhaseDensity_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseDensity_dPressure => (no description available)-->
+		<!--dPhaseDensity_dPressure => Derivative of phase density with respect to pressure-->
 		<xsd:attribute name="dPhaseDensity_dPressure" type="real64_array3d" />
-		<!--dPhaseDensity_dTemperature => (no description available)-->
+		<!--dPhaseDensity_dTemperature => Derivative of phase density with respect to temperature-->
 		<xsd:attribute name="dPhaseDensity_dTemperature" type="real64_array3d" />
-		<!--dPhaseFraction_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseFraction_dGlobalCompFraction => Derivative of phase fraction with respect to global component fraction-->
 		<xsd:attribute name="dPhaseFraction_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseFraction_dPressure => (no description available)-->
+		<!--dPhaseFraction_dPressure => Derivative of phase fraction with respect to pressure-->
 		<xsd:attribute name="dPhaseFraction_dPressure" type="real64_array3d" />
-		<!--dPhaseFraction_dTemperature => (no description available)-->
+		<!--dPhaseFraction_dTemperature => Derivative of phase fraction with respect to temperature-->
 		<xsd:attribute name="dPhaseFraction_dTemperature" type="real64_array3d" />
-		<!--dPhaseMassDensity_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseMassDensity_dGlobalCompFraction => Derivative of phase mass density with respect to global component fraction-->
 		<xsd:attribute name="dPhaseMassDensity_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseMassDensity_dPressure => (no description available)-->
+		<!--dPhaseMassDensity_dPressure => Derivative of phase mass density with respect to pressure-->
 		<xsd:attribute name="dPhaseMassDensity_dPressure" type="real64_array3d" />
-		<!--dPhaseMassDensity_dTemperature => (no description available)-->
+		<!--dPhaseMassDensity_dTemperature => Derivative of phase mass density with respect to temperature-->
 		<xsd:attribute name="dPhaseMassDensity_dTemperature" type="real64_array3d" />
-		<!--dPhaseViscosity_dGlobalCompFraction => (no description available)-->
+		<!--dPhaseViscosity_dGlobalCompFraction => Derivative of phase viscosity with respect to global component fraction-->
 		<xsd:attribute name="dPhaseViscosity_dGlobalCompFraction" type="real64_array4d" />
-		<!--dPhaseViscosity_dPressure => (no description available)-->
+		<!--dPhaseViscosity_dPressure => Derivative of phase viscosity with respect to pressure-->
 		<xsd:attribute name="dPhaseViscosity_dPressure" type="real64_array3d" />
-		<!--dPhaseViscosity_dTemperature => (no description available)-->
+		<!--dPhaseViscosity_dTemperature => Derivative of phase viscosity with respect to temperature-->
 		<xsd:attribute name="dPhaseViscosity_dTemperature" type="real64_array3d" />
-		<!--dTotalDensity_dGlobalCompFraction => (no description available)-->
+		<!--dTotalDensity_dGlobalCompFraction => Derivative of total density with respect to global component fraction-->
 		<xsd:attribute name="dTotalDensity_dGlobalCompFraction" type="real64_array3d" />
-		<!--dTotalDensity_dPressure => (no description available)-->
+		<!--dTotalDensity_dPressure => Derivative of total density with respect to pressure-->
 		<xsd:attribute name="dTotalDensity_dPressure" type="real64_array2d" />
-		<!--dTotalDensity_dTemperature => (no description available)-->
+		<!--dTotalDensity_dTemperature => Derivative of total density with respect to temperature-->
 		<xsd:attribute name="dTotalDensity_dTemperature" type="real64_array2d" />
 		<!--formationVolFactorTableWrappers => (no description available)-->
 		<xsd:attribute name="formationVolFactorTableWrappers" type="LvArray_Array&lt;geosx_TableFunction_KernelWrapper, 1, camp_int_seq&lt;long, 0l&gt;, long, LvArray_ChaiBuffer&gt;" />
 		<!--hydrocarbonPhaseOrder => (no description available)-->
 		<xsd:attribute name="hydrocarbonPhaseOrder" type="integer_array" />
-		<!--initialTotalMassDensity => (no description available)-->
+		<!--initialTotalMassDensity => Initial total mass density-->
 		<xsd:attribute name="initialTotalMassDensity" type="real64_array2d" />
-		<!--phaseCompFraction => (no description available)-->
+		<!--phaseCompFraction => Phase component fraction-->
 		<xsd:attribute name="phaseCompFraction" type="real64_array4d" />
-		<!--phaseDensity => (no description available)-->
+		<!--phaseDensity => Phase density-->
 		<xsd:attribute name="phaseDensity" type="real64_array3d" />
-		<!--phaseFraction => (no description available)-->
+		<!--phaseFraction => Phase fraction-->
 		<xsd:attribute name="phaseFraction" type="real64_array3d" />
-		<!--phaseMassDensity => (no description available)-->
+		<!--phaseMassDensity => Phase mass density-->
 		<xsd:attribute name="phaseMassDensity" type="real64_array3d" />
 		<!--phaseOrder => (no description available)-->
 		<xsd:attribute name="phaseOrder" type="integer_array" />
 		<!--phaseTypes => (no description available)-->
 		<xsd:attribute name="phaseTypes" type="integer_array" />
-		<!--phaseViscosity => (no description available)-->
+		<!--phaseViscosity => Phase viscosity-->
 		<xsd:attribute name="phaseViscosity" type="real64_array3d" />
-		<!--totalDensity => (no description available)-->
+		<!--totalDensity => Total density-->
 		<xsd:attribute name="totalDensity" type="real64_array2d" />
 		<!--useMass => (no description available)-->
 		<xsd:attribute name="useMass" type="integer" />
@@ -1528,9 +1528,9 @@
 	<xsd:complexType name="TableCapillaryPressureType">
 		<!--capPresWrappers => (no description available)-->
 		<xsd:attribute name="capPresWrappers" type="LvArray_Array&lt;geosx_TableFunction_KernelWrapper, 1, camp_int_seq&lt;long, 0l&gt;, long, LvArray_ChaiBuffer&gt;" />
-		<!--dPhaseCapPressure_dPhaseVolFraction => (no description available)-->
+		<!--dPhaseCapPressure_dPhaseVolFraction => Derivative of phase capillary pressure with respect to phase volume fraction-->
 		<xsd:attribute name="dPhaseCapPressure_dPhaseVolFraction" type="real64_array4d" />
-		<!--phaseCapPressure => (no description available)-->
+		<!--phaseCapPressure => Phase capillary pressure-->
 		<xsd:attribute name="phaseCapPressure" type="real64_array3d" />
 		<!--phaseOrder => (no description available)-->
 		<xsd:attribute name="phaseOrder" type="integer_array" />
@@ -1538,13 +1538,13 @@
 		<xsd:attribute name="phaseTypes" type="integer_array" />
 	</xsd:complexType>
 	<xsd:complexType name="TableRelativePermeabilityType">
-		<!--dPhaseRelPerm_dPhaseVolFraction => (no description available)-->
+		<!--dPhaseRelPerm_dPhaseVolFraction => Derivative of phase relative permeability with respect to phase volume fraction-->
 		<xsd:attribute name="dPhaseRelPerm_dPhaseVolFraction" type="real64_array4d" />
 		<!--phaseMinVolumeFraction => (no description available)-->
 		<xsd:attribute name="phaseMinVolumeFraction" type="real64_array" />
 		<!--phaseOrder => (no description available)-->
 		<xsd:attribute name="phaseOrder" type="integer_array" />
-		<!--phaseRelPerm => (no description available)-->
+		<!--phaseRelPerm => Phase relative permeability-->
 		<xsd:attribute name="phaseRelPerm" type="real64_array3d" />
 		<!--phaseTypes => (no description available)-->
 		<xsd:attribute name="phaseTypes" type="integer_array" />
@@ -1552,11 +1552,11 @@
 		<xsd:attribute name="relPermWrappers" type="LvArray_Array&lt;geosx_TableFunction_KernelWrapper, 1, camp_int_seq&lt;long, 0l&gt;, long, LvArray_ChaiBuffer&gt;" />
 	</xsd:complexType>
 	<xsd:complexType name="VanGenuchtenBakerRelativePermeabilityType">
-		<!--dPhaseRelPerm_dPhaseVolFraction => (no description available)-->
+		<!--dPhaseRelPerm_dPhaseVolFraction => Derivative of phase relative permeability with respect to phase volume fraction-->
 		<xsd:attribute name="dPhaseRelPerm_dPhaseVolFraction" type="real64_array4d" />
 		<!--phaseOrder => (no description available)-->
 		<xsd:attribute name="phaseOrder" type="integer_array" />
-		<!--phaseRelPerm => (no description available)-->
+		<!--phaseRelPerm => Phase relative permeability-->
 		<xsd:attribute name="phaseRelPerm" type="real64_array3d" />
 		<!--phaseTypes => (no description available)-->
 		<xsd:attribute name="phaseTypes" type="integer_array" />
@@ -1564,9 +1564,9 @@
 		<xsd:attribute name="volFracScale" type="real64" />
 	</xsd:complexType>
 	<xsd:complexType name="VanGenuchtenCapillaryPressureType">
-		<!--dPhaseCapPressure_dPhaseVolFraction => (no description available)-->
+		<!--dPhaseCapPressure_dPhaseVolFraction => Derivative of phase capillary pressure with respect to phase volume fraction-->
 		<xsd:attribute name="dPhaseCapPressure_dPhaseVolFraction" type="real64_array4d" />
-		<!--phaseCapPressure => (no description available)-->
+		<!--phaseCapPressure => Phase capillary pressure-->
 		<xsd:attribute name="phaseCapPressure" type="real64_array3d" />
 		<!--phaseOrder => (no description available)-->
 		<xsd:attribute name="phaseOrder" type="integer_array" />

--- a/src/coreComponents/unitTests/constitutiveTests/testMultiFluid.cpp
+++ b/src/coreComponents/unitTests/constitutiveTests/testMultiFluid.cpp
@@ -15,6 +15,7 @@
 // Source includes
 #include "common/DataTypes.hpp"
 #include "common/TimingMacros.hpp"
+#include "constitutive/fluid/MultiFluidExtrinsicData.hpp"
 #include "constitutive/fluid/multiFluidSelector.hpp"
 #include "constitutive/fluid/MultiFluidUtils.hpp"
 #include "unitTests/fluidFlowTests/testCompFlowUtils.hpp"
@@ -127,49 +128,49 @@ void testNumericalDerivatives( MultiFluidBase & fluid,
   fluidCopy.allocateConstitutiveData( fluid.getParent(), 1 );
 
   // extract data views from both fluids
-  #define GET_FLUID_DATA( FLUID, DIM, PERM, KEY ) \
-    FLUID.getReference< Array< real64, DIM, PERM > >( MultiFluidBase::viewKeyStruct::KEY() )[0][0]
+  #define GET_FLUID_DATA( FLUID, TRAIT ) \
+    FLUID.getReference< TRAIT::type >( TRAIT::key() )[0][0]
 
   MultiFluidVarSlice< real64, 1, USD_PHASE - 2, USD_PHASE_DC - 2 > phaseFrac {
-    GET_FLUID_DATA( fluid, 3, LAYOUT_PHASE, phaseFractionString ),
-    GET_FLUID_DATA( fluid, 3, LAYOUT_PHASE, dPhaseFraction_dPressureString ),
-    GET_FLUID_DATA( fluid, 3, LAYOUT_PHASE, dPhaseFraction_dTemperatureString ),
-    GET_FLUID_DATA( fluid, 4, LAYOUT_PHASE_DC, dPhaseFraction_dGlobalCompFractionString )
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::phaseFraction ),
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::dPhaseFraction_dPressure ),
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::dPhaseFraction_dTemperature ),
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::dPhaseFraction_dGlobalCompFraction )
   };
 
   MultiFluidVarSlice< real64, 1, USD_PHASE - 2, USD_PHASE_DC - 2 > phaseDens {
-    GET_FLUID_DATA( fluid, 3, LAYOUT_PHASE, phaseDensityString ),
-    GET_FLUID_DATA( fluid, 3, LAYOUT_PHASE, dPhaseDensity_dPressureString ),
-    GET_FLUID_DATA( fluid, 3, LAYOUT_PHASE, dPhaseDensity_dTemperatureString ),
-    GET_FLUID_DATA( fluid, 4, LAYOUT_PHASE_DC, dPhaseDensity_dGlobalCompFractionString )
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::phaseDensity ),
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::dPhaseDensity_dPressure ),
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::dPhaseDensity_dTemperature ),
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::dPhaseDensity_dGlobalCompFraction )
   };
 
   MultiFluidVarSlice< real64, 1, USD_PHASE - 2, USD_PHASE_DC - 2 > phaseVisc {
-    GET_FLUID_DATA( fluid, 3, LAYOUT_PHASE, phaseViscosityString ),
-    GET_FLUID_DATA( fluid, 3, LAYOUT_PHASE, dPhaseViscosity_dPressureString ),
-    GET_FLUID_DATA( fluid, 3, LAYOUT_PHASE, dPhaseViscosity_dTemperatureString ),
-    GET_FLUID_DATA( fluid, 4, LAYOUT_PHASE_DC, dPhaseViscosity_dGlobalCompFractionString )
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::phaseViscosity ),
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::dPhaseViscosity_dPressure ),
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::dPhaseViscosity_dTemperature ),
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::dPhaseViscosity_dGlobalCompFraction )
   };
 
   MultiFluidVarSlice< real64, 2, USD_PHASE_COMP - 2, USD_PHASE_COMP_DC - 2 > phaseCompFrac {
-    GET_FLUID_DATA( fluid, 4, LAYOUT_PHASE_COMP, phaseCompFractionString ),
-    GET_FLUID_DATA( fluid, 4, LAYOUT_PHASE_COMP, dPhaseCompFraction_dPressureString ),
-    GET_FLUID_DATA( fluid, 4, LAYOUT_PHASE_COMP, dPhaseCompFraction_dTemperatureString ),
-    GET_FLUID_DATA( fluid, 5, LAYOUT_PHASE_COMP_DC, dPhaseCompFraction_dGlobalCompFractionString )
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::phaseCompFraction ),
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::dPhaseCompFraction_dPressure ),
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::dPhaseCompFraction_dTemperature ),
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::dPhaseCompFraction_dGlobalCompFraction )
   };
 
   MultiFluidVarSlice< real64, 0, USD_FLUID - 2, USD_FLUID_DC - 2 > totalDens {
-    GET_FLUID_DATA( fluid, 2, LAYOUT_FLUID, totalDensityString ),
-    GET_FLUID_DATA( fluid, 2, LAYOUT_FLUID, dTotalDensity_dPressureString ),
-    GET_FLUID_DATA( fluid, 2, LAYOUT_FLUID, dTotalDensity_dTemperatureString ),
-    GET_FLUID_DATA( fluid, 3, LAYOUT_FLUID_DC, dTotalDensity_dGlobalCompFractionString )
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::totalDensity ),
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::dTotalDensity_dPressure ),
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::dTotalDensity_dTemperature ),
+    GET_FLUID_DATA( fluid, extrinsicMeshData::multifluid::dTotalDensity_dGlobalCompFraction )
   };
 
-  auto const & phaseFracCopy     = GET_FLUID_DATA( fluidCopy, 3, LAYOUT_PHASE, phaseFractionString );
-  auto const & phaseDensCopy     = GET_FLUID_DATA( fluidCopy, 3, LAYOUT_PHASE, phaseDensityString );
-  auto const & phaseViscCopy     = GET_FLUID_DATA( fluidCopy, 3, LAYOUT_PHASE, phaseViscosityString );
-  auto const & phaseCompFracCopy = GET_FLUID_DATA( fluidCopy, 4, LAYOUT_PHASE_COMP, phaseCompFractionString );
-  auto const & totalDensCopy     = GET_FLUID_DATA( fluidCopy, 2, LAYOUT_FLUID, totalDensityString );
+  auto const & phaseFracCopy     = GET_FLUID_DATA( fluidCopy, extrinsicMeshData::multifluid::phaseFraction );
+  auto const & phaseDensCopy     = GET_FLUID_DATA( fluidCopy, extrinsicMeshData::multifluid::phaseDensity );
+  auto const & phaseViscCopy     = GET_FLUID_DATA( fluidCopy, extrinsicMeshData::multifluid::phaseViscosity );
+  auto const & phaseCompFracCopy = GET_FLUID_DATA( fluidCopy, extrinsicMeshData::multifluid::phaseCompFraction );
+  auto const & totalDensCopy     = GET_FLUID_DATA( fluidCopy, extrinsicMeshData::multifluid::totalDensity );
 
 #undef GET_FLUID_DATA
 


### PR DESCRIPTION
This PR implements the extrinsic data structure in the multiphase constitutive models: multifluid, relative permeability, capillary pressure. 

This is needed to allow the "automatic" construction of the material `ElementViewAccessors` in the future flux kernel class that is implemented in PR #1696:
https://github.com/GEOSX/GEOSX/blob/0e751cae28351fbd887542ab63db60890ee7a9a8/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFVMKernels.hpp#L152-L159

The present work is only about adding extrinsic data structure to hopefully facilitate the review of this PR. This PR passes the integrated tests and is ready for review.

