### PR TITLE
Fixed Pamela parallel properties import (inside GEOSX)

### DIFF
--- a/src/coreComponents/mesh/generators/PAMELAMeshGenerator.cpp
+++ b/src/coreComponents/mesh/generators/PAMELAMeshGenerator.cpp
@@ -22,6 +22,7 @@
 #include "common/TypeDispatch.hpp"
 #include "mesh/DomainPartition.hpp"
 #include "mesh/MeshBody.hpp"
+#include "mesh/mpiCommunications/CommunicationTools.hpp"
 
 // PAMELA includes
 #include "Elements/Element.hpp"
@@ -382,11 +383,8 @@ void importRegularField( PAMELA::VariableDouble & source,
     GEOSX_ERROR_IF_NE_MSG( numComponentsDst, numComponentsSrc,
                            objectName << ": mismatch in number of components for field " << source.Label );
 
-    // Sanity check, shouldn't happen
-    GEOSX_ERROR_IF_NE_MSG( view.size( 0 ), LvArray::integerConversion< localIndex >( indexMap.size() ),
-                           objectName << ": mismatch in size for field " << source.Label );
-
-    for( int i = 0; i < view.size( 0 ); ++i )
+    // the assumption here is that before this step, GEOSX has added ghost elements **at the end** of the view
+    for( localIndex i = 0; i < LvArray::integerConversion< localIndex >( indexMap.size() ); ++i )
     {
       // get_data() currently returns a new vector for each cell, but auto const & makes sure
       // this code keeps working if/when PAMELA is fixed to return a more reasonable type (span/pointer)
@@ -418,11 +416,8 @@ void importMaterialField( PAMELA::VariableDouble & source,
     GEOSX_ERROR_IF_NE_MSG( numComponentsDst, numComponentsSrc,
                            objectName << ": mismatch in number of components for field " << source.Label );
 
-    // Sanity check, shouldn't happen
-    GEOSX_ERROR_IF_NE_MSG( view.size( 0 ), LvArray::integerConversion< localIndex >( indexMap.size() ),
-                           objectName << ": mismatch in size for field " << source.Label );
-
-    for( int i = 0; i < view.size( 0 ); ++i )
+    // the assumption here is that before this step, GEOSX has added ghost elements **at the end** of the view
+    for( localIndex i = 0; i < LvArray::integerConversion< localIndex >( indexMap.size() ); ++i )
     {
       // get_data() currently returns a new vector for each cell, but auto const & makes sure
       // this code keeps working if/when PAMELA is fixed to return a more reasonable type (span/pointer)
@@ -513,6 +508,19 @@ void PAMELAMeshGenerator::importFields( DomainPartition & domain ) const
       }
     }
   } );
+
+  // this is needed to avoid breaking the unit test testPamelaImport, in which CommunicationTools is not setup
+  if( MpiWrapper::commSize( MPI_COMM_GEOSX ) > 1 )
+  {
+    std::map< string, string_array > fieldNames;
+    for( localIndex fieldIndex = 0; fieldIndex < m_fieldsToImport.size(); fieldIndex++ )
+    {
+      string const & wrapperName = m_fieldNamesInGEOSX[fieldIndex];
+      fieldNames["elems"].emplace_back( wrapperName );
+    }
+    CommunicationTools::getInstance().synchronizeFields( fieldNames, domain.getMeshBody( this->getName() ).getMeshLevel( 0 ), domain.getNeighbors(), false );
+  }
+
 }
 
 REGISTER_CATALOG_ENTRY( MeshGeneratorBase, PAMELAMeshGenerator, string const &, Group * const )


### PR DESCRIPTION
If we want to (partially) fix the parallel import of properties using PAMELA, the call to `synchronizeFields` that was added to VTK is also needed in `PAMELAMeshGenerator.cpp`. 

There are other fixes needed in the PAMELA submodule to allow for the parallel import of properties, but they are hacks that only work in the one-region case (what I need for the test case I am running now), so I have been reluctant to merging them and always used GEOSX tables instead.