### PR TITLE
Reduce visibility of nested structures after refactoring.

### DIFF
--- a/src/coreComponents/constitutive/fluid/CompressibleSinglePhaseFluid.hpp
+++ b/src/coreComponents/constitutive/fluid/CompressibleSinglePhaseFluid.hpp
@@ -133,7 +133,7 @@ public:
    */
   KernelWrapper createKernelWrapper();
 
-  struct viewKeyStruct : public SingleFluidBase::viewKeyStruct
+  struct viewKeyStruct
   {
     static constexpr char const * compressibilityString() { return "compressibility"; }
     static constexpr char const * viscosibilityString() { return "viscosibility"; }

--- a/src/coreComponents/constitutive/fluid/ParticleFluid.hpp
+++ b/src/coreComponents/constitutive/fluid/ParticleFluid.hpp
@@ -209,7 +209,7 @@ public:
 
   // *** Data repository keys
 
-  struct viewKeyStruct : public ParticleFluidBase::viewKeyStruct
+  struct viewKeyStruct
   {
     static constexpr char const * fluidViscosityString() { return "fluidViscosity"; }
     static constexpr char const * proppantDiameterString() { return "proppantDiameter"; }

--- a/src/coreComponents/constitutive/fluid/ParticleFluidBase.hpp
+++ b/src/coreComponents/constitutive/fluid/ParticleFluidBase.hpp
@@ -154,14 +154,6 @@ public:
 
   static constexpr localIndex MAX_NUM_COMPONENTS = 4;
 
-  // *** Data repository keys
-
-  struct viewKeyStruct
-  {
-    static constexpr char const * maxProppantConcentrationString() { return "maxProppantConcentration"; }
-    static constexpr char const * isCollisionalSlipString() { return "isCollisionalSlip"; }
-  };
-
 protected:
 
   virtual void postProcessInput() override;
@@ -179,6 +171,15 @@ protected:
   integer m_isCollisionalSlip;
 
   real64 m_maxProppantConcentration;
+
+private:
+
+  // *** Data repository keys
+  struct viewKeyStruct
+  {
+    static constexpr char const * maxProppantConcentrationString() { return "maxProppantConcentration"; }
+    static constexpr char const * isCollisionalSlipString() { return "isCollisionalSlip"; }
+  };
 
 };
 

--- a/src/coreComponents/constitutive/fluid/ProppantSlurryFluid.hpp
+++ b/src/coreComponents/constitutive/fluid/ProppantSlurryFluid.hpp
@@ -307,7 +307,7 @@ public:
 
   // *** Data repository keys
 
-  struct viewKeyStruct : public SlurryFluidBase::viewKeyStruct
+  struct viewKeyStruct
   {
     static constexpr char const * compressibilityString() { return "compressibility"; }
     static constexpr char const * referencePressureString() { return "referencePressure"; }

--- a/src/coreComponents/constitutive/fluid/SingleFluidBase.hpp
+++ b/src/coreComponents/constitutive/fluid/SingleFluidBase.hpp
@@ -185,14 +185,6 @@ public:
   real64 defaultDensity() const { return m_defaultDensity; }
   real64 defaultViscosity() const { return m_defaultViscosity; }
 
-  // *** Data repository keys
-
-  struct viewKeyStruct
-  {
-    static constexpr char const * defaultDensityString() { return "defaultDensity"; }
-    static constexpr char const * defaultViscosityString() { return "defaultViscosity"; }
-  };
-
 protected:
 
   virtual void postProcessInput() override;
@@ -208,6 +200,14 @@ protected:
   array2d< real64 > m_viscosity;
   array2d< real64 > m_dViscosity_dPressure;
 
+private:
+
+  // *** Data repository keys
+  struct viewKeyStruct
+  {
+    static constexpr char const * defaultDensityString() { return "defaultDensity"; }
+    static constexpr char const * defaultViscosityString() { return "defaultViscosity"; }
+  };
 };
 
 } //namespace constitutive

--- a/src/coreComponents/constitutive/fluid/SlurryFluidBase.hpp
+++ b/src/coreComponents/constitutive/fluid/SlurryFluidBase.hpp
@@ -310,20 +310,6 @@ public:
 
   bool isNewtonianFluid() const { return m_isNewtonianFluid; }
 
-  // *** Data repository keys
-
-  struct viewKeyStruct
-  {
-    static constexpr char const * componentNamesString() { return "componentNames"; }
-
-    static constexpr char const * defaultDensityString() { return "defaultDensity"; }
-    static constexpr char const * defaultCompressibilityString() { return "defaultCompressibility"; }
-    static constexpr char const * defaultViscosityString() { return "defaultViscosity"; }
-
-    static constexpr char const * flowBehaviorIndexString() { return "flowBehaviorIndex"; }
-    static constexpr char const * flowConsistencyIndexString() { return "flowConsistencyIndex"; }
-  };
-
 protected:
 
   virtual void postProcessInput() override;
@@ -361,6 +347,20 @@ protected:
 
   bool m_isNewtonianFluid;
 
+private:
+
+  // *** Data repository keys
+  struct viewKeyStruct
+  {
+    static constexpr char const * componentNamesString() { return "componentNames"; }
+
+    static constexpr char const * defaultDensityString() { return "defaultDensity"; }
+    static constexpr char const * defaultCompressibilityString() { return "defaultCompressibility"; }
+    static constexpr char const * defaultViscosityString() { return "defaultViscosity"; }
+
+    static constexpr char const * flowBehaviorIndexString() { return "flowBehaviorIndex"; }
+    static constexpr char const * flowConsistencyIndexString() { return "flowConsistencyIndex"; }
+  };
 };
 
 } //namespace constitutive


### PR DESCRIPTION
https://github.com/GEOSX/GEOSX/pull/1718 did leave some structures `public` (and kept some unused inheritances).