### PR TITLE
Improved the Newton solver for solubility and density in CO2-brine fluid

### DIFF
--- a/src/coreComponents/constitutive/CMakeLists.txt
+++ b/src/coreComponents/constitutive/CMakeLists.txt
@@ -43,6 +43,7 @@ set( constitutive_headers
      fluid/PVTFunctions/CO2Enthalpy.hpp
      fluid/PVTFunctions/BrineInternalEnergy.hpp
      fluid/PVTFunctions/CO2InternalEnergy.hpp
+     fluid/PVTFunctions/CO2EOSSolver.hpp     
      fluid/ParticleFluid.hpp
      fluid/ParticleFluidBase.hpp
      fluid/ProppantSlurryFluid.hpp
@@ -137,6 +138,7 @@ set( constitutive_sources
      fluid/PVTFunctions/CO2Enthalpy.cpp
      fluid/PVTFunctions/BrineInternalEnergy.cpp
      fluid/PVTFunctions/CO2InternalEnergy.cpp
+     fluid/PVTFunctions/CO2EOSSolver.cpp          
      fluid/ParticleFluid.cpp              
      fluid/ParticleFluidBase.cpp
      fluid/ProppantSlurryFluid.cpp

--- a/src/coreComponents/constitutive/fluid/PVTFunctions/BrineEnthalpy.cpp
+++ b/src/coreComponents/constitutive/fluid/PVTFunctions/BrineEnthalpy.cpp
@@ -124,7 +124,7 @@ TableFunction const * makeCO2EnthalpyTable( string_array const & inputParams,
     array1d< real64 > enthalpies( tableCoords.nPressures() * tableCoords.nTemperatures() );
 
 
-    SpanWagnerCO2Density::calculateCO2Density( tolerance, tableCoords, densities );
+    SpanWagnerCO2Density::calculateCO2Density( functionName, tolerance, tableCoords, densities );
 
     CO2Enthalpy::calculateCO2Enthalpy( tableCoords, densities, enthalpies );
 

--- a/src/coreComponents/constitutive/fluid/PVTFunctions/CO2EOSSolver.cpp
+++ b/src/coreComponents/constitutive/fluid/PVTFunctions/CO2EOSSolver.cpp
@@ -1,0 +1,156 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file CO2EOSSolver.cpp
+ */
+
+#include "constitutive/fluid/PVTFunctions/CO2EOSSolver.hpp"
+
+
+namespace geosx
+{
+
+namespace constitutive
+{
+
+namespace PVTProps
+{
+
+real64
+CO2EOSSolver::solve( string const & name,
+                     integer const maxNumNewtonIter,
+                     integer const maxNumBacktrackIter,
+                     real64 const & tolerance,
+                     real64 const & minAbsDeriv,
+                     real64 const & maxAbsUpdate,
+                     real64 const & allowedMinValue,
+                     real64 const & initialGuess,
+                     real64 const & temp,
+                     real64 const & pres,
+                     real64 const & presMultiplierForReporting,
+                     real64 (* f)( real64 const & t, real64 const & p, real64 const & var ))
+{
+  // evaluate the residual using the initial guess
+  real64 var = initialGuess;
+  real64 res = (*f)( temp, pres, var );
+  real64 update = LvArray::NumericLimits< real64 >::infinity;
+
+  // follow the standard practice
+  // (and multiply by 10, otherwise the FD derivative is often too close to zero.
+  //  To remove this fudge factor, we should probably implement analytical derivatives here).
+  real64 const dVar = 10 * sqrt( LvArray::NumericLimits< real64 >::epsilon ) * var;
+
+  // start the Newton iterations
+  bool newtonHasConverged = false;
+  for( integer newtonIter = 0; newtonIter < maxNumNewtonIter; ++newtonIter )
+  {
+
+    // chop back if the variable goes below the minimum value
+    if( var < allowedMinValue )
+    {
+      var = allowedMinValue;
+      (*f)( temp, pres, var );
+    }
+
+    // check convergence (based on the magnitude of the Newton update for historical reasons)
+    if( LvArray::math::abs( update ) < tolerance )
+    {
+      newtonHasConverged = true;
+      break;
+    }
+
+    // compute finite-difference derivative
+    real64 const perturbedVar = var + dVar;
+    real64 const perturbedRes = (*f)( temp, pres, perturbedVar );
+    real64 deriv = ( perturbedRes - res ) / dVar;
+
+    // we need to make sure that we won't divide by zero
+    // this is critical for the Helmholtz energy equation (Span-Wagner density)
+    if( deriv > 0 && deriv < minAbsDeriv )
+    {
+      deriv = minAbsDeriv;
+    }
+    else if( deriv <= 0 && deriv > -minAbsDeriv )
+    {
+      deriv = -minAbsDeriv;
+    }
+
+    // compute Newton update
+    update = -res / deriv;
+
+    // we need to impose a max update value, otherwise Newton struggles when deriv is close to zero
+    // this is critical for the Helmholtz energy equation (Span-Wagner density)
+    if( update > maxAbsUpdate )
+    {
+      update = maxAbsUpdate;
+    }
+    else if( update < -maxAbsUpdate )
+    {
+      update = -maxAbsUpdate;
+    }
+
+    // recompute the residual
+    real64 const newVar = var + update;
+    real64 const newRes = (*f)( temp, pres, newVar );
+
+    // if the new residual is larger than the previous one, do some backtracking steps
+    bool backtrackingIsSuccessful = false;
+    real64 alpha = 1.0;
+    real64 backtrackVar = newVar;
+    real64 backtrackRes = LvArray::NumericLimits< real64 >::infinity;
+    if( LvArray::math::abs( newRes ) > LvArray::math::abs( res ) )
+    {
+
+      // launch the backtracking steps, and break if successful
+      for( integer iBacktrackIter = 0; iBacktrackIter < maxNumBacktrackIter; ++iBacktrackIter )
+      {
+        alpha *= 0.5;
+        backtrackVar = var + alpha*update;
+        backtrackRes = (*f)( temp, pres, backtrackVar );
+
+        // if we managed to reduce the residual, we can break the loop
+        if( LvArray::math::abs( backtrackRes ) < LvArray::math::abs( res ) )
+        {
+          backtrackingIsSuccessful = true;
+          var = backtrackVar;
+          res = backtrackRes;
+          break;
+        }
+      }
+    }
+
+    // if backtracking failed, keep the original new residual
+    if( !backtrackingIsSuccessful )
+    {
+      var = newVar;
+      res = newRes;
+    }
+  }
+
+  GEOSX_THROW_IF( !newtonHasConverged,
+                  name << ": Newton's method failed to converge for pair "
+                       << "( pressure = " << pres*presMultiplierForReporting << " Pa, temperature = " << temp+273.15 << " K) :"
+                       << " final residual = " << res << ", final update = " << update << ", tolerance = " << tolerance,
+                  InputError );
+  return var;
+}
+
+
+
+} // namespace PVTProps
+
+} // namespace constitutive
+
+} // namespace geosx

--- a/src/coreComponents/constitutive/fluid/PVTFunctions/CO2EOSSolver.hpp
+++ b/src/coreComponents/constitutive/fluid/PVTFunctions/CO2EOSSolver.hpp
@@ -1,0 +1,86 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file CO2EOSSolver.hpp
+ */
+
+#include "common/DataTypes.hpp"
+
+#ifndef GEOSX_CONSTITUTIVE_FLUID_PVTFUNCTIONS_CO2EOSSOLVER_HPP
+#define GEOSX_CONSTITUTIVE_FLUID_PVTFUNCTIONS_CO2EOSSOLVER_HPP
+
+namespace geosx
+{
+
+namespace constitutive
+{
+
+namespace PVTProps
+{
+
+/**
+ * @class CO2EOSSolver
+ *
+ * A class to solve a nonlinear CO2 EOS equation for a given pair (pres, temp)
+ * This class is used to:
+ * 1- Solve the CO2 equation of state (to get the CO2 solubility in brine) in CO2Solubility.cpp
+ * 2- Solve the Helmholtz energy equation (to get the CO2 density) in SpanWagnerCO2Density.cpp
+ */
+class CO2EOSSolver
+{
+public:
+
+  /**
+   * @brief Find the solution to f(temp,pres,var) = 0, and return var
+   * @param[in] name the catalog name of the calling class
+   * @param[in] maxNumNewtonIter the maximum number of Newton iterations
+   * @param[in] maxNumBacktrackIter the maximum number of backtracking iterations
+   * @param[in] tolerance the tolerance used in the convergence check
+   * @param[in] minAbsDeriv the minimum value of the derivative that we allow (since we use FD, the deriv may be zero...)
+   * @param[in] maxAbsUpdate the maximum value of the Newton update that we allow
+   * @param[in] allowedMinValue the minimum value that we allow (otherwise, we chop back)
+   * @param[in] initialGuess the initial guess for Newton's methode
+   * @param[in] temp temperature
+   * @param[in] pres pressure
+   * @param[in] presMultiplierForReporting pressure multiplier used to report problems (since the CO2Solubility solve does use Pascal)
+   * @param[in] f the objective function
+   *
+   * @detail var is reduced volume in the CO2 equation of state, and density in the Helmholtz energy equation
+   */
+  static real64
+  solve( string const & name,
+         integer const maxNumNewtonIter,
+         integer const maxNumBacktrackIter,
+         real64 const & tolerance,
+         real64 const & minAbsDeriv,
+         real64 const & maxAbsUpdate,
+         real64 const & allowedMinValue,
+         real64 const & initialGuess,
+         real64 const & temp,
+         real64 const & pres,
+         real64 const & presMultiplierForReporting,
+         real64 (* f)( real64 const & t, real64 const & p, real64 const & var ));
+
+};
+
+
+} // namespace PVTProps
+
+} // namespace constitutive
+
+} // namespace geosx
+
+
+#endif

--- a/src/coreComponents/constitutive/fluid/PVTFunctions/CO2Enthalpy.cpp
+++ b/src/coreComponents/constitutive/fluid/PVTFunctions/CO2Enthalpy.cpp
@@ -232,7 +232,7 @@ TableFunction const * makeCO2EnthalpyTable( string_array const & inputParams,
     array1d< real64 > enthalpies( tableCoords.nPressures() * tableCoords.nTemperatures() );
 
 
-    SpanWagnerCO2Density::calculateCO2Density( tolerance, tableCoords, densities );
+    SpanWagnerCO2Density::calculateCO2Density( functionName, tolerance, tableCoords, densities );
 
     CO2Enthalpy::calculateCO2Enthalpy( tableCoords, densities, enthalpies );
 

--- a/src/coreComponents/constitutive/fluid/PVTFunctions/CO2Solubility.cpp
+++ b/src/coreComponents/constitutive/fluid/PVTFunctions/CO2Solubility.cpp
@@ -18,6 +18,7 @@
 
 #include "constitutive/fluid/PVTFunctions/CO2Solubility.hpp"
 
+#include "constitutive/fluid/PVTFunctions/CO2EOSSolver.hpp"
 #include "constitutive/fluid/PVTFunctions/PVTFunctionHelpers.hpp"
 #include "functions/FunctionManager.hpp"
 
@@ -125,40 +126,42 @@ real64 Par( real64 const & T, real64 const & P, real64 const * cc )
   return x;
 }
 
-real64 CO2SolubilityFunction( real64 const & tolerance,
+real64 CO2SolubilityFunction( string const & name,
+                              real64 const & tolerance,
                               real64 const & T,
                               real64 const & P,
                               real64 (* f)( real64 const & x1, real64 const & x2, real64 const & x3 ) )
 {
-  constexpr integer maxIter = 50;
-  constexpr real64 dx = 1e-10;
+  // compute the initial guess for Newton's method
+  real64 const initialReducedVolume = 0.75*Rgas*(T_K_f+T)/(P*P_Pa_f)*(1/V_c);
 
-  real64 Vr_int = 0.05;
-  real64 V_r = 0.75*Rgas*(T_K_f+T)/(P*P_Pa_f)*(1/V_c);
+  // define the local solver parameters
+  // for now, this is hard-coded, but we may want to let the user access the parameters at some point
+  integer const maxNumNewtonIter = 500;
+  integer const maxNumBacktrackIter = 20;
+  real64 const maxAbsUpdate = 1e12;
+  real64 const minAbsDeriv = 0;
+  real64 const allowedMinValue = 0.05; // value chosen to match previous implementation
+  real64 const presMultiplierForReporting = 1e5; // this is because P is in hectopascal in this function
 
-  // iterate until the solution of the CO2 equation of state is found
-  integer count = 0;
-  real64 dre = LvArray::NumericLimits< real64 >::infinity;
-  for(; count < maxIter && fabs( dre ) >= tolerance; ++count )
-  {
-    if( V_r < 0.0 )
-    {
-      V_r = Vr_int;
-      Vr_int += 0.05;
-    }
-    real64 const v0 = (*f)( T, P, V_r );
-    real64 const v1 = (*f)( T, P, V_r+dx );
-    dre = -v0/((v1-v0)/dx);
-    V_r += dre;
-  }
-
-  GEOSX_THROW_IF( count == maxIter,
-                  "CO2Solubility NR convergence fails! " << "dre = " << dre << ", tolerance = " << tolerance,
-                  InputError );
-  return V_r;
+  // solve the CO2 equation of state for this pair of (pres, temp)
+  // return the reduced volume
+  return CO2EOSSolver::solve( name,
+                              maxNumNewtonIter,
+                              maxNumBacktrackIter,
+                              tolerance,
+                              minAbsDeriv,
+                              maxAbsUpdate,
+                              allowedMinValue,
+                              initialReducedVolume,
+                              T,
+                              P,
+                              presMultiplierForReporting,
+                              f );
 }
 
-void calculateCO2Solubility( real64 const & tolerance,
+void calculateCO2Solubility( string const & functionName,
+                             real64 const & tolerance,
                              PTTableCoordinates const & tableCoords,
                              real64 const & salinity,
                              array1d< real64 > const & values )
@@ -182,7 +185,7 @@ void calculateCO2Solubility( real64 const & tolerance,
       real64 const T = tableCoords.getTemperature( j );
 
       // compute reduced volume by solving the CO2 equation of state
-      real64 const V_r = CO2SolubilityFunction( tolerance, T, P, &co2EOS );
+      real64 const V_r = CO2SolubilityFunction( functionName, tolerance, T, P, &co2EOS );
 
       // compute equation (6) of Duan and Sun (2003)
       real64 const logK = Par( T+T_K_f, P, mu )
@@ -226,7 +229,7 @@ TableFunction const * makeSolubilityTable( string_array const & inputParams,
   }
 
   array1d< real64 > values( tableCoords.nPressures() * tableCoords.nTemperatures() );
-  calculateCO2Solubility( tolerance, tableCoords, salinity, values );
+  calculateCO2Solubility( functionName, tolerance, tableCoords, salinity, values );
 
   string const tableName = functionName + "_table";
   if( functionManager.hasGroup< TableFunction >( tableName ) )

--- a/src/coreComponents/constitutive/fluid/PVTFunctions/CO2Solubility.cpp
+++ b/src/coreComponents/constitutive/fluid/PVTFunctions/CO2Solubility.cpp
@@ -138,7 +138,7 @@ real64 CO2SolubilityFunction( string const & name,
   // define the local solver parameters
   // for now, this is hard-coded, but we may want to let the user access the parameters at some point
   integer const maxNumNewtonIter = 500;
-  integer const maxNumBacktrackIter = 20;
+  integer const maxNumBacktrackIter = 8;
   real64 const maxAbsUpdate = 1e12;
   real64 const minAbsDeriv = 0;
   real64 const allowedMinValue = 0.05; // value chosen to match previous implementation

--- a/src/coreComponents/constitutive/fluid/PVTFunctions/FenghourCO2Viscosity.cpp
+++ b/src/coreComponents/constitutive/fluid/PVTFunctions/FenghourCO2Viscosity.cpp
@@ -112,7 +112,7 @@ TableFunction const * makeViscosityTable( string_array const & inputParams,
   localIndex const nT = tableCoords.nTemperatures();
   array1d< real64 > density( nP * nT );
   array1d< real64 > viscosity( nP * nT );
-  SpanWagnerCO2Density::calculateCO2Density( tolerance, tableCoords, density );
+  SpanWagnerCO2Density::calculateCO2Density( functionName, tolerance, tableCoords, density );
   calculateCO2Viscosity( tableCoords, density, viscosity );
 
   string const tableName = functionName + "_table";

--- a/src/coreComponents/constitutive/fluid/PVTFunctions/SpanWagnerCO2Density.cpp
+++ b/src/coreComponents/constitutive/fluid/PVTFunctions/SpanWagnerCO2Density.cpp
@@ -183,7 +183,7 @@ real64 spanWagnerCO2DensityFunction( string const & name,
   // define the local solver parameters
   // for now, this is hard-coded, but we may want to let the user access the parameters at some point
   integer const maxNumNewtonIter = 500;
-  integer const maxNumBacktrackIter = 20;
+  integer const maxNumBacktrackIter = 4;
   real64 const maxAbsUpdate = 500;
   real64 const minAbsDeriv = 1e-12; // needed to avoid divisions by zero in the calculation of the Newton update
   real64 const allowedMinValue = -1e12; // use this negative value to disable the chopping on the min value

--- a/src/coreComponents/constitutive/fluid/PVTFunctions/SpanWagnerCO2Density.cpp
+++ b/src/coreComponents/constitutive/fluid/PVTFunctions/SpanWagnerCO2Density.cpp
@@ -18,6 +18,7 @@
 
 #include "constitutive/fluid/PVTFunctions/SpanWagnerCO2Density.hpp"
 
+#include "constitutive/fluid/PVTFunctions/CO2EOSSolver.hpp"
 #include "functions/FunctionManager.hpp"
 
 namespace geosx
@@ -136,11 +137,13 @@ real64 co2HelmholtzEnergy( real64 const & T,
   return rho * (1.0 + delta * phi_r_delta) / (P / (R * T)) - 1.0;
 }
 
-real64 spanWagnerCO2DensityFunction( real64 const & tolerance,
+real64 spanWagnerCO2DensityFunction( string const & name,
+                                     real64 const & tolerance,
                                      real64 const & T,
                                      real64 const & P,
                                      real64 (* f)( real64 const & x1, real64 const & x2, real64 const & x3 ) )
 {
+  // define local variables needed to compute the initial guess
   constexpr real64 P_Pa_f = 1e+5;
   constexpr real64 P_c = 73.773 * P_Pa_f;
   constexpr real64 T_c = 304.1282;
@@ -153,57 +156,53 @@ real64 spanWagnerCO2DensityFunction( real64 const & tolerance,
   constexpr real64 lda[] = { 1.9245108, -0.62385555, -0.32731127, 0.39245142 };
   constexpr real64 ldt[] = { 0.340, 0.5, 1.6666666667, 1.833333333 };
 
-  real64 rho;
-
-  // initial guess
+  // compute the initial guess for density using the method ported from NUFT
+  real64 initialRho = 0.0;
   if( T < T_c )
   {
     real64 sum = 0;
-    for( int i=0; i < 4; i++ )
+    for( integer i=0; i < 4; i++ )
     {
       sum += vpa[i] * pow( 1.0 - T / T_c, vpt[i] );
     }
     real64 const psat = P_c * exp( T_c / T * sum );
 
     sum = 0;
-    for( int i=0; i < 4; i++ )
+    for( integer i=0; i < 4; i++ )
     {
       sum += lda[i] * pow( 1.0 - T / T_c, ldt[i] );
     }
     real64 const denl = rho_c * exp( sum );
-
-    if( P >= psat )
-    {
-      rho = denl;
-    }
-    else
-    {
-      rho = P / (R * T);
-    }
+    initialRho = ( P >= psat ) ?  denl : P / (R * T);
   }
   else
   {
-    rho = 1.0 / (30.0 + R * T / P);
+    initialRho = 1.0 / (30.0 + R * T / P);
   }
 
-  constexpr real64 dx = 1e-10;
-  constexpr integer maxIter = 50;
+  // define the local solver parameters
+  // for now, this is hard-coded, but we may want to let the user access the parameters at some point
+  integer const maxNumNewtonIter = 500;
+  integer const maxNumBacktrackIter = 20;
+  real64 const maxAbsUpdate = 500;
+  real64 const minAbsDeriv = 1e-12; // needed to avoid divisions by zero in the calculation of the Newton update
+  real64 const allowedMinValue = -1e12; // use this negative value to disable the chopping on the min value
+  real64 const presMultiplierForReporting = 1;
 
-  // Newton loop
-  integer count = 0;
-  real64 dre = LvArray::NumericLimits< real64 >::infinity;
-  for(; count < maxIter && fabs( dre ) >= tolerance; ++count )
-  {
-    real64 const v0 = (*f)( T, P, rho );
-    real64 const v1 = (*f)( T, P, rho+dx );
-    dre = -v0/((v1-v0)/dx);
-    rho += dre;
-  }
-
-  GEOSX_THROW_IF( count == maxIter,
-                  GEOSX_FMT( "SpanWagnerCO2Density: Newton convergence fails in CO2 solubility computation: dre = {}, tolerance = {}", dre, tolerance ),
-                  InputError );
-  return rho;
+  // solve the Helmholtz energy equation for this pair of (pres, temp)
+  // return the density
+  return CO2EOSSolver::solve( name,
+                              maxNumNewtonIter,
+                              maxNumBacktrackIter,
+                              tolerance,
+                              minAbsDeriv,
+                              maxAbsUpdate,
+                              allowedMinValue,
+                              initialRho,
+                              T,
+                              P,
+                              presMultiplierForReporting,
+                              f );
 }
 
 
@@ -228,7 +227,7 @@ TableFunction const * makeDensityTable( string_array const & inputParams,
   }
 
   array1d< real64 > densities( tableCoords.nPressures() * tableCoords.nTemperatures() );
-  SpanWagnerCO2Density::calculateCO2Density( tolerance, tableCoords, densities );
+  SpanWagnerCO2Density::calculateCO2Density( functionName, tolerance, tableCoords, densities );
 
   string const & tableName = functionName + "_table";
   if( functionManager.hasGroup< TableFunction >( tableName ) )
@@ -247,7 +246,8 @@ TableFunction const * makeDensityTable( string_array const & inputParams,
 
 } // namespace
 
-void SpanWagnerCO2Density::calculateCO2Density( real64 const & tolerance,
+void SpanWagnerCO2Density::calculateCO2Density( string const & functionName,
+                                                real64 const & tolerance,
                                                 PTTableCoordinates const & tableCoords,
                                                 array1d< real64 > const & densities )
 {
@@ -263,7 +263,7 @@ void SpanWagnerCO2Density::calculateCO2Density( real64 const & tolerance,
     for( localIndex j = 0; j < nTemperatures; ++j )
     {
       real64 const TK = tableCoords.getTemperature( j ) + TK_f;
-      densities[j*nPressures+i] = spanWagnerCO2DensityFunction( tolerance, TK, PPa, &co2HelmholtzEnergy );
+      densities[j*nPressures+i] = spanWagnerCO2DensityFunction( functionName, tolerance, TK, PPa, &co2HelmholtzEnergy );
     }
   }
 }

--- a/src/coreComponents/constitutive/fluid/PVTFunctions/SpanWagnerCO2Density.hpp
+++ b/src/coreComponents/constitutive/fluid/PVTFunctions/SpanWagnerCO2Density.hpp
@@ -111,7 +111,8 @@ public:
   KernelWrapper createKernelWrapper() const;
 
   static
-  void calculateCO2Density( real64 const & tolerance,
+  void calculateCO2Density( string const & functionName,
+                            real64 const & tolerance,
                             PVTProps::PTTableCoordinates const & tableCoords,
                             array1d< real64 > const & densities );
 

--- a/src/coreComponents/mesh/WellElementRegion.cpp
+++ b/src/coreComponents/mesh/WellElementRegion.cpp
@@ -67,8 +67,11 @@ void WellElementRegion::generateWell( MeshLevel & mesh,
   GEOSX_THROW_IF( matchedPerforations != numPerforationsGlobal,
                   "Invalid mapping perforation-to-element in well " << wellGeometry.getName() << "." <<
                   " This happens when GEOSX cannot match a perforation with a reservoir element." <<
-                  " The most common reason for this error is that a perforation is on a section of " <<
-                  " the well polyline located outside the domain.",
+                  " There are two common reasons for this error:\n" <<
+                  " 1- The most common reason for this error is that a perforation is on a section of " <<
+                  " the well polyline located outside the domain.\n" <<
+                  " 2- This error can also happen if a perforation falls on a mesh face or a mesh vertex." <<
+                  " Please try to move the perforation slightly (to the interior of the perforated cell) to see if it fixes the problem.",
                   InputError );
 
 

--- a/src/coreComponents/unitTests/constitutiveTests/testCO2BrinePVTModels.cpp
+++ b/src/coreComponents/unitTests/constitutiveTests/testCO2BrinePVTModels.cpp
@@ -55,10 +55,12 @@ static const char * pvtLiquidInternalEnergyTableContent = "InternalEnergyFun Bri
 static const char * pvtLiquidEzrokhiTableContent = "DensityFun EzrokhiBrineDensity 2.01e-6 -6.34e-7 1e-4\n"
                                                    "ViscosityFun EzrokhiBrineViscosity 2.42e-7 0 1e-4";
 
-static const char * pvtGasTableContent = "DensityFun SpanWagnerCO2Density 1e6 1.5e7 5e4 367.15 369.15 1\n"
-                                         "ViscosityFun FenghourCO2Viscosity 1e6 1.5e7 5e4 367.15 369.15 1";
+static const char * pvtGasTableContent = "DensityFun SpanWagnerCO2Density 1e5 7.5e7 5e4 285.15 369.15 4.0\n" // we want to test the full
+                                                                                                             // (pres, temp) range here
+                                         "ViscosityFun FenghourCO2Viscosity 1e6 1.5e7 5e4 367.15 369.15 1.0";
 
-static const char * co2FlashTableContent = "FlashModel CO2Solubility 1e6 1.5e7 5e4 367.15 369.15 1 0.15";
+static const char * co2FlashTableContent = "FlashModel CO2Solubility 1e5 7.5e7 5e4 285.15 369.15 4.0 0.15"; // we want to test the full
+                                                                                                            // (pres, temp) range here
 
 template< typename PVT_WRAPPER >
 void testValuesAgainstPreviousImplementation( PVT_WRAPPER const & pvtFunctionWrapper,
@@ -804,7 +806,9 @@ TEST_F( SpanWagnerCO2DensityTest, spanWagnerCO2DensityMassValuesAndDeriv )
   real64 const deltaComp = 0.2;
 
   real64 const eps = sqrt( std::numeric_limits< real64 >::epsilon());
-  real64 const relTol = 5e-5;
+  real64 const relTolPrevImpl = 1e-3; // the saved values have been generated with a different pressure spacing, so we loosen the tol a
+                                      // little bit
+  real64 const relTolDeriv = 5e-5;
 
   real64 const savedValues[] = { 82.78363562, 82.56888654, 82.39168811, 135.3774839, 134.9199659, 134.5440568, 281.9140962, 280.2559694,
                                  278.9092508, 82.78363562, 82.56888654, 82.39168811, 135.3774839, 134.9199659, 134.5440568, 281.9140962,
@@ -821,8 +825,8 @@ TEST_F( SpanWagnerCO2DensityTest, spanWagnerCO2DensityMassValuesAndDeriv )
       for( localIndex iTemp = 0; iTemp < 3; ++iTemp )
       {
         testValuesAgainstPreviousImplementation( pvtFunctionWrapper,
-                                                 P[iPres], TC[iTemp], comp, savedValues[counter], true, relTol );
-        testNumericalDerivatives( pvtFunctionWrapper, P[iPres], TC[iTemp], comp, true, eps, relTol );
+                                                 P[iPres], TC[iTemp], comp, savedValues[counter], true, relTolPrevImpl );
+        testNumericalDerivatives( pvtFunctionWrapper, P[iPres], TC[iTemp], comp, true, eps, relTolDeriv );
         counter++;
       }
     }
@@ -842,7 +846,8 @@ TEST_F( SpanWagnerCO2DensityTest, spanWagnerCO2DensityMolarValuesAndDeriv )
   real64 const deltaComp = 0.2;
 
   real64 const eps = sqrt( std::numeric_limits< real64 >::epsilon());
-  real64 const relTol = 5e-5;
+  real64 const relTolPrevImpl = 1e-3;
+  real64 const relTolDeriv = 5e-5;
 
   real64 const savedValues[] = { 1881.446264, 1876.565603, 1872.538366, 3076.760999, 3066.362862, 3057.819473, 6407.138549, 6369.45385,
                                  6338.846609, 1881.446264, 1876.565603, 1872.538366, 3076.760999, 3066.362862, 3057.819473, 6407.138549,
@@ -859,8 +864,8 @@ TEST_F( SpanWagnerCO2DensityTest, spanWagnerCO2DensityMolarValuesAndDeriv )
       for( localIndex iTemp = 0; iTemp < 3; ++iTemp )
       {
         testValuesAgainstPreviousImplementation( pvtFunctionWrapper,
-                                                 P[iPres], TC[iTemp], comp, savedValues[counter], false, relTol );
-        testNumericalDerivatives( pvtFunctionWrapper, P[iPres], TC[iTemp], comp, false, eps, relTol );
+                                                 P[iPres], TC[iTemp], comp, savedValues[counter], false, relTolPrevImpl );
+        testNumericalDerivatives( pvtFunctionWrapper, P[iPres], TC[iTemp], comp, false, eps, relTolDeriv );
         counter++;
       }
     }
@@ -901,7 +906,8 @@ TEST_F( CO2SolubilityTest, co2SolubilityValuesAndDeriv )
   real64 const deltaComp = 0.2;
 
   real64 const eps = sqrt( std::numeric_limits< real64 >::epsilon());
-  real64 const relTol = 5e-5;
+  real64 const relTolPrevImpl = 5e-4;
+  real64 const relTolDeriv = 5e-5;
 
   real64 const savedGasPhaseFrac[] = { 0.298158785, 0.298183347, 0.2982033821, 0.295950309, 0.2959791448, 0.2960026365, 0.2926988393,
                                        0.292724834, 0.2927459702, 0.499837295, 0.499854799, 0.4998690769, 0.4982634386, 0.4982839883,
@@ -924,8 +930,8 @@ TEST_F( CO2SolubilityTest, co2SolubilityValuesAndDeriv )
       {
         testValuesAgainstPreviousImplementation( flashModelWrapper,
                                                  P[iPres], TC[iTemp], comp,
-                                                 savedGasPhaseFrac[counter], savedWaterPhaseGasComp[counter], relTol );
-        testNumericalDerivatives( flashModelWrapper, P[iPres], TC[iTemp], comp, eps, relTol );
+                                                 savedGasPhaseFrac[counter], savedWaterPhaseGasComp[counter], relTolPrevImpl );
+        testNumericalDerivatives( flashModelWrapper, P[iPres], TC[iTemp], comp, eps, relTolDeriv );
         counter++;
       }
     }


### PR DESCRIPTION
This PR adds some improvements to the local Newton solver used in the CO2-brine fluid package to compute the CO2 solubility and density. Previously, the local solver would not converge below about 300 K, which was problematic for some use cases (PR #1723 and surface conditions in wells). 

I unified the local solver code (previously duplicated) and added some simple safeguards (backtrackings, chopping, etc) to make sure it converges in the full (pressure, temperature) range. This is checked in `testCO2BrinePVTModels`. 

The CO2-brine fluid package would benefit from more refactoring (remove hard-coded constants, unify some functions, etc) but this can be done in a separate PR.

This PR does not need a rebaseline.