### PR TITLE
Testing - feature/mazuyer/vtkMeshGenerator branch with updated blt and CMake 3.19.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ git:
   submodules: false
 geosx_before_script: &geosx_before_script
   before_script:
+  - mkdir /tmp/cmake-install
+  - curl -s https://cmake.org/files/v3.19/cmake-3.19.2-Linux-x86_64.tar.gz | tar --directory=/tmp/cmake-install  --strip-components=1 -xzf -
   - git submodule update --init --recursive src/cmake/blt
   - git submodule update --init --recursive src/coreComponents/LvArray
   - git submodule update --init --recursive src/coreComponents/constitutive/PVTPackage
@@ -48,6 +50,7 @@ geosx_linux_build: &geosx_linux_build
     -e ENABLE_HYPRE=${ENABLE_HYPRE:-OFF}
     -e ENABLE_HYPRE_CUDA=${ENABLE_HYPRE_CUDA:-OFF}
     -e ENABLE_TRILINOS=${ENABLE_TRILINOS:-ON}
+    -e PATH=/tmp/cmake-install:/tmp/cmake-install/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     ${DOCKER_REPOSITORY}:${GEOSX_TPL_TAG}
     ${TRAVIS_BUILD_DIR_MOUNT_POINT}/scripts/travis_build_and_test.sh ${BUILD_AND_TEST_ARGS};
 
@@ -186,34 +189,34 @@ jobs:
   - stage: checks
     name: check_pr_is_assigned
     <<: *assigned_script
-  - stage: builds
-    name: Ubuntu CUDA debug (18.04, clang 8.0.0 + gcc 8.3.1, open-mpi 2.1.1, cuda-10.1.243)
-    <<: *geosx_linux_build
-    # Builds only the geosx executable (timeout when building tests)
-    env:
-    - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
-    - CMAKE_BUILD_TYPE=Debug
-    - BUILD_AND_TEST_ARGS="--disable-unit-tests --build-exe-only"
-    - ENABLE_HYPRE=ON
-    - ENABLE_HYPRE_CUDA=ON
-    - ENABLE_TRILINOS=OFF
-  - stage: builds
-    name: Ubuntu CUDA (18.04, clang 8.0.0 + gcc 8.3.1, open-mpi 2.1.1, cuda-10.1.243)
-    <<: *geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
-    - CMAKE_BUILD_TYPE=Release
-    - BUILD_AND_TEST_ARGS=--disable-unit-tests
-    - ENABLE_HYPRE=ON
-    - ENABLE_HYPRE_CUDA=ON
-    - ENABLE_TRILINOS=OFF
-  - stage: builds
-    name: Centos (7.6, gcc 8.3.1, open-mpi 1.10.7, cuda 10.1.243)
-    <<: *geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/centos7.6.1810-gcc8.3.1-cuda10.1.243
-    - CMAKE_BUILD_TYPE=Release
-    - BUILD_AND_TEST_ARGS=--disable-unit-tests
+#  - stage: builds
+#    name: Ubuntu CUDA debug (18.04, clang 8.0.0 + gcc 8.3.1, open-mpi 2.1.1, cuda-10.1.243)
+#    <<: *geosx_linux_build
+#    # Builds only the geosx executable (timeout when building tests)
+#    env:
+#    - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
+#    - CMAKE_BUILD_TYPE=Debug
+#    - BUILD_AND_TEST_ARGS="--disable-unit-tests --build-exe-only"
+#    - ENABLE_HYPRE=ON
+#    - ENABLE_HYPRE_CUDA=ON
+#    - ENABLE_TRILINOS=OFF
+#  - stage: builds
+#    name: Ubuntu CUDA (18.04, clang 8.0.0 + gcc 8.3.1, open-mpi 2.1.1, cuda-10.1.243)
+#    <<: *geosx_linux_build
+#    env:
+#    - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
+#    - CMAKE_BUILD_TYPE=Release
+#    - BUILD_AND_TEST_ARGS=--disable-unit-tests
+#    - ENABLE_HYPRE=ON
+#    - ENABLE_HYPRE_CUDA=ON
+#    - ENABLE_TRILINOS=OFF
+#  - stage: builds
+#    name: Centos (7.6, gcc 8.3.1, open-mpi 1.10.7, cuda 10.1.243)
+#    <<: *geosx_linux_build
+#    env:
+#    - DOCKER_REPOSITORY=geosx/centos7.6.1810-gcc8.3.1-cuda10.1.243
+#    - CMAKE_BUILD_TYPE=Release
+#    - BUILD_AND_TEST_ARGS=--disable-unit-tests
   - stage: builds
     name: Pecan GPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5, cuda 10.2.89p2)
     <<: *geosx_totalenergies_cluster_build
@@ -240,33 +243,33 @@ jobs:
     - GCP_BUCKET=geosx/Pangea2
     - ENABLE_HYPRE=ON
     - ENABLE_TRILINOS=OFF
-  - stage: builds
-    name: Mac_OSX
-    <<: *geosx_osx_build
-  - stage: builds
-    name: Centos (7.7, clang 9.0.0 + gcc 4.9.3, open-mpi 1.10.7)
-    <<: *geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/centos7.7.1908-clang9.0.0
-    - CMAKE_BUILD_TYPE=Release
-  - stage: builds
-    name: Ubuntu (20.04, gcc 9.3.0, open-mpi 4.0.3)
-    <<: *geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc9
-    - CMAKE_BUILD_TYPE=Release
-    - BUILD_AND_TEST_ARGS=--disable-unit-tests
-  - stage: builds
-    name: Ubuntu debug (20.04, gcc 10.3.0, open-mpi 4.0.3)
-    <<: *geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc10
-    - CMAKE_BUILD_TYPE=Debug
-  - stage: builds
-    name: Ubuntu (20.04, gcc 10.3.0, open-mpi 4.0.3)
-    <<: *geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc10
-    - CMAKE_BUILD_TYPE=Release
+#  - stage: builds
+#    name: Mac_OSX
+#    <<: *geosx_osx_build
+#  - stage: builds
+#    name: Centos (7.7, clang 9.0.0 + gcc 4.9.3, open-mpi 1.10.7)
+#    <<: *geosx_linux_build
+#    env:
+#    - DOCKER_REPOSITORY=geosx/centos7.7.1908-clang9.0.0
+#    - CMAKE_BUILD_TYPE=Release
+#  - stage: builds
+#    name: Ubuntu (20.04, gcc 9.3.0, open-mpi 4.0.3)
+#    <<: *geosx_linux_build
+#    env:
+#    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc9
+#    - CMAKE_BUILD_TYPE=Release
+#    - BUILD_AND_TEST_ARGS=--disable-unit-tests
+#  - stage: builds
+#    name: Ubuntu debug (20.04, gcc 10.3.0, open-mpi 4.0.3)
+#    <<: *geosx_linux_build
+#    env:
+#    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc10
+#    - CMAKE_BUILD_TYPE=Debug
+#  - stage: builds
+#    name: Ubuntu (20.04, gcc 10.3.0, open-mpi 4.0.3)
+#    <<: *geosx_linux_build
+#    env:
+#    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc10
+#    - CMAKE_BUILD_TYPE=Release
   - stage: return_status
     <<: *return_script

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: minimal
 
 env:
   global:
-  - GEOSX_TPL_TAG=latest
+  - GEOSX_TPL_TAG=173-714
   - secure: CGs2uH6efq1Me6xJWRr0BnwtwxoujzlowC4FHXHdWbNOkPsXf7nCgdaW5vthfD3bhnOeEUQSrfxdhTRtyU/NfcKLmKgGBnZOdUG4/JJK4gDSJ2Wp8LZ/mB0QEoODKVxbh+YtoAiHe3y4M9PGCs+wkNDw/3eEU00cK12DZ6gad0RbLjI3xkhEr/ZEZDZkcYg9yHAhl5bmpqoh/6QGnIg8mxIqdAtGDw+6tT0EgUqjeqc5bG5WwsamKzJItHSXD5zx8IJAlgDk4EzEGjZe0m56YnNfb9iwqqUsmL3Cuwgs7ByVDYw78JC5Kv42YqoxA5BxMT2mFsEe37TpYNXlzofU7ma2Duw9DGXWQd4IkTCcBxlyR0I0bfo0TmgO+y7PYG9lIyHPUkENemdozsZcWamqqkqegiEdRhDVYlSRo3mu7iCwTS6ZTALliVyEYjYxYb7oAnR3cNywXjblTCI8oKfgLSY+8WijM9SRl57JruIHLkLMCjmRI+cZBfv5tS2tYQTBPkygGrigrrN77ZiC7/TGyfggSN0+y0oYtOAgqEnBcKcreiibMW7tKcV2Z1RFD9ZvIkSc1EXLUPDP8FX1oyhmqBMqVo8LksrYLDJHQ05+F3YNgl2taSt7uMjQ4e8iZ3/IjFeMnbylDw+cj/RbS520HXsFPbWFm2Pb9pceA9n6GnY=
 
 # The integrated test repository contains large data (using git lfs) and we do not use them here.
@@ -26,7 +26,7 @@ geosx_linux_build: &geosx_linux_build
     # Optional BUILD_AND_TEST_ARGS to pass arguments to travis_build_and_test.sh script.
     #
     # We extract the location of the GEOSX_TPL from the container...
-  - GEOSX_TPL_DIR=$(docker run --rm ${DOCKER_REPOSITORY}:latest /bin/bash -c 'echo ${GEOSX_TPL_DIR}')
+  - GEOSX_TPL_DIR=$(docker run --rm ${DOCKER_REPOSITORY}:${GEOSX_TPL_TAG} /bin/bash -c 'echo ${GEOSX_TPL_DIR}')
     # ... so we can install GEOSX alongside. This is assumed for bundling the binaries, so consider modifying with care.
   - GEOSX_DIR=${GEOSX_TPL_DIR}/../GEOSX-${TRAVIS_COMMIT:0:7}
     # We need to know where the code folder is mounted inside the container so we can run the script at the proper location!
@@ -48,7 +48,7 @@ geosx_linux_build: &geosx_linux_build
     -e ENABLE_HYPRE=${ENABLE_HYPRE:-OFF}
     -e ENABLE_HYPRE_CUDA=${ENABLE_HYPRE_CUDA:-OFF}
     -e ENABLE_TRILINOS=${ENABLE_TRILINOS:-ON}
-    ${DOCKER_REPOSITORY}:latest
+    ${DOCKER_REPOSITORY}:${GEOSX_TPL_TAG}
     ${TRAVIS_BUILD_DIR_MOUNT_POINT}/scripts/travis_build_and_test.sh ${BUILD_AND_TEST_ARGS};
 
 geosx_osx_build: &geosx_osx_build
@@ -218,7 +218,7 @@ jobs:
     name: Pecan GPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5, cuda 10.2.89p2)
     <<: *geosx_totalenergies_cluster_build
     env:
-    - DOCKER_REPOSITORY=han12/pecan-cpu-gcc8.2.0-openmpi4.0.1-mkl2019.5-cuda10.2.89p2
+    - DOCKER_REPOSITORY=geosx/pecan-gpu-gcc8.2.0-openmpi4.0.1-mkl2019.5-cuda10.2.89p2
     - CMAKE_BUILD_TYPE=Release
     - BUILD_AND_TEST_ARGS=--disable-unit-tests
     - HOST_CONFIG=host-configs/TOTAL/pecan-GPU.cmake
@@ -227,7 +227,7 @@ jobs:
     name: Pecan CPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5)
     <<: *geosx_totalenergies_cluster_build
     env:
-    - DOCKER_REPOSITORY=han12/pecan-cpu-gcc8.2.0-openmpi4.0.1-mkl2019.5
+    - DOCKER_REPOSITORY=geosx/pecan-cpu-gcc8.2.0-openmpi4.0.1-mkl2019.5
     - CMAKE_BUILD_TYPE=Release
     - HOST_CONFIG=host-configs/TOTAL/pecan-CPU.cmake
     - GCP_BUCKET=geosx/Pecan-CPU
@@ -235,7 +235,7 @@ jobs:
     name: Pangea 2 (centos 7.6, gcc 8.3.0, open-mpi 2.1.5, mkl 2019.3)
     <<: *geosx_totalenergies_cluster_build
     env:
-    - DOCKER_REPOSITORY=han12/pangea2-gcc8.3.0-openmpi2.1.5-mkl2019.3
+    - DOCKER_REPOSITORY=geosx/pangea2-gcc8.3.0-openmpi2.1.5-mkl2019.3
     - CMAKE_BUILD_TYPE=Release
     - GCP_BUCKET=geosx/Pangea2
     - ENABLE_HYPRE=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: minimal
 
 env:
   global:
-  - GEOSX_TPL_TAG=155-707
+  - GEOSX_TPL_TAG=latest
   - secure: CGs2uH6efq1Me6xJWRr0BnwtwxoujzlowC4FHXHdWbNOkPsXf7nCgdaW5vthfD3bhnOeEUQSrfxdhTRtyU/NfcKLmKgGBnZOdUG4/JJK4gDSJ2Wp8LZ/mB0QEoODKVxbh+YtoAiHe3y4M9PGCs+wkNDw/3eEU00cK12DZ6gad0RbLjI3xkhEr/ZEZDZkcYg9yHAhl5bmpqoh/6QGnIg8mxIqdAtGDw+6tT0EgUqjeqc5bG5WwsamKzJItHSXD5zx8IJAlgDk4EzEGjZe0m56YnNfb9iwqqUsmL3Cuwgs7ByVDYw78JC5Kv42YqoxA5BxMT2mFsEe37TpYNXlzofU7ma2Duw9DGXWQd4IkTCcBxlyR0I0bfo0TmgO+y7PYG9lIyHPUkENemdozsZcWamqqkqegiEdRhDVYlSRo3mu7iCwTS6ZTALliVyEYjYxYb7oAnR3cNywXjblTCI8oKfgLSY+8WijM9SRl57JruIHLkLMCjmRI+cZBfv5tS2tYQTBPkygGrigrrN77ZiC7/TGyfggSN0+y0oYtOAgqEnBcKcreiibMW7tKcV2Z1RFD9ZvIkSc1EXLUPDP8FX1oyhmqBMqVo8LksrYLDJHQ05+F3YNgl2taSt7uMjQ4e8iZ3/IjFeMnbylDw+cj/RbS520HXsFPbWFm2Pb9pceA9n6GnY=
 
 # The integrated test repository contains large data (using git lfs) and we do not use them here.
@@ -11,8 +11,6 @@ git:
   submodules: false
 geosx_before_script: &geosx_before_script
   before_script:
-  - mkdir /tmp/cmake-install
-  - curl -s https://cmake.org/files/v3.19/cmake-3.19.2-Linux-x86_64.tar.gz | tar --directory=/tmp/cmake-install  --strip-components=1 -xzf -
   - git submodule update --init --recursive src/cmake/blt
   - git submodule update --init --recursive src/coreComponents/LvArray
   - git submodule update --init --recursive src/coreComponents/constitutive/PVTPackage
@@ -28,7 +26,7 @@ geosx_linux_build: &geosx_linux_build
     # Optional BUILD_AND_TEST_ARGS to pass arguments to travis_build_and_test.sh script.
     #
     # We extract the location of the GEOSX_TPL from the container...
-  - GEOSX_TPL_DIR=$(docker run --rm ${DOCKER_REPOSITORY}:${GEOSX_TPL_TAG} /bin/bash -c 'echo ${GEOSX_TPL_DIR}')
+  - GEOSX_TPL_DIR=$(docker run --rm ${DOCKER_REPOSITORY}:latest /bin/bash -c 'echo ${GEOSX_TPL_DIR}')
     # ... so we can install GEOSX alongside. This is assumed for bundling the binaries, so consider modifying with care.
   - GEOSX_DIR=${GEOSX_TPL_DIR}/../GEOSX-${TRAVIS_COMMIT:0:7}
     # We need to know where the code folder is mounted inside the container so we can run the script at the proper location!
@@ -50,8 +48,7 @@ geosx_linux_build: &geosx_linux_build
     -e ENABLE_HYPRE=${ENABLE_HYPRE:-OFF}
     -e ENABLE_HYPRE_CUDA=${ENABLE_HYPRE_CUDA:-OFF}
     -e ENABLE_TRILINOS=${ENABLE_TRILINOS:-ON}
-    -e PATH=/tmp/cmake-install:/tmp/cmake-install/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    ${DOCKER_REPOSITORY}:${GEOSX_TPL_TAG}
+    ${DOCKER_REPOSITORY}:latest
     ${TRAVIS_BUILD_DIR_MOUNT_POINT}/scripts/travis_build_and_test.sh ${BUILD_AND_TEST_ARGS};
 
 geosx_osx_build: &geosx_osx_build
@@ -169,20 +166,20 @@ jobs:
   - stage: checks
     name: check_pr_is_not_a_draft
     <<: *draft_script
-  - stage: checks
-    name: code_style
-    <<: *geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc9
-    - CMAKE_BUILD_TYPE=Release
-    - BUILD_AND_TEST_ARGS=--test-code-style
-  - stage: checks
-    name: documentation
-    <<: *geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc9
-    - CMAKE_BUILD_TYPE=Release
-    - BUILD_AND_TEST_ARGS=--test-documentation
+#  - stage: checks
+#    name: code_style
+#    <<: *geosx_linux_build
+#    env:
+#    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc9
+#    - CMAKE_BUILD_TYPE=Release
+#    - BUILD_AND_TEST_ARGS=--test-code-style
+#  - stage: checks
+#    name: documentation
+#    <<: *geosx_linux_build
+#    env:
+#    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc9
+#    - CMAKE_BUILD_TYPE=Release
+#    - BUILD_AND_TEST_ARGS=--test-documentation
   - stage: checks
     name: check_submodules
     script: scripts/test_submodule_updated.sh
@@ -221,7 +218,7 @@ jobs:
     name: Pecan GPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5, cuda 10.2.89p2)
     <<: *geosx_totalenergies_cluster_build
     env:
-    - DOCKER_REPOSITORY=geosx/pecan-gpu-gcc8.2.0-openmpi4.0.1-mkl2019.5-cuda10.2.89p2
+    - DOCKER_REPOSITORY=han12/pecan-cpu-gcc8.2.0-openmpi4.0.1-mkl2019.5-cuda10.2.89p2
     - CMAKE_BUILD_TYPE=Release
     - BUILD_AND_TEST_ARGS=--disable-unit-tests
     - HOST_CONFIG=host-configs/TOTAL/pecan-GPU.cmake
@@ -230,7 +227,7 @@ jobs:
     name: Pecan CPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5)
     <<: *geosx_totalenergies_cluster_build
     env:
-    - DOCKER_REPOSITORY=geosx/pecan-cpu-gcc8.2.0-openmpi4.0.1-mkl2019.5
+    - DOCKER_REPOSITORY=han12/pecan-cpu-gcc8.2.0-openmpi4.0.1-mkl2019.5
     - CMAKE_BUILD_TYPE=Release
     - HOST_CONFIG=host-configs/TOTAL/pecan-CPU.cmake
     - GCP_BUCKET=geosx/Pecan-CPU
@@ -238,7 +235,7 @@ jobs:
     name: Pangea 2 (centos 7.6, gcc 8.3.0, open-mpi 2.1.5, mkl 2019.3)
     <<: *geosx_totalenergies_cluster_build
     env:
-    - DOCKER_REPOSITORY=geosx/pangea2-gcc8.3.0-openmpi2.1.5-mkl2019.3
+    - DOCKER_REPOSITORY=han12/pangea2-gcc8.3.0-openmpi2.1.5-mkl2019.3
     - CMAKE_BUILD_TYPE=Release
     - GCP_BUCKET=geosx/Pangea2
     - ENABLE_HYPRE=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: minimal
 
 env:
   global:
-  - GEOSX_TPL_TAG=173-714
+  - GEOSX_TPL_TAG=174-717
   - secure: CGs2uH6efq1Me6xJWRr0BnwtwxoujzlowC4FHXHdWbNOkPsXf7nCgdaW5vthfD3bhnOeEUQSrfxdhTRtyU/NfcKLmKgGBnZOdUG4/JJK4gDSJ2Wp8LZ/mB0QEoODKVxbh+YtoAiHe3y4M9PGCs+wkNDw/3eEU00cK12DZ6gad0RbLjI3xkhEr/ZEZDZkcYg9yHAhl5bmpqoh/6QGnIg8mxIqdAtGDw+6tT0EgUqjeqc5bG5WwsamKzJItHSXD5zx8IJAlgDk4EzEGjZe0m56YnNfb9iwqqUsmL3Cuwgs7ByVDYw78JC5Kv42YqoxA5BxMT2mFsEe37TpYNXlzofU7ma2Duw9DGXWQd4IkTCcBxlyR0I0bfo0TmgO+y7PYG9lIyHPUkENemdozsZcWamqqkqegiEdRhDVYlSRo3mu7iCwTS6ZTALliVyEYjYxYb7oAnR3cNywXjblTCI8oKfgLSY+8WijM9SRl57JruIHLkLMCjmRI+cZBfv5tS2tYQTBPkygGrigrrN77ZiC7/TGyfggSN0+y0oYtOAgqEnBcKcreiibMW7tKcV2Z1RFD9ZvIkSc1EXLUPDP8FX1oyhmqBMqVo8LksrYLDJHQ05+F3YNgl2taSt7uMjQ4e8iZ3/IjFeMnbylDw+cj/RbS520HXsFPbWFm2Pb9pceA9n6GnY=
 
 # The integrated test repository contains large data (using git lfs) and we do not use them here.
@@ -166,54 +166,54 @@ jobs:
   - stage: checks
     name: check_pr_is_not_a_draft
     <<: *draft_script
-#  - stage: checks
-#    name: code_style
-#    <<: *geosx_linux_build
-#    env:
-#    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc9
-#    - CMAKE_BUILD_TYPE=Release
-#    - BUILD_AND_TEST_ARGS=--test-code-style
-#  - stage: checks
-#    name: documentation
-#    <<: *geosx_linux_build
-#    env:
-#    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc9
-#    - CMAKE_BUILD_TYPE=Release
-#    - BUILD_AND_TEST_ARGS=--test-documentation
+  - stage: checks
+    name: code_style
+    <<: *geosx_linux_build
+    env:
+    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc9
+    - CMAKE_BUILD_TYPE=Release
+    - BUILD_AND_TEST_ARGS=--test-code-style
+  - stage: checks
+    name: documentation
+    <<: *geosx_linux_build
+    env:
+    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc9
+    - CMAKE_BUILD_TYPE=Release
+    - BUILD_AND_TEST_ARGS=--test-documentation
   - stage: checks
     name: check_submodules
     script: scripts/test_submodule_updated.sh
   - stage: checks
     name: check_pr_is_assigned
     <<: *assigned_script
-#  - stage: builds
-#    name: Ubuntu CUDA debug (18.04, clang 8.0.0 + gcc 8.3.1, open-mpi 2.1.1, cuda-10.1.243)
-#    <<: *geosx_linux_build
-#    # Builds only the geosx executable (timeout when building tests)
-#    env:
-#    - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
-#    - CMAKE_BUILD_TYPE=Debug
-#    - BUILD_AND_TEST_ARGS="--disable-unit-tests --build-exe-only"
-#    - ENABLE_HYPRE=ON
-#    - ENABLE_HYPRE_CUDA=ON
-#    - ENABLE_TRILINOS=OFF
-#  - stage: builds
-#    name: Ubuntu CUDA (18.04, clang 8.0.0 + gcc 8.3.1, open-mpi 2.1.1, cuda-10.1.243)
-#    <<: *geosx_linux_build
-#    env:
-#    - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
-#    - CMAKE_BUILD_TYPE=Release
-#    - BUILD_AND_TEST_ARGS=--disable-unit-tests
-#    - ENABLE_HYPRE=ON
-#    - ENABLE_HYPRE_CUDA=ON
-#    - ENABLE_TRILINOS=OFF
-#  - stage: builds
-#    name: Centos (7.6, gcc 8.3.1, open-mpi 1.10.7, cuda 10.1.243)
-#    <<: *geosx_linux_build
-#    env:
-#    - DOCKER_REPOSITORY=geosx/centos7.6.1810-gcc8.3.1-cuda10.1.243
-#    - CMAKE_BUILD_TYPE=Release
-#    - BUILD_AND_TEST_ARGS=--disable-unit-tests
+  - stage: builds
+    name: Ubuntu CUDA debug (18.04, clang 8.0.0 + gcc 8.3.1, open-mpi 2.1.1, cuda-10.1.243)
+    <<: *geosx_linux_build
+    # Builds only the geosx executable (timeout when building tests)
+    env:
+    - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
+    - CMAKE_BUILD_TYPE=Debug
+    - BUILD_AND_TEST_ARGS="--disable-unit-tests --build-exe-only"
+    - ENABLE_HYPRE=ON
+    - ENABLE_HYPRE_CUDA=ON
+    - ENABLE_TRILINOS=OFF
+  - stage: builds
+    name: Ubuntu CUDA (18.04, clang 8.0.0 + gcc 8.3.1, open-mpi 2.1.1, cuda-10.1.243)
+    <<: *geosx_linux_build
+    env:
+    - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
+    - CMAKE_BUILD_TYPE=Release
+    - BUILD_AND_TEST_ARGS=--disable-unit-tests
+    - ENABLE_HYPRE=ON
+    - ENABLE_HYPRE_CUDA=ON
+    - ENABLE_TRILINOS=OFF
+  - stage: builds
+    name: Centos (7.6, gcc 8.3.1, open-mpi 1.10.7, cuda 10.1.243)
+    <<: *geosx_linux_build
+    env:
+    - DOCKER_REPOSITORY=geosx/centos7.6.1810-gcc8.3.1-cuda10.1.243
+    - CMAKE_BUILD_TYPE=Release
+    - BUILD_AND_TEST_ARGS=--disable-unit-tests
   - stage: builds
     name: Pecan GPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5, cuda 10.2.89p2)
     <<: *geosx_totalenergies_cluster_build
@@ -240,33 +240,33 @@ jobs:
     - GCP_BUCKET=geosx/Pangea2
     - ENABLE_HYPRE=ON
     - ENABLE_TRILINOS=OFF
-#  - stage: builds
-#    name: Mac_OSX
-#    <<: *geosx_osx_build
-#  - stage: builds
-#    name: Centos (7.7, clang 9.0.0 + gcc 4.9.3, open-mpi 1.10.7)
-#    <<: *geosx_linux_build
-#    env:
-#    - DOCKER_REPOSITORY=geosx/centos7.7.1908-clang9.0.0
-#    - CMAKE_BUILD_TYPE=Release
-#  - stage: builds
-#    name: Ubuntu (20.04, gcc 9.3.0, open-mpi 4.0.3)
-#    <<: *geosx_linux_build
-#    env:
-#    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc9
-#    - CMAKE_BUILD_TYPE=Release
-#    - BUILD_AND_TEST_ARGS=--disable-unit-tests
-#  - stage: builds
-#    name: Ubuntu debug (20.04, gcc 10.3.0, open-mpi 4.0.3)
-#    <<: *geosx_linux_build
-#    env:
-#    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc10
-#    - CMAKE_BUILD_TYPE=Debug
-#  - stage: builds
-#    name: Ubuntu (20.04, gcc 10.3.0, open-mpi 4.0.3)
-#    <<: *geosx_linux_build
-#    env:
-#    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc10
-#    - CMAKE_BUILD_TYPE=Release
+  - stage: builds
+    name: Mac_OSX
+    <<: *geosx_osx_build
+  - stage: builds
+    name: Centos (7.7, clang 9.0.0 + gcc 4.9.3, open-mpi 1.10.7)
+    <<: *geosx_linux_build
+    env:
+    - DOCKER_REPOSITORY=geosx/centos7.7.1908-clang9.0.0
+    - CMAKE_BUILD_TYPE=Release
+  - stage: builds
+    name: Ubuntu (20.04, gcc 9.3.0, open-mpi 4.0.3)
+    <<: *geosx_linux_build
+    env:
+    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc9
+    - CMAKE_BUILD_TYPE=Release
+    - BUILD_AND_TEST_ARGS=--disable-unit-tests
+  - stage: builds
+    name: Ubuntu debug (20.04, gcc 10.3.0, open-mpi 4.0.3)
+    <<: *geosx_linux_build
+    env:
+    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc10
+    - CMAKE_BUILD_TYPE=Debug
+  - stage: builds
+    name: Ubuntu (20.04, gcc 10.3.0, open-mpi 4.0.3)
+    <<: *geosx_linux_build
+    env:
+    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc10
+    - CMAKE_BUILD_TYPE=Release
   - stage: return_status
     <<: *return_script

--- a/src/coreComponents/mesh/CMakeLists.txt
+++ b/src/coreComponents/mesh/CMakeLists.txt
@@ -125,9 +125,10 @@ if( ENABLE_VTK )
     message(STATUS "Adding VTKMeshGenerator sources and headers")
     set( mesh_headers ${mesh_headers} generators/VTKMeshGenerator.hpp )                                                                                                                                         
     set( mesh_sources ${mesh_sources} generators/VTKMeshGenerator.cpp)
-    set( dependencyList ${dependencyList} VTK::CommonCore VTK::CommonSystem VTK::CommonMisc VTK::IOCore VTK::IOLegacy VTK::IOXML VTK::expat VTK::doubleconversion VTK::lz4 VTK::lzma VTK::zlib VTK::loguru VTK::FiltersParallelDIY2 )
+
+    set( dependencyList ${dependencyList} VTK::FiltersParallelDIY2 VTK::IOLegacy )
     if( ENABLE_MPI )
-      set( dependencyList ${dependencyList} VTK::IOParallelXML VTK::ParallelMPI )
+      set( dependencyList ${dependencyList} VTK::ParallelMPI )
     endif()
 endif()
 


### PR DESCRIPTION
This PR is a test to see if updating blt to develop will resolve Travis CI errors with Pangea/Pecan builds on the `feature/mazuyer/vtkMeshGenerator` branch.