### PR TITLE
buildrootdir/installrootdir options in config-build.py

### DIFF
--- a/src/docs/sphinx/buildGuide/BuildProcess.rst
+++ b/src/docs/sphinx/buildGuide/BuildProcess.rst
@@ -38,6 +38,12 @@ Build steps
   * ``--hostconfig`` or ``-hc`` is a path to host-config file.
   * all unrecognized options are passed to CMake.
 
+  If ``--buildpath`` is not used, build directory is automatically named ``build-<config-filename-without-extension>-<buildtype>``.
+  It is possible to keep automatic naming and change the build root directory with ``--buildrootdir``.
+  In that case, build path will be set to ``<buildrootdir>/<config-filename-without-extension>-<buildtype>``.
+  Both ``--buildpath`` and ``--buildrootdir`` are incompatible and cannot be used in the same time.
+  Same pattern is applicable to install path, with ``--installpath`` and ``--installrootdir`` options.
+
 - Run the build:
 
   .. code-block:: console


### PR DESCRIPTION
Adds a `build root dir` / `build path` distinction.
The first option will keep the auto-generated folder name. The latter is unchanged.
Two options overlap somehow: the script fails if both options are provided.

https://github.com/GEOSX/thirdPartyLibs/pull/175 makes the same changes to the TPL version of the script.