### PR TITLE
Correct traits and add template getter protection.

### DIFF
--- a/src/coreComponents/codingUtilities/tests/testGeosxTraits.cpp
+++ b/src/coreComponents/codingUtilities/tests/testGeosxTraits.cpp
@@ -213,3 +213,20 @@ TEST( testGeosxTraits, hasCopyAssignment )
   static_assert( hasCopyAssignmentOp< Foo >, "Should be true." );
   static_assert( !hasCopyAssignmentOp< Bar >, "Should be false." );
 }
+
+struct A
+{};
+
+struct B
+{};
+
+struct C
+{};
+
+TEST( testGeosxTraits, typeListIndex )
+{
+  static_assert( type_list_index< A, std::tuple< A, B > > == 0, "Should be true." );
+  static_assert( type_list_index< B, std::tuple< A, B > > == 1, "Should be true." );
+  static_assert( type_list_index< C, std::tuple< A, B > > == 2, "Should be true." );
+  static_assert( type_list_index< A, std::tuple<> > == 0, "Should be true." );
+}

--- a/src/coreComponents/codingUtilities/traits.hpp
+++ b/src/coreComponents/codingUtilities/traits.hpp
@@ -215,8 +215,8 @@ static constexpr bool hasCopyAssignmentOp = hasCopyAssignmentOperatorImpl< T >::
 namespace internal
 {
 
-template< typename T, typename U >
-constexpr std::size_t type_list_index( T, U ) { return -1ull; }
+template< typename T, template< typename ... > class L, typename ... Ts >
+constexpr std::size_t type_list_index( T, L<> ) { return 0; }
 
 template< typename T, template< typename ... > class L, typename ... Ts >
 constexpr std::size_t type_list_index( T, L< T, Ts ... > ) { return 0; }
@@ -227,9 +227,12 @@ constexpr std::size_t type_list_index( T, L< U, Ts ... > ) { return 1 + type_lis
 } // namespace internal
 
 /**
- * @brief Index of a given type in a type list
+ * @brief Index of a given type in a type list.
  * @tparam T type to find
  * @tparam LIST list of types (any variadic type, such as std::tuple<>, camp::list<>, etc.)
+ *
+ *  If @p T is not found, returns the size of the tuple.
+ *  This is symmetric with @p end iterator for STL algorithms.
  */
 template< typename T, typename LIST >
 constexpr std::size_t type_list_index = internal::type_list_index( T{}, LIST{} );

--- a/src/coreComponents/codingUtilities/traits.hpp
+++ b/src/coreComponents/codingUtilities/traits.hpp
@@ -215,7 +215,7 @@ static constexpr bool hasCopyAssignmentOp = hasCopyAssignmentOperatorImpl< T >::
 namespace internal
 {
 
-template< typename T, template< typename ... > class L, typename ... Ts >
+template< typename T, template< typename ... > class L >
 constexpr std::size_t type_list_index( T, L<> ) { return 0; }
 
 template< typename T, template< typename ... > class L, typename ... Ts >
@@ -232,7 +232,7 @@ constexpr std::size_t type_list_index( T, L< U, Ts ... > ) { return 1 + type_lis
  * @tparam LIST list of types (any variadic type, such as std::tuple<>, camp::list<>, etc.)
  *
  *  If @p T is not found, returns the size of the tuple.
- *  This is symmetric with @p end iterator for STL algorithms.
+ *  This is consistent with @p end iterator for STL algorithms.
  */
 template< typename T, typename LIST >
 constexpr std::size_t type_list_index = internal::type_list_index( T{}, LIST{} );

--- a/src/coreComponents/physicsSolvers/fluidFlow/StencilAccessors.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/StencilAccessors.hpp
@@ -45,14 +45,17 @@ public:
   template< typename TRAIT >
   auto get( TRAIT ) const
   {
-    return std::get< traits::type_list_index< TRAIT, std::tuple< TRAITS ... > > >( m_accessors ).toNestedViewConst();
+    constexpr std::size_t idx = traits::type_list_index< TRAIT, std::tuple< TRAITS ... > >;
+    static_assert( idx != std::tuple_size< std::tuple< TRAITS... > >::value, "Trait/stencil does not match the available traits/stencils." );
+    return std::get< idx >( m_accessors ).toNestedViewConst();
   }
 
   template< typename TRAIT >
   auto get() const
   {
-    return std::get< traits::type_list_index< TRAIT, std::tuple< TRAITS ... > > >( m_accessors ).toNestedViewConst();
+    return get( TRAIT{} );
   }
+
   /**
    * @brief Constructor for the struct
    * @param[in] elemManager a reference to the elemRegionManager

--- a/src/coreComponents/physicsSolvers/fluidFlow/StencilAccessors.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/StencilAccessors.hpp
@@ -46,7 +46,7 @@ public:
   auto get( TRAIT ) const
   {
     constexpr std::size_t idx = traits::type_list_index< TRAIT, std::tuple< TRAITS ... > >;
-    static_assert( idx != std::tuple_size< std::tuple< TRAITS... > >::value, "Trait/stencil does not match the available traits/stencils." );
+    static_assert( idx != std::tuple_size< std::tuple< TRAITS... > >::value, "input trait/stencil does not match the available traits/stencils." );
     return std::get< idx >( m_accessors ).toNestedViewConst();
   }
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/proppantTransport/ProppantTransportKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/proppantTransport/ProppantTransportKernels.hpp
@@ -186,7 +186,8 @@ struct FluxKernel
 
   using CellBasedFluxFlowAccessors =
     StencilAccessors< extrinsicMeshData::flow::pressure,
-                      extrinsicMeshData::flow::gravityCoefficient >;
+                      extrinsicMeshData::flow::gravityCoefficient,
+                      extrinsicMeshData::elementAperture >;
 
   using ParticleFluidAccessors =
     StencilAccessors< extrinsicMeshData::particlefluid::settlingFactor,


### PR DESCRIPTION
The was a bug in the `type_list_index` traits which was pointing to last element even when the type was not found.
I corrected by returning ~`end` like for STL algorithms.
I added an index check in `StencilAccessors` to prevent anyone from using an "unsupported" template argument.