### PR TITLE
Delay initialization of HistoryOuput

### DIFF
--- a/src/coreComponents/fileIO/Outputs/TimeHistoryOutput.cpp
+++ b/src/coreComponents/fileIO/Outputs/TimeHistoryOutput.cpp
@@ -109,15 +109,17 @@ void TimeHistoryOutput::initCollectorParallel( DomainPartition & domain, History
 
 void TimeHistoryOutput::initializePostInitialConditionsPostSubGroups()
 {
-  // check whether to truncate or append to the file up front so we don't have to bother during later accesses
-  string const outputDirectory = getOutputDirectory();
-  if( MpiWrapper::commRank( MPI_COMM_GEOSX ) == 0 )
   {
-    makeDirsForPath( outputDirectory );
+    // check whether to truncate or append to the file up front so we don't have to bother during later accesses
+    string const outputDirectory = getOutputDirectory();
+    if( MpiWrapper::commRank( MPI_COMM_GEOSX ) == 0 )
+    {
+      makeDirsForPath( outputDirectory );
+    }
+    MpiWrapper::barrier( MPI_COMM_GEOSX );
+    string const outputFile = joinPath( outputDirectory, m_filename );
+    HDFFile( outputFile, (m_recordCount == 0), true, MPI_COMM_GEOSX );
   }
-  MpiWrapper::barrier( MPI_COMM_GEOSX );
-  string const outputFile = joinPath( outputDirectory, m_filename );
-  HDFFile( outputFile, (m_recordCount == 0), true, MPI_COMM_GEOSX );
 
   DomainPartition & domain = this->getGroupByPath< DomainPartition >( "/Problem/domain" );
   for( auto collectorPath : m_collectorPaths )

--- a/src/coreComponents/fileIO/Outputs/TimeHistoryOutput.cpp
+++ b/src/coreComponents/fileIO/Outputs/TimeHistoryOutput.cpp
@@ -107,19 +107,17 @@ void TimeHistoryOutput::initCollectorParallel( DomainPartition & domain, History
   MpiWrapper::barrier( MPI_COMM_GEOSX );
 }
 
-void TimeHistoryOutput::initializePostSubGroups()
+void TimeHistoryOutput::initializePostInitialConditionsPostSubGroups()
 {
+  // check whether to truncate or append to the file up front so we don't have to bother during later accesses
+  string const outputDirectory = getOutputDirectory();
+  if( MpiWrapper::commRank( MPI_COMM_GEOSX ) == 0 )
   {
-    // check whether to truncate or append to the file up front so we don't have to bother during later accesses
-    string const outputDirectory = getOutputDirectory();
-    if( MpiWrapper::commRank( MPI_COMM_GEOSX ) == 0 )
-    {
-      makeDirsForPath( outputDirectory );
-    }
-    MpiWrapper::barrier( MPI_COMM_GEOSX );
-    string const outputFile = joinPath( outputDirectory, m_filename );
-    HDFFile( outputFile, (m_recordCount == 0), true, MPI_COMM_GEOSX );
+    makeDirsForPath( outputDirectory );
   }
+  MpiWrapper::barrier( MPI_COMM_GEOSX );
+  string const outputFile = joinPath( outputDirectory, m_filename );
+  HDFFile( outputFile, (m_recordCount == 0), true, MPI_COMM_GEOSX );
 
   DomainPartition & domain = this->getGroupByPath< DomainPartition >( "/Problem/domain" );
   for( auto collectorPath : m_collectorPaths )

--- a/src/coreComponents/fileIO/Outputs/TimeHistoryOutput.hpp
+++ b/src/coreComponents/fileIO/Outputs/TimeHistoryOutput.hpp
@@ -57,7 +57,7 @@ public:
    *   file and data spaces/sets and output any set index metatata for the time history.
    * @note There are operations in this function that are collective on the GEOSX comm.
    */
-  virtual void initializePostSubGroups() override;
+  virtual void initializePostInitialConditionsPostSubGroups() override;
 
   /**
    * @brief Writes out a time history file.


### PR DESCRIPTION
This PR is about delaying the initialization of the HistoryOutput. This modification is required for python users (PyGEOSX) who want to be able to update/modify the output filename of HistoryOutput when doing multiple realizations. (ie, Without having to set specific filename in the XML for each simulation and without having to re-initialize all GEOSX).