### PR TITLE
Set an error if non-supported object is requested for Pack.

### DIFF
--- a/src/coreComponents/fileIO/timeHistory/PackCollection.cpp
+++ b/src/coreComponents/fileIO/timeHistory/PackCollection.cpp
@@ -200,6 +200,11 @@ void PackCollection::buildMetaCollectors( )
     {
       coordField = ElementSubRegionBase::viewKeyStruct::elementCenterString();
     }
+    else
+    {
+      GEOSX_ERROR( "Data collection for \"" << m_objectPath << "\" is unimplemented." );
+    }
+
     string metaName( "coordinates" );
     std::unique_ptr< PackCollection > coordCollector = std::make_unique< PackCollection >( metaName, this );
     coordCollector->getWrapper< string >( PackCollection::viewKeysStruct::objectPathString() ).reference() = m_objectPath;


### PR DESCRIPTION
No more segfault.

Resolves #1683 which becomes a feature and no more a bug.
The requirements of the feature need to be discussed.