### PR TITLE
Fix a couple minor issues with XML preprocessor

### DIFF
--- a/examples/advanced_xml_features/included/included_a.xml
+++ b/examples/advanced_xml_features/included/included_a.xml
@@ -6,7 +6,7 @@
     <SinglePhaseFVM
       name="SinglePhaseFlow"
       discretization="singlePhaseTPFA"
-      targetRegions="{ Fracture }">
+      targetRegions="{ Region1 }">
       <LinearSolverParameters
         solverType="gmres"
         krylovTol="1.0e-12"/>

--- a/examples/advanced_xml_features/parameters_example.xml
+++ b/examples/advanced_xml_features/parameters_example.xml
@@ -35,7 +35,7 @@ XML Units:
     <SinglePhaseFVM
       name="SinglePhaseFlow"
       discretization="singlePhaseTPFA"
-      targetRegions="{ Fracture }">
+      targetRegions="{ Region1 }">
       <LinearSolverParameters
         solverType="gmres"
         krylovTol="1.0e-12"/>

--- a/examples/advanced_xml_features/symbolic_math_example.xml
+++ b/examples/advanced_xml_features/symbolic_math_example.xml
@@ -45,7 +45,7 @@ XML Symbolic Math:
     <SinglePhaseFVM
       name="SinglePhaseFlow"
       discretization="singlePhaseTPFA"
-      targetRegions="{ Fracture }">
+      targetRegions="{ Region1 }">
       <LinearSolverParameters
         solverType="gmres"
         krylovTol="1.0e-12"/>
@@ -137,7 +137,7 @@ XML Symbolic Math:
 
     <ConstantPermeability
       name="rockPerm"
-      permeabilityComponents="{ 2*$permeability$, 0.5*$permeability$, 1*$permeability$ }"/>
+      permeabilityComponents="{ `2*$permeability$`, `0.5*$permeability$`, `1*$permeability$` }"/>
   </Constitutive>
 
   <Outputs>

--- a/scripts/setupPythonEnvironment.bash
+++ b/scripts/setupPythonEnvironment.bash
@@ -146,11 +146,21 @@ then
     for p in "${LINK_SCRIPTS[@]}"
     do
         echo "  $p"
+
+        pp=
         if [ -f "$MOD_PATH/$p" ]
         then
-            ln -s $MOD_PATH/$p $BIN_DIR/$p 
+            pp="$MOD_PATH/$p"
         else
+            pp="$(which $p)"
+        fi
+
+        if [ -z "$pp" ]
+        then
             echo "  (could not find where $p is installed)"      
+        else
+            echo "  (found $p as $pp)"
+            ln -s $pp $BIN_DIR/$p 
         fi
     done
 

--- a/src/coreComponents/functions/SymbolicFunction.cpp
+++ b/src/coreComponents/functions/SymbolicFunction.cpp
@@ -59,7 +59,7 @@ class GeosxMathpressoLogger : public mathpresso::OutputLog
 public:
 
   explicit GeosxMathpressoLogger( string name )
-  : m_name( std::move( name ) )
+    : m_name( std::move( name ) )
   {}
 
   virtual ~GeosxMathpressoLogger() override
@@ -78,7 +78,7 @@ public:
                     const char * const message,
                     size_t const GEOSX_UNUSED_PARAM( size ) ) override
   {
-    switch (type)
+    switch( type )
     {
       case kMessageError:
       {

--- a/src/coreComponents/functions/SymbolicFunction.cpp
+++ b/src/coreComponents/functions/SymbolicFunction.cpp
@@ -54,6 +54,57 @@ SymbolicFunction::SymbolicFunction( const string & name,
 SymbolicFunction::~SymbolicFunction()
 {}
 
+class GeosxMathpressoLogger : public mathpresso::OutputLog
+{
+public:
+
+  explicit GeosxMathpressoLogger( string name )
+  : m_name( std::move( name ) )
+  {}
+
+  virtual ~GeosxMathpressoLogger() override
+  {
+    string const s = m_stream.str();
+    if( !s.empty() )
+    {
+      GEOSX_LOG_RANK_0( GEOSX_FMT( "{} '{}': JIT compiler produced the following output:\n{}",
+                                   SymbolicFunction::catalogName(), m_name, s ) );
+    }
+  }
+
+  virtual void log( unsigned int type,
+                    unsigned int line,
+                    unsigned int column,
+                    const char * const message,
+                    size_t const GEOSX_UNUSED_PARAM( size ) ) override
+  {
+    switch (type)
+    {
+      case kMessageError:
+      {
+        m_stream << GEOSX_FMT( "[ERROR]: {} (line {}, column {})\n", message, line, column );
+        break;
+      }
+      case kMessageWarning:
+      {
+        m_stream << GEOSX_FMT( "[WARNING]: {} (line {}, column {})\n", message, line, column );
+        break;
+      }
+      default:
+      {
+        m_stream << GEOSX_FMT( "[OTHER]\n{}", message );
+        break;
+      }
+    }
+  }
+
+private:
+
+  string m_name;
+  std::ostringstream m_stream;
+
+};
+
 void SymbolicFunction::initializeFunction()
 {
   // Register variables
@@ -65,8 +116,12 @@ void SymbolicFunction::initializeFunction()
   // Add built in constants/functions (PI, E, sin, cos, ceil, exp, etc.),
   // compile
   parserContext.addBuiltIns();
-  mathpresso::Error err = parserExpression.compile( parserContext, m_expression.c_str(), mathpresso::kNoOptions );
-  GEOSX_ERROR_IF( err != mathpresso::kErrorOk, "JIT Compiler Error" );
+  mathpresso::Error const err = [&]
+  {
+    GeosxMathpressoLogger outputLog( getName() );
+    return parserExpression.compile( parserContext, m_expression.c_str(), mathpresso::kNoOptions, &outputLog );
+  }();
+  GEOSX_ERROR_IF( err != mathpresso::kErrorOk, "MathPresso JIT Compiler Error" );
 }
 
 REGISTER_CATALOG_ENTRY( FunctionBase, SymbolicFunction, string const &, Group * const )

--- a/src/coreComponents/python/modules/geosx_xml_tools_package/geosx_xml_tools/xml_formatter.py
+++ b/src/coreComponents/python/modules/geosx_xml_tools_package/geosx_xml_tools/xml_formatter.py
@@ -83,7 +83,9 @@ def format_xml_level(output,
 
             # Format attributes
             for ka in akeys:
-                attribute_dict[ka] = format_attribute(attribute_indent, ka, attribute_dict[ka])
+                # Avoid formatting mathpresso expressions
+                if not (node.tag in ["SymbolicFunction", "CompositeFunction"] and ka == "expression"):
+                    attribute_dict[ka] = format_attribute(attribute_indent, ka, attribute_dict[ka])
 
             for ii in range(0, len(akeys)):
                 k = akeys[ii]


### PR DESCRIPTION
This PR fixes a couple corner cases related to my use of the XML preprocessor:
* Avoid formatting symbolic function expressions. Formatter adds spaces after each comma (such as argument separator in built-in binary functions), making the expression unreadable by mathpresso. The other option would have been to forcibly remove spaces once the string is read by GEOSX. I prefer that the string is left unmodified and the user is the one responsible for ensuring the input complies with mathpresso requirements. To aid in debugging problems like this, I've added an error logger for mathpresso JIT.
* Work around an issue when `geosx_xml_tools` is installed in user mode. If a user on a typical linux box uses system python (often located in `/usr/bin`) to build `geosx_xml_tools`, the package installation automatically takes place in `--user` mode, placing installed modules, including scripts, under `~/.local/` (default behavior of `pip` since 20.0). In this case the existing lookup for the scripts doesn't quite work. I've added a fallback lookup via `which`, that manages to find the scripts correctly in this case.

No rebaseline required.