### PR TITLE
Ideas for fixing the unit tests compilation problem

### DIFF
--- a/src/coreComponents/constitutive/unitTests/CMakeLists.txt
+++ b/src/coreComponents/constitutive/unitTests/CMakeLists.txt
@@ -11,7 +11,7 @@ set( gtest_geosx_tests
      testPropertyConversions.cpp
    )
 
-set( dependencyList gtest constitutive )
+set( dependencyList gtest )
 
 if( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )

--- a/src/coreComponents/dataRepository/unitTests/CMakeLists.txt
+++ b/src/coreComponents/dataRepository/unitTests/CMakeLists.txt
@@ -9,7 +9,7 @@ set( dataRepository_tests
      testBufferOps.cpp
    )
 
-set( dependencyList gtest dataRepository )
+set( dependencyList gtest )
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )

--- a/src/coreComponents/finiteElement/unitTests/CMakeLists.txt
+++ b/src/coreComponents/finiteElement/unitTests/CMakeLists.txt
@@ -12,7 +12,7 @@ set(testSources
     testH1_TriangleFace_Lagrange1_Gauss1.cpp
    )
 
-set( dependencyList gtest finiteElement)
+set( dependencyList gtest)
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )

--- a/src/coreComponents/linearAlgebra/unitTests/CMakeLists.txt
+++ b/src/coreComponents/linearAlgebra/unitTests/CMakeLists.txt
@@ -11,7 +11,7 @@ set( parallel_tests
 
 set( nranks 2 )
 
-set( dependencyList gtest linearAlgebra )
+set( dependencyList gtest )
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )

--- a/src/coreComponents/unitTests/constitutiveTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/constitutiveTests/CMakeLists.txt
@@ -28,11 +28,11 @@ set( gtest_pvt_xmls
 
 set( dependencyList gtest )
 
-if ( GEOSX_BUILD_SHARED_LIBS )
-  set (dependencyList ${dependencyList} geosx_core )
-else()
-  set (dependencyList ${dependencyList} ${geosx_core_libs} )
-endif()
+#if ( GEOSX_BUILD_SHARED_LIBS )
+#  set (dependencyList ${dependencyList} geosx_core )
+#else()
+#  set (dependencyList ${dependencyList} ${geosx_core_libs} )
+#endif()
 
 if( ENABLE_PVTPackage )
     list( APPEND gtest_geosx_tests

--- a/src/coreComponents/unitTests/dataRepositoryTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/dataRepositoryTests/CMakeLists.txt
@@ -12,11 +12,11 @@ set( dataRepository_tests
 
 set( dependencyList gtest )
 
-if ( GEOSX_BUILD_SHARED_LIBS )
-  set (dependencyList ${dependencyList} geosx_core )
-else()
-  set (dependencyList ${dependencyList} ${geosx_core_libs} )
-endif()
+#if ( GEOSX_BUILD_SHARED_LIBS )
+#  set (dependencyList ${dependencyList} geosx_core )
+#else()
+#  set (dependencyList ${dependencyList} ${geosx_core_libs} )
+#endif()
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )

--- a/src/coreComponents/unitTests/fieldSpecificationTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/fieldSpecificationTests/CMakeLists.txt
@@ -11,11 +11,11 @@ set( gtest_geosx_tests
 
 set( dependencyList gtest )
 
-if ( GEOSX_BUILD_SHARED_LIBS )
-  set (dependencyList ${dependencyList} geosx_core )
-else()
-  set (dependencyList ${dependencyList} ${geosx_core_libs} )
-endif()
+#if ( GEOSX_BUILD_SHARED_LIBS )
+#  set (dependencyList ${dependencyList} geosx_core )
+#else()
+#  set (dependencyList ${dependencyList} ${geosx_core_libs} )
+#endif()
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )

--- a/src/coreComponents/unitTests/fileIOTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/fileIOTests/CMakeLists.txt
@@ -8,11 +8,11 @@ set(geosx_fileio_tests
 
 set( dependencyList gtest )
 
-if ( GEOSX_BUILD_SHARED_LIBS )
-  set (dependencyList ${dependencyList} geosx_core )
-else()
-  set (dependencyList ${dependencyList} ${geosx_core_libs} )
-endif()
+#if ( GEOSX_BUILD_SHARED_LIBS )
+#  set (dependencyList ${dependencyList} geosx_core )
+#else()
+#  set (dependencyList ${dependencyList} ${geosx_core_libs} )
+#endif()
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )

--- a/src/coreComponents/unitTests/finiteVolumeTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/finiteVolumeTests/CMakeLists.txt
@@ -8,11 +8,11 @@ set( gtest_geosx_tests
 
 set( dependencyList gtest )
 
-if ( GEOSX_BUILD_SHARED_LIBS )
-  set (dependencyList ${dependencyList} geosx_core )
-else()
-  set (dependencyList ${dependencyList} ${geosx_core_libs} )
-endif()
+#if ( GEOSX_BUILD_SHARED_LIBS )
+#  set (dependencyList ${dependencyList} geosx_core )
+#else()
+#  set (dependencyList ${dependencyList} ${geosx_core_libs} )
+#endif()
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )

--- a/src/coreComponents/unitTests/fluidFlowTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/fluidFlowTests/CMakeLists.txt
@@ -10,11 +10,11 @@ set( gtest_geosx_tests
 
 set( dependencyList gtest )
 
-if ( GEOSX_BUILD_SHARED_LIBS )
-  set (dependencyList ${dependencyList} geosx_core )
-else()
-  set (dependencyList ${dependencyList} ${geosx_core_libs} )
-endif()
+#if ( GEOSX_BUILD_SHARED_LIBS )
+#  set (dependencyList ${dependencyList} geosx_core )
+#else()
+#  set (dependencyList ${dependencyList} ${geosx_core_libs} )
+#endif()
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )

--- a/src/coreComponents/unitTests/functionsTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/functionsTests/CMakeLists.txt
@@ -9,11 +9,11 @@ set( gtest_geosx_tests
 
 set( dependencyList gtest )
 
-if ( GEOSX_BUILD_SHARED_LIBS )
-  set (dependencyList ${dependencyList} geosx_core )
-else()
-  set (dependencyList ${dependencyList} ${geosx_core_libs} )
-endif()
+#if ( GEOSX_BUILD_SHARED_LIBS )
+#  set (dependencyList ${dependencyList} geosx_core )
+#else()
+#  set (dependencyList ${dependencyList} ${geosx_core_libs} )
+#endif()
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )

--- a/src/coreComponents/unitTests/linearAlgebraTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/linearAlgebraTests/CMakeLists.txt
@@ -13,11 +13,11 @@ set( nranks 2 )
 #
 set( dependencyList gtest )
 
-if ( GEOSX_BUILD_SHARED_LIBS )
-  set (dependencyList ${dependencyList} geosx_core )
-else()
-  set (dependencyList ${dependencyList} ${geosx_core_libs} )
-endif()
+#if ( GEOSX_BUILD_SHARED_LIBS )
+#  set (dependencyList ${dependencyList} geosx_core )
+#else()
+#  set (dependencyList ${dependencyList} ${geosx_core_libs} )
+#endif()
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )

--- a/src/coreComponents/unitTests/meshTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/meshTests/CMakeLists.txt
@@ -35,11 +35,11 @@ endif()
 
 set( dependencyList gtest )
 
-if( GEOSX_BUILD_SHARED_LIBS )
-  set( dependencyList ${dependencyList} geosx_core )
-else()
-  set( dependencyList ${dependencyList} ${geosx_core_libs} )
-endif()
+#if( GEOSX_BUILD_SHARED_LIBS )
+#  set( dependencyList ${dependencyList} geosx_core )
+#else()
+#  set( dependencyList ${dependencyList} ${geosx_core_libs} )
+#endif()
 
 if( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )

--- a/src/coreComponents/unitTests/virtualElementTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/virtualElementTests/CMakeLists.txt
@@ -8,11 +8,11 @@ set(testSources
 
 set( dependencyList gtest )
 
-if ( GEOSX_BUILD_SHARED_LIBS )
-  set (dependencyList ${dependencyList} geosx_core)
-else()
-  set (dependencyList ${dependencyList} ${geosx_core_libs} )
-endif()
+#if ( GEOSX_BUILD_SHARED_LIBS )
+#  set (dependencyList ${dependencyList} geosx_core)
+#else()
+#  set (dependencyList ${dependencyList} ${geosx_core_libs} )
+#endif()
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )

--- a/src/coreComponents/unitTests/wellsTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/wellsTests/CMakeLists.txt
@@ -9,11 +9,11 @@ set( gtest_geosx_tests
 
 set( dependencyList gtest )
 
-if ( GEOSX_BUILD_SHARED_LIBS )
-  set (dependencyList ${dependencyList} geosx_core )
-else()
-  set (dependencyList ${dependencyList} ${geosx_core_libs} )
-endif()
+#if ( GEOSX_BUILD_SHARED_LIBS )
+#  set (dependencyList ${dependencyList} geosx_core )
+#else()
+#  set (dependencyList ${dependencyList} ${geosx_core_libs} )
+#endif()
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )

--- a/src/coreComponents/unitTests/xmlTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/xmlTests/CMakeLists.txt
@@ -27,11 +27,11 @@ set( multi_files
 #
 set( dependencyList gtest optionparser )
 
-if ( GEOSX_BUILD_SHARED_LIBS )
-  set (dependencyList ${dependencyList} geosx_core)
-else()
-  set (dependencyList ${dependencyList} ${geosx_core_libs} )
-endif()
+#if ( GEOSX_BUILD_SHARED_LIBS )
+#  set (dependencyList ${dependencyList} geosx_core)
+#else()
+#  set (dependencyList ${dependencyList} ${geosx_core_libs} )
+#endif()
 
 if ( ENABLE_CUDA )
   set( dependencyList ${dependencyList} cuda )


### PR DESCRIPTION
Hello @labesse40 and @sframba,

I spent some time digging into the problem arising in our unit tests with clang10 after the merge of the PyGEOSX PR. I really do not know much about compilation and cmake, but I made the following observation: if I uncomment all the dependencies in the `CMakeLists.txt` of the unit tests (this PR), the problem goes away and the unit tests run fine on Quartz (CPU) for both clang10 and gcc8 (to be honest, I cannot explain why).

Of course, the content of this PR is not a fix and these dependencies should be there, so this PR is not meant to be merged. But hopefully this PR can give you ideas about where to look (the CMakeLists of the unit tests?) to fix the problem and what to fix (the way we compile the unit tests). There must be some kind of inconsistency in the way we build the unit tests now. 

No need to do anything on this PR 

Related to https://github.com/GEOSX/GEOSX/issues/1802