### PR TITLE
Correct argument order inconsistency.

### DIFF
--- a/src/coreComponents/mesh/EmbeddedSurfaceSubRegion.cpp
+++ b/src/coreComponents/mesh/EmbeddedSurfaceSubRegion.cpp
@@ -137,14 +137,14 @@ void EmbeddedSurfaceSubRegion::computeConnectivityIndex( localIndex const k,
   m_connectivityIndex[k] = m_elementArea[ k ] / averageDistance;
 }
 
-bool EmbeddedSurfaceSubRegion::addNewEmbeddedSurface ( localIndex const cellIndex,
-                                                       localIndex const subRegionIndex,
-                                                       localIndex const regionIndex,
-                                                       NodeManager const & nodeManager,
-                                                       EmbeddedSurfaceNodeManager & embSurfNodeManager,
-                                                       EdgeManager const & edgeManager,
-                                                       FixedOneToManyRelation const & cellToEdges,
-                                                       BoundedPlane const * fracture )
+bool EmbeddedSurfaceSubRegion::addNewEmbeddedSurface( localIndex const cellIndex,
+                                                      localIndex const regionIndex,
+                                                      localIndex const subRegionIndex,
+                                                      NodeManager const & nodeManager,
+                                                      EmbeddedSurfaceNodeManager & embSurfNodeManager,
+                                                      EdgeManager const & edgeManager,
+                                                      FixedOneToManyRelation const & cellToEdges,
+                                                      BoundedPlane const * fracture )
 {
   /* The goal is to add an embeddedSurfaceElem if it is contained within the BoundedPlane
    *

--- a/src/coreComponents/physicsSolvers/surfaceGeneration/EmbeddedSurfaceGenerator.cpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/EmbeddedSurfaceGenerator.cpp
@@ -175,8 +175,8 @@ void EmbeddedSurfaceGenerator::initializePostSubGroups()
           if( isPositive * isNegative == 1 )
           {
             bool added = embeddedSurfaceSubRegion.addNewEmbeddedSurface( cellIndex,
-                                                                         esr,
                                                                          er,
+                                                                         esr,
                                                                          nodeManager,
                                                                          embSurfNodeManager,
                                                                          edgeManager,


### PR DESCRIPTION
The parameters order of `EmbeddedSurfaceSubRegion::addNewEmbeddedSurface` was not consistent between header and definition. Quite dangerous!

I've left the header unchanged but changed the definition (and the calls) such that regions come before sub-regions.