### PR TITLE
Cleaned up isPointInsidePolyhedron

### DIFF
--- a/src/coreComponents/mesh/WellElementSubRegion.cpp
+++ b/src/coreComponents/mesh/WellElementSubRegion.cpp
@@ -115,35 +115,6 @@ void collectLocalAndBoundaryNodes( InternalWellGenerator const & wellGeometry,
 }
 
 /**
- * @brief Check if "location" is contained in reservoir element
- * @param[in] referencePosition the coordinates of the nodes
- * @param[in] elemsToFaces the map from element to faces
- * @param[in] facesToNodes the map from face to nodes
- * @param[in] elemCenter the coordinates of the element center
- * @param[in] location the target coordinates
- * @return true if "location" is contained in the reservoir element, false otherwise
- */
-bool isPointInsideElement( arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const referencePosition,
-                           arraySlice1d< localIndex const > const elemsToFaces,
-                           ArrayOfArraysView< localIndex const > const facesToNodes,
-                           real64 const (&elemCenter)[3],
-                           real64 const (&location)[3] )
-{
-  bool isInsideElement = false;
-
-  // if the point is in the element, save the indices and stop the search
-  if( computationalGeometry::isPointInsidePolyhedron( referencePosition,
-                                                      elemsToFaces,
-                                                      facesToNodes,
-                                                      elemCenter,
-                                                      location ))
-  {
-    isInsideElement = true;
-  }
-  return isInsideElement;
-}
-
-/**
  * @brief Collect the nodes of reservoir element ei
  * @param[in] subRegion the subRegion of reservoir element ei
  * @param[in] ei the index of the reservoir element
@@ -241,11 +212,11 @@ bool visitNeighborElements( MeshLevel const & mesh,
 
         // perform the test to see if the point is in this reservoir element
         // if the point is in the resevoir element, save the indices and stop the search
-        if( isPointInsideElement( referencePosition,
-                                  elemsToFaces[eiLocal],
-                                  facesToNodes,
-                                  elemCenter,
-                                  location ) )
+        if( computationalGeometry::isPointInsidePolyhedron( referencePosition,
+                                                            elemsToFaces[eiLocal],
+                                                            facesToNodes,
+                                                            elemCenter,
+                                                            location ) )
         {
           erMatched  = er;
           esrMatched = esr;

--- a/src/coreComponents/mesh/utilities/ComputationalGeometry.hpp
+++ b/src/coreComponents/mesh/utilities/ComputationalGeometry.hpp
@@ -345,48 +345,6 @@ int sign( T const val )
   return (T( 0 ) < val) - (val < T( 0 ));
 }
 
-/**
- * @brief Check if a point is inside a convex polyhedron (3D polygon)
- * @tparam POINT_TYPE type of @p point
- * @param[in] nodeCoordinates a global array of nodal coordinates
- * @param[in] faceNodeIndices ordered lists of node indices for each face of the polyhedron
- * @param[in] point coordinates of the query point
- * @param[in] areaTolerance same as in centroid_3DPolygon
- * @return whether the point is inside
- *
- * @note Face nodes must all be ordered the same way (i.e. CW or CCW),
- * resulting in all face normals pointing either outside or inside the polyhendron
- *
- * @note For faces with n>3 nodes that are non-planar, average normal is used
- */
-template< typename POINT_TYPE >
-GEOSX_HOST_DEVICE
-bool isPointInsidePolyhedron( arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const & nodeCoordinates,
-                              arrayView1d< arrayView1d< localIndex const > const > const & faceNodeIndices,
-                              POINT_TYPE const & point,
-                              real64 const areaTolerance = 0.0 )
-{
-  localIndex const numFaces = faceNodeIndices.size( 0 );
-  R1Tensor faceCenter, faceNormal;
-  int prevSign = 0;
-
-  for( localIndex kf = 0; kf < numFaces; ++kf )
-  {
-    centroid_3DPolygon( faceNodeIndices[kf], nodeCoordinates, faceCenter, faceNormal, areaTolerance );
-
-    LvArray::tensorOps::subtract< 3 >( faceCenter, point );
-    int const s = sign( LvArray::tensorOps::AiBi< 3 >( faceNormal, faceCenter ) );
-
-    // all dot products should be non-negative (for outward normals) or non-positive (for inward normals)
-    if( prevSign * s < 0 )
-    {
-      return false;
-    }
-    prevSign = s;
-  }
-
-  return true;
-}
 
 /**
  * @brief Check if a point is inside a convex polyhedron (3D polygon)


### PR DESCRIPTION
This PR cleans up the computational geometry functions in charge of locating a point inside an element (called `isPointInsidePolyhedron`). Before this PR, we had two versions of the function, but only one working robustly for prisms and pyramids. 

This PR removes entirely the not-robust version and makes the necessary changes to use the robust version in the code that matches a well perforation with a reservoir element. 

No need for a rebaseline