### PR TITLE
Fix performance regression of mesh map generation

### DIFF
--- a/src/coreComponents/codingUtilities/Utilities.hpp
+++ b/src/coreComponents/codingUtilities/Utilities.hpp
@@ -119,6 +119,69 @@ T_VALUE softMapLookup( mapBase< T_KEY, T_VALUE, SORTED > const & theMap,
 }
 
 /**
+ * @brief Call a user function on sub-ranges of repeating values.
+ * @tparam ITER type of range iterator
+ * @tparam FUNC type of user function
+ * @tparam COMP type of comparison function
+ * @param first iterator to start of the input range
+ * @param last iterator past the end of the input range
+ * @param func the function to call, must be callable with a pair of iterators
+ *
+ * User function will be called once per consecutive group of equal values, as defined
+ * by @p comp, with a pair of iterators to the beginning and past the end of each group.
+ * For example, given an input [1,1,2,2,2,3,3,1], @p func will be called with iterators
+ * to sub-ranges [1,1], [2,2,2], [3,3], [1].
+ *
+ * @note @p comp is an equality comparison, not a less-than type predicate used in sorting.
+ *       For a range sorted with some predicate P, one can use comp(x,y) = !(P(x,y) || P(y,x)),
+ *       but in most cases default value (std::equal_to<>) should be fine.
+ */
+template< typename ITER, typename FUNC, typename COMP = std::equal_to<> >
+void forEqualRanges( ITER first, ITER const last, FUNC && func, COMP && comp = {} )
+{
+  using R = typename std::iterator_traits< ITER >::reference;
+  while( first != last )
+  {
+    R curr = *first;
+    auto const pred = [&]( R v ) { return comp( curr, v ); };
+    ITER const next = std::find_if_not( std::next( first ), last, pred );
+    func( first, next );
+    first = next;
+  }
+}
+
+/**
+ * @brief Execute a user function on unique values in a range.
+ * @tparam ITER type of range iterator
+ * @tparam FUNC type of user function
+ * @tparam COMP type of comparison function
+ * @param first iterator to start of the range
+ * @param last iterator past the end of the range
+ * @param func the function to call, must be callable with value and size (as int)
+ *
+ * User function will be called once per consecutive group of equal values, as defined
+ * by @p comp, with a reference to one of the values from each group and the group size.
+ * If the range is (partially) ordered w.r.t. to a predicate compatible with @p comp,
+ * the function will be called once per unique value in the entire range.
+ * For example, given an input [a,a,b,b,b,c,c,a], @p func will be called with
+ * (a,2), (b,3), (c,2), (a,1), where a,b,c will be references to one of the
+ * corresponding elements in the input (which one exactly is unspecified).
+ *
+ * @note @p comp is an equality comparison, not a less-than type predicate used in sorting.
+ *       For a range sorted with some predicate P, one can use comp(x,y) = !(P(x,y) || P(y,x)),
+ *       but in most cases default value (std::equal_to<>) should be fine.
+ */
+template< typename ITER, typename FUNC, typename COMP = std::equal_to<> >
+void forUniqueValues( ITER first, ITER const last, FUNC && func, COMP && comp = {} )
+{
+  auto const f = [&func]( ITER r_first, ITER r_last )
+  {
+    func( *r_first, std::distance( r_first, r_last ) );
+  };
+  forEqualRanges( first, last, f, std::forward< COMP >( comp ) );
+}
+
+/**
  * @brief Perform lookup in a map of options and throw a user-friendly exception if not found.
  * @tparam KEY map key type
  * @tparam VAL map value type

--- a/src/coreComponents/constitutive/fluid/PVTDriver.hpp
+++ b/src/coreComponents/constitutive/fluid/PVTDriver.hpp
@@ -64,7 +64,7 @@ public:
    * @param table Table with input/output time history
    */
   template< typename FLUID_TYPE >
-  void runTest( FLUID_TYPE & fluid, arrayView2d< real64 > & table );
+  void runTest( FLUID_TYPE & fluid, arrayView2d< real64 > const & table );
 
   /**
    * @brief Ouput table to file for easy plotting

--- a/src/coreComponents/constitutive/solid/TriaxialDriver.cpp
+++ b/src/coreComponents/constitutive/solid/TriaxialDriver.cpp
@@ -157,9 +157,10 @@ void TriaxialDriver::postProcessInput()
 
 
 template< typename SOLID_TYPE >
-void TriaxialDriver::runStrainControlTest( SOLID_TYPE & solid, arrayView2d< real64 > & table )
+void TriaxialDriver::runStrainControlTest( SOLID_TYPE & solid, arrayView2d< real64 > const & table )
 {
   typename SOLID_TYPE::KernelWrapper updates = solid.createKernelUpdates();
+  localIndex const numSteps = m_numSteps;
 
   forAll< parallelDevicePolicy<> >( 1, [=]  GEOSX_HOST_DEVICE ( integer const ei )
   {
@@ -167,7 +168,7 @@ void TriaxialDriver::runStrainControlTest( SOLID_TYPE & solid, arrayView2d< real
     real64 strainIncrement[6] = {};
     real64 stiffness[6][6] = {{}};
 
-    for( integer n=1; n<=m_numSteps; ++n )
+    for( integer n = 1; n <= numSteps; ++n )
     {
       strainIncrement[0] = table( n, EPS0 )-table( n-1, EPS0 );
       strainIncrement[1] = table( n, EPS1 )-table( n-1, EPS1 );
@@ -187,9 +188,13 @@ void TriaxialDriver::runStrainControlTest( SOLID_TYPE & solid, arrayView2d< real
 
 
 template< typename SOLID_TYPE >
-void TriaxialDriver::runMixedControlTest( SOLID_TYPE & solid, arrayView2d< real64 > & table )
+void TriaxialDriver::runMixedControlTest( SOLID_TYPE & solid, arrayView2d< real64 > const & table )
 {
   typename SOLID_TYPE::KernelWrapper updates = solid.createKernelUpdates();
+  integer const numSteps = m_numSteps;
+  integer const maxIter = m_maxIter;
+  integer const maxCuts = m_maxCuts;
+  real64 const newtonTol = m_newtonTol;
 
   forAll< parallelDevicePolicy<> >( 1, [=]  GEOSX_HOST_DEVICE ( integer const ei )
   {
@@ -199,13 +204,13 @@ void TriaxialDriver::runMixedControlTest( SOLID_TYPE & solid, arrayView2d< real6
     real64 stiffness[6][6] = {{}};
 
     real64 scale = 0;
-    for( integer n=1; n<=m_numSteps; ++n )
+    for( integer n = 1; n <= numSteps; ++n )
     {
       scale += fabs( table( n, SIG0 )) + fabs( table( n, SIG1 )) + fabs( table( n, SIG2 ));
     }
-    scale = 3*m_numSteps / scale;
+    scale = 3 * numSteps / scale;
 
-    for( integer n=1; n<=m_numSteps; ++n )
+    for( integer n=1; n<=numSteps; ++n )
     {
       strainIncrement[0] = table( n, EPS0 )-table( n-1, EPS0 );
       strainIncrement[1] = 0;
@@ -215,7 +220,7 @@ void TriaxialDriver::runMixedControlTest( SOLID_TYPE & solid, arrayView2d< real6
       integer k = 0;
       integer cuts = 0;
 
-      for(; k<m_maxIter; ++k )
+      for(; k < maxIter; ++k )
       {
         updates.smallStrainUpdate( ei, 0, strainIncrement, stress, stiffness );
 
@@ -226,11 +231,11 @@ void TriaxialDriver::runMixedControlTest( SOLID_TYPE & solid, arrayView2d< real6
           normZero = norm;
         }
 
-        if( norm < m_newtonTol ) // success
+        if( norm < newtonTol ) // success
         {
           break;
         }
-        else if( k > 0 && norm > normZero && cuts < m_maxCuts ) // backtrack by half delta
+        else if( k > 0 && norm > normZero && cuts < maxCuts ) // backtrack by half delta
         {
           cuts++;
           deltaStrainIncrement *= 0.5;
@@ -254,7 +259,7 @@ void TriaxialDriver::runMixedControlTest( SOLID_TYPE & solid, arrayView2d< real6
       table( n, ITER ) = k;
       table( n, NORM ) = norm;
 
-      if( norm > m_newtonTol )
+      if( norm > newtonTol )
       {
         break;
       }
@@ -264,9 +269,13 @@ void TriaxialDriver::runMixedControlTest( SOLID_TYPE & solid, arrayView2d< real6
 
 
 template< typename SOLID_TYPE >
-void TriaxialDriver::runStressControlTest( SOLID_TYPE & solid, arrayView2d< real64 > & table )
+void TriaxialDriver::runStressControlTest( SOLID_TYPE & solid, arrayView2d< real64 > const & table )
 {
   typename SOLID_TYPE::KernelWrapper updates = solid.createKernelUpdates();
+  integer const numSteps = m_numSteps;
+  integer const maxIter = m_maxIter;
+  integer const maxCuts = m_maxCuts;
+  real64 const newtonTol = m_newtonTol;
 
   forAll< parallelDevicePolicy<> >( 1, [=]  GEOSX_HOST_DEVICE ( integer const ei )
   {
@@ -279,13 +288,13 @@ void TriaxialDriver::runStressControlTest( SOLID_TYPE & solid, arrayView2d< real
     real64 jacobian[2][2] = {{}};
 
     real64 scale = 0;
-    for( integer n=1; n<=m_numSteps; ++n )
+    for( integer n = 1; n <= numSteps; ++n )
     {
       scale += fabs( table( n, SIG0 )) + fabs( table( n, SIG1 )) + fabs( table( n, SIG2 ));
     }
-    scale = 3*m_numSteps / scale;
+    scale = 3 * numSteps / scale;
 
-    for( integer n=1; n<=m_numSteps; ++n )
+    for( integer n = 1; n <= numSteps; ++n )
     {
       //   std::cout<<"time step="<<n<<std::endl;
       strainIncrement[0] = 0;
@@ -296,7 +305,7 @@ void TriaxialDriver::runStressControlTest( SOLID_TYPE & solid, arrayView2d< real
       integer k = 0;
       integer cuts = 0;
 
-      for(; k<m_maxIter; ++k )
+      for(; k < maxIter; ++k )
       {
         updates.smallStrainUpdate( ei, 0, strainIncrement, stress, stiffness );
 
@@ -312,11 +321,11 @@ void TriaxialDriver::runStressControlTest( SOLID_TYPE & solid, arrayView2d< real
           normZero = norm;
         }
 
-        if( norm < m_newtonTol ) // success
+        if( norm < newtonTol ) // success
         {
           break;
         }
-        else if( k > 0 && norm > normZero && cuts < m_maxCuts ) // backtrack by half delta
+        else if( k > 0 && norm > normZero && cuts < maxCuts ) // backtrack by half delta
         {
           cuts++;
           deltaStrainIncrement[0] *= 0.5;
@@ -354,7 +363,7 @@ void TriaxialDriver::runStressControlTest( SOLID_TYPE & solid, arrayView2d< real
       table( n, ITER ) = k;
       table( n, NORM ) = norm;
 
-      if( norm > m_newtonTol )
+      if( norm > newtonTol )
       {
         break;
       }

--- a/src/coreComponents/constitutive/solid/TriaxialDriver.hpp
+++ b/src/coreComponents/constitutive/solid/TriaxialDriver.hpp
@@ -64,7 +64,7 @@ public:
    * @param table Table with stress / strain time history
    */
   template< typename SOLID_TYPE >
-  void runStrainControlTest( SOLID_TYPE & solid, arrayView2d< real64 > & table );
+  void runStrainControlTest( SOLID_TYPE & solid, arrayView2d< real64 > const & table );
 
   /**
    * @brief Run a stress-controlled test using loading protocol in table
@@ -72,7 +72,7 @@ public:
    * @param table Table with stress / strain time history
    */
   template< typename SOLID_TYPE >
-  void runStressControlTest( SOLID_TYPE & solid, arrayView2d< real64 > & table );
+  void runStressControlTest( SOLID_TYPE & solid, arrayView2d< real64 > const & table );
 
   /**
    * @brief Run a mixed stress/strain-controlled test using loading protocol in table
@@ -80,7 +80,7 @@ public:
    * @param table Table with stress / strain time history
    */
   template< typename SOLID_TYPE >
-  void runMixedControlTest( SOLID_TYPE & solid, arrayView2d< real64 > & table );
+  void runMixedControlTest( SOLID_TYPE & solid, arrayView2d< real64 > const & table );
 
   /**
    * @brief Validate results by checking residual and removing erroneous data
@@ -114,7 +114,7 @@ private:
     constexpr static char const * baselineString() { return "baseline"; }
   };
 
-  integer m_numSteps;              ///< Number of load steps
+  integer m_numSteps;          ///< Number of load steps
   string m_solidMaterialName;  ///< Material identifier
   string m_mode;               ///< Test mode: strainControl, stressControl, mixedControl
   string m_axialFunctionName;  ///< Time-dependent function controlling axial stress or strain (depends on test mode)

--- a/src/coreComponents/dataRepository/BufferOps_inline.hpp
+++ b/src/coreComponents/dataRepository/BufferOps_inline.hpp
@@ -406,7 +406,7 @@ localIndex Unpack( buffer_unit_type const * & buffer,
 {
   ArrayOfArrays< T > varAsArray;
   localIndex sizeOfUnpackedChars = Unpack( buffer, varAsArray );
-  var.assimilate( std::move( varAsArray ), LvArray::sortedArrayManipulation::SORTED_UNIQUE );
+  var.template assimilate< parallelHostPolicy >( std::move( varAsArray ), LvArray::sortedArrayManipulation::SORTED_UNIQUE );
   return sizeOfUnpackedChars;
 }
 

--- a/src/coreComponents/mainInterface/ProblemManager.cpp
+++ b/src/coreComponents/mainInterface/ProblemManager.cpp
@@ -576,9 +576,9 @@ void ProblemManager::generateMesh()
 
       elemManager.generateMesh( cellBlockManager );
 
-      nodeManager.setGeometricalRelations( cellBlockManager );
+      nodeManager.setGeometricalRelations( cellBlockManager, elemManager );
       edgeManager.setGeometricalRelations( cellBlockManager );
-      faceManager.setGeometricalRelations( cellBlockManager, nodeManager );
+      faceManager.setGeometricalRelations( cellBlockManager, elemManager, nodeManager );
 
       nodeManager.constructGlobalToLocalMap( cellBlockManager );
 
@@ -594,9 +594,6 @@ void ProblemManager::generateMesh()
       nodeManager.setupRelatedObjectsInRelations( edgeManager, faceManager, elemManager );
       edgeManager.setupRelatedObjectsInRelations( nodeManager, faceManager );
       faceManager.setupRelatedObjectsInRelations( nodeManager, edgeManager, elemManager );
-
-      nodeManager.buildRegionMaps( elemManager );
-      faceManager.buildRegionMaps( elemManager );
 
       // Node and edge managers rely on the boundary information provided by the face manager.
       // This is why `faceManager.setDomainBoundaryObjects` is called first.

--- a/src/coreComponents/mesh/CellElementRegion.hpp
+++ b/src/coreComponents/mesh/CellElementRegion.hpp
@@ -66,14 +66,14 @@ public:
    * @brief The key name for the FaceElementRegion in the object catalog.
    * @return A string containing the key name.
    */
-  static const string catalogName()
+  static string catalogName()
   { return "CellElementRegion"; }
 
   /**
    * @copydoc catalogName()
    */
-  virtual const string getCatalogName() const override final
-  { return CellElementRegion::catalogName(); }
+  virtual string getCatalogName() const override final
+  { return catalogName(); }
 
   ///@}
 

--- a/src/coreComponents/mesh/CellElementSubRegion.cpp
+++ b/src/coreComponents/mesh/CellElementSubRegion.cpp
@@ -271,11 +271,11 @@ void CellElementSubRegion::fixUpDownMaps( bool const clearIfUnmapped )
                                     clearIfUnmapped );
 }
 
-void CellElementSubRegion::getFaceNodes( localIndex const elementIndex,
-                                         localIndex const localFaceIndex,
-                                         array1d< localIndex > & nodeIndices ) const
+localIndex CellElementSubRegion::getFaceNodes( localIndex const elementIndex,
+                                               localIndex const localFaceIndex,
+                                               Span< localIndex > const nodeIndices ) const
 {
-  geosx::getFaceNodes( m_elementType, elementIndex, localFaceIndex, m_toNodesRelation, nodeIndices );
+  return geosx::getFaceNodes( m_elementType, elementIndex, localFaceIndex, m_toNodesRelation, nodeIndices );
 }
 
 void CellElementSubRegion::
@@ -325,7 +325,9 @@ void CellElementSubRegion::
 void CellElementSubRegion::calculateElementGeometricQuantities( NodeManager const & nodeManager,
                                                                 FaceManager const & GEOSX_UNUSED_PARAM( faceManager ) )
 {
-  arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const & X = nodeManager.referencePosition();
+  GEOSX_MARK_FUNCTION;
+
+  arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const X = nodeManager.referencePosition();
 
   forAll< parallelHostPolicy >( this->size(), [=] ( localIndex const k )
   {

--- a/src/coreComponents/mesh/CellElementSubRegion.hpp
+++ b/src/coreComponents/mesh/CellElementSubRegion.hpp
@@ -50,14 +50,14 @@ public:
    * @brief Const getter for the catalog name.
    * @return the name of this type in the catalog
    */
-  static const string catalogName()
+  static string catalogName()
   { return "CellElementSubRegion"; }
 
   /**
    * @copydoc catalogName()
    */
-  virtual const string getCatalogName() const override final
-  { return CellElementSubRegion::catalogName(); }
+  virtual string getCatalogName() const override final
+  { return catalogName(); }
 
   /**
    * @name Constructor / Destructor
@@ -202,12 +202,13 @@ public:
    * @brief Get the local indices of the nodes in a face of the element.
    * @param[in] elementIndex The local index of the target element.
    * @param[in] localFaceIndex The local index of the target face in the element (this will be [0, numFacesInElement[)
-   * @param[out] nodeIndices A reference to the array of node indices of the face. Gets resized at the proper size.
+   * @param[out] nodeIndices Memory to which node indices for the face will be written, must have sufficient size.
+   * @return tne number of values written into @p nodeIndices
    * @deprecated This method will be removed soon.
    */
-  void getFaceNodes( localIndex const elementIndex,
-                     localIndex const localFaceIndex,
-                     array1d< localIndex > & nodeIndices ) const;
+  localIndex getFaceNodes( localIndex const elementIndex,
+                           localIndex const localFaceIndex,
+                           Span< localIndex > const nodeIndices ) const;
 
   /**
    * @brief Get the element-to-node map.
@@ -261,7 +262,7 @@ public:
    * @param[in] a the index of the face in the element
    * @return a const reference to the local index of the face
    */
-  localIndex const & faceList( localIndex k, localIndex a ) const { return m_toFacesRelation( k, a ); }
+  localIndex faceList( localIndex k, localIndex a ) const { return m_toFacesRelation( k, a ); }
 
   /**
    * @brief @return The array of shape function derivatives.

--- a/src/coreComponents/mesh/EdgeManager.hpp
+++ b/src/coreComponents/mesh/EdgeManager.hpp
@@ -56,7 +56,7 @@ public:
   /**
    * @return the string representing the edge manager name in the catalog
    */
-  static const string catalogName()
+  static string catalogName()
   { return "EdgeManager"; }
 
 
@@ -64,8 +64,8 @@ public:
    * @brief Getter used to access the edge manager catalog name.
    * @return the edge manager catalog name
    */
-  virtual const string getCatalogName() const override
-  { return EdgeManager::catalogName(); }
+  virtual string getCatalogName() const override
+  { return catalogName(); }
 
   ///@}
 
@@ -75,7 +75,7 @@ public:
    *
    * @note Value forwarding is due to refactoring.
    */
-  static localIndex faceMapExtraSpacePerEdge()
+  static constexpr localIndex faceMapOverallocation()
   { return CellBlockManagerABC::faceMapExtraSpacePerEdge(); }
 
   /**
@@ -91,11 +91,6 @@ public:
   EdgeManager( string const & name,
                Group * const parent );
 
-  /**
-   * @brief default destructor
-   */
-  ~EdgeManager() override;
-
   ///@}
 
   /**
@@ -108,9 +103,9 @@ public:
 
   /**
    * @brief Set the node of the domain boundary object.
-   * @param[in] faceManager The reference of the face manager.
+   * @param[in] faceIndex The reference of the face manager.
    */
-  void setDomainBoundaryObjects( FaceManager const & faceManager );
+  void setDomainBoundaryObjects( FaceManager const & faceIndex );
 
   /**
    * @brief Set external edges.
@@ -217,34 +212,12 @@ public:
                          ArrayOfArraysView< localIndex const > const & facesToEdges );
 
   /**
-   * @brief Build the mapping edge-to-nodes relation from the mapping global to local nodes.
-   * @param[in] indices array of index of the global to local nodes
-   * @param[in] nodeGlobalToLocal map of the global to local nodes
-   * @param[in] faceGlobalToLocal GEOX UNUSED PARAMETER
+   * @brief Check if edge \p edgeIndex contains node \p nodeIndex
+   * @param[in] edgeIndex local index of the edge
+   * @param[in] nodeIndex local index of the node
+   * @return boolean : true if the node \p nodeIndex is part of the edge \p edgeIndex; false otherwise
    */
-  void connectivityFromGlobalToLocal( const SortedArray< localIndex > & indices,
-                                      const map< globalIndex, localIndex > & nodeGlobalToLocal,
-                                      const map< globalIndex, localIndex > & faceGlobalToLocal );
-
-  /**
-   * @brief Split an edge (separate its two extremity nodes)
-   * @param[in] indexToSplit Index of the edge to split
-   * @param[in] parentNodeIndex index of the parent node
-   * @param[in] childNodeIndex index of the child node
-   * @param[in] nodesToEdges array of nodes-to-edges list
-   */
-  void splitEdge( const localIndex indexToSplit,
-                  const localIndex parentNodeIndex,
-                  const localIndex childNodeIndex[2],
-                  array1d< SortedArray< localIndex > > & nodesToEdges );
-
-  /**
-   * @brief Check if edge \p edgeID contains node \p nodeID
-   * @param[in] edgeID local index of the edge
-   * @param[in] nodeID local index of the node
-   * @return boolean : true if the node \p nodeID is part of the edge \p edgeID; false otherwise
-   */
-  bool hasNode( const localIndex edgeID, const localIndex nodeID ) const;
+  bool hasNode( const localIndex edgeIndex, const localIndex nodeIndex ) const;
 
   /**
    * @brief Calculate the center of an edge given its index.
@@ -302,15 +275,6 @@ public:
   viewKeys;
 
   ///}@
-
-  /**
-   * @brief Return the  maximum number of edges per node.
-   * @return Maximum allowable number of edges connected to one node (hardcoded for now)
-   *
-   * @note Value forwarding is due to refactoring.
-   */
-  static constexpr int maxEdgesPerNode()
-  { return CellBlockManagerABC::maxEdgesPerNode(); }
 
   /**
    * @name Getters for stored value.

--- a/src/coreComponents/mesh/ElementRegionManager.hpp
+++ b/src/coreComponents/mesh/ElementRegionManager.hpp
@@ -105,15 +105,15 @@ public:
    * @brief The function is to return the name of the ElementRegionManager in the object catalog
    * @return string that contains the catalog name used to register/lookup this class in  the object catalog
    */
-  static const string catalogName()
+  static string catalogName()
   { return "ZoneManager"; }
 
   /**
    * @brief Virtual access to catalogName()
    * @return string that contains the catalog name used to register/lookup this class in the object catalog
    */
-  virtual const string getCatalogName() const override final
-  { return ElementRegionManager::catalogName(); }
+  virtual string getCatalogName() const override final
+  { return catalogName(); }
 
   /**
    * @brief Constructor.
@@ -263,6 +263,14 @@ public:
   {
     return this->getRegions().size();
   }
+
+  /**
+   * @brief Produce a map from cell block indices to element region and subregion indices
+   * @param cellBlockManager the CellBlocKManager
+   * @return a (numBlock x 2) array with each row corresponding to a cell block and containing
+   *         region (first entry) and subregion (second entry) indices, or -1 if block was not used.
+   */
+  array2d< localIndex > getCellBlockToSubRegionMap( CellBlockManagerABC const & cellBlockManager ) const;
 
   /**
    * @brief This function is used to launch kernel function over all the element regions with region type =

--- a/src/coreComponents/mesh/EmbeddedSurfaceNodeManager.cpp
+++ b/src/coreComponents/mesh/EmbeddedSurfaceNodeManager.cpp
@@ -17,14 +17,14 @@
  */
 
 #include "EmbeddedSurfaceNodeManager.hpp"
-#include "FaceManager.hpp"
-#include "EdgeManager.hpp"
-#include "ToElementRelation.hpp"
-#include "BufferOps.hpp"
-#include "mesh/ExtrinsicMeshData.hpp"
+
 #include "common/TimingMacros.hpp"
 #include "common/MpiWrapper.hpp"
-#include "ElementRegionManager.hpp"
+#include "mesh/BufferOps.hpp"
+#include "mesh/EdgeManager.hpp"
+#include "mesh/ElementRegionManager.hpp"
+#include "mesh/ToElementRelation.hpp"
+#include "mesh/utilities/MeshMapUtilities.hpp"
 
 namespace geosx
 {
@@ -50,16 +50,12 @@ EmbeddedSurfaceNodeManager::EmbeddedSurfaceNodeManager( string const & name,
 }
 
 
-EmbeddedSurfaceNodeManager::~EmbeddedSurfaceNodeManager()
-{}
-
-
 void EmbeddedSurfaceNodeManager::resize( localIndex const newSize )
 {
-  m_toEdgesRelation.resize( newSize, 2 * getEdgeMapOverallocation() );
-  m_toElements.m_toElementRegion.resize( newSize, 2 * getElemMapOverAllocation() );
-  m_toElements.m_toElementSubRegion.resize( newSize, 2 * getElemMapOverAllocation() );
-  m_toElements.m_toElementIndex.resize( newSize, 2 * getElemMapOverAllocation() );
+  m_toEdgesRelation.resize( newSize, 2 * edgeMapOverallocation() );
+  m_toElements.m_toElementRegion.resize( newSize, 2 * elemMapOverallocation() );
+  m_toElements.m_toElementSubRegion.resize( newSize, 2 * elemMapOverallocation() );
+  m_toElements.m_toElementIndex.resize( newSize, 2 * elemMapOverallocation() );
   ObjectManagerBase::resize( newSize );
 }
 
@@ -69,46 +65,14 @@ void EmbeddedSurfaceNodeManager::setEdgeMaps( EdgeManager const & embSurfEdgeMan
   GEOSX_MARK_FUNCTION;
 
   arrayView2d< localIndex const > const edgeToNodeMap = embSurfEdgeManager.nodeList();
-  localIndex const numEdges = edgeToNodeMap.size( 0 );
-  localIndex const numNodes = size();
 
-  ArrayOfArrays< localIndex > toEdgesTemp( numNodes, EdgeManager::maxEdgesPerNode() );
-  RAJA::ReduceSum< parallelHostReduce, localIndex > totalNodeEdges = 0;
+  ArrayOfArrays< localIndex > nodeToEdges =
+    meshMapUtilities::transposeIndexMap< parallelHostPolicy >( edgeToNodeMap,
+                                                               size(),
+                                                               edgeMapOverallocation() );
 
-  forAll< parallelHostPolicy >( numEdges, [&]( localIndex const edgeID )
-  {
-    toEdgesTemp.emplaceBackAtomic< parallelHostAtomic >( edgeToNodeMap( edgeID, 0 ), edgeID );
-    toEdgesTemp.emplaceBackAtomic< parallelHostAtomic >( edgeToNodeMap( edgeID, 1 ), edgeID );
-    totalNodeEdges += 2;
-  } );
-
-  // Resize the node to edge map.
-  m_toEdgesRelation.resize( 0 );
-
-  // Reserve space for the number of current nodes plus some extra.
-  double const overAllocationFactor = 0.3;
-  localIndex const entriesToReserve = ( 1 + overAllocationFactor ) * numNodes;
-  m_toEdgesRelation.reserve( entriesToReserve );
-
-  // Reserve space for the total number of face nodes + extra space for existing faces + even more space for new faces.
-  localIndex const valuesToReserve = totalNodeEdges.get() + numNodes * getEdgeMapOverallocation() * ( 1 + 2 * overAllocationFactor );
-  m_toEdgesRelation.reserveValues( valuesToReserve );
-
-  // Append the individual sets.
-  for( localIndex nodeID = 0; nodeID < numNodes; ++nodeID )
-  {
-    m_toEdgesRelation.appendSet( toEdgesTemp.sizeOfArray( nodeID ) + getEdgeMapOverallocation() );
-  }
-
-  ArrayOfSetsView< localIndex > const & toEdgesView = m_toEdgesRelation.toView();
-  forAll< parallelHostPolicy >( numNodes, [&]( localIndex const nodeID )
-  {
-    localIndex * const edges = toEdgesTemp[ nodeID ];
-    localIndex const numNodeEdges = toEdgesTemp.sizeOfArray( nodeID );
-    localIndex const numUniqueEdges = LvArray::sortedArrayManipulation::makeSortedUnique( edges, edges + numNodeEdges );
-    toEdgesView.insertIntoSet( nodeID, edges, edges + numUniqueEdges );
-  } );
-
+  m_toEdgesRelation.assimilate< parallelHostPolicy >( std::move( nodeToEdges ),
+                                                      LvArray::sortedArrayManipulation::UNSORTED_NO_DUPLICATES );
   m_toEdgesRelation.setRelatedObject( embSurfEdgeManager );
 }
 
@@ -156,21 +120,21 @@ void EmbeddedSurfaceNodeManager::setElementMaps( ElementRegionManager const & el
   toElementList.reserve( entriesToReserve );
 
   // Reserve space for the total number of face nodes + extra space for existing faces + even more space for new faces.
-  localIndex const valuesToReserve = totalNodeElems.get() + numNodes * getElemMapOverAllocation() * ( 1 + 2 * overAllocationFactor );
+  localIndex const valuesToReserve = totalNodeElems.get() + numNodes * elemMapOverallocation() * ( 1 + 2 * overAllocationFactor );
   toElementRegionList.reserveValues( valuesToReserve );
   toElementSubRegionList.reserveValues( valuesToReserve );
   toElementList.reserveValues( valuesToReserve );
 
   // Append an array for each node with capacity to hold the appropriate number of elements plus some wiggle room.
-  for( localIndex nodeID = 0; nodeID < numNodes; ++nodeID )
+  for( localIndex nodeIndex = 0; nodeIndex < numNodes; ++nodeIndex )
   {
     toElementRegionList.appendArray( 0 );
     toElementSubRegionList.appendArray( 0 );
     toElementList.appendArray( 0 );
 
-    toElementRegionList.setCapacityOfArray( nodeID, elemsPerNode[ nodeID ] + getElemMapOverAllocation() );
-    toElementSubRegionList.setCapacityOfArray( nodeID, elemsPerNode[ nodeID ] + getElemMapOverAllocation() );
-    toElementList.setCapacityOfArray( nodeID, elemsPerNode[ nodeID ] + getElemMapOverAllocation() );
+    toElementRegionList.setCapacityOfArray( nodeIndex, elemsPerNode[ nodeIndex ] + elemMapOverallocation() );
+    toElementSubRegionList.setCapacityOfArray( nodeIndex, elemsPerNode[ nodeIndex ] + elemMapOverallocation() );
+    toElementList.setCapacityOfArray( nodeIndex, elemsPerNode[ nodeIndex ] + elemMapOverallocation() );
   }
 
   // Populate the element maps.

--- a/src/coreComponents/mesh/EmbeddedSurfaceNodeManager.hpp
+++ b/src/coreComponents/mesh/EmbeddedSurfaceNodeManager.hpp
@@ -53,14 +53,14 @@ public:
    *
    * @note Value forwarding is due to refactoring.
    */
-  inline localIndex getEdgeMapOverallocation()
-  { return CellBlockManagerABC::getEdgeMapOverallocation(); }
+  static constexpr localIndex edgeMapOverallocation()
+  { return CellBlockManagerABC::edgeMapExtraSpacePerNode(); }
 
   /**
    * @brief return default size of the value array in the node-to-element mapping
    * @return default size of value array in the node-to-element mapping
    */
-  inline localIndex getElemMapOverAllocation()
+  static constexpr localIndex elemMapOverallocation()
   { return 8; }
 
 
@@ -76,36 +76,6 @@ public:
    */
   EmbeddedSurfaceNodeManager( string const & name,
                               dataRepository::Group * const parent );
-
-  /**
-   * @brief The default EmbeddedSurfaceNodeManager destructor.
-   */
-  ~EmbeddedSurfaceNodeManager() override;
-
-  /// @cond DO_NOT_DOCUMENT
-  /**
-   * @brief deleted constructor
-   */
-  EmbeddedSurfaceNodeManager() = delete;
-
-  /**
-   * @brief deleted copy constructor
-   */
-  EmbeddedSurfaceNodeManager( EmbeddedSurfaceNodeManager const & init ) = delete;
-
-  /**
-   * @brief Default move constructor.
-   */
-  EmbeddedSurfaceNodeManager( EmbeddedSurfaceNodeManager && ) = delete;
-
-  /**
-   * @brief deleted assignement operator
-   */
-  EmbeddedSurfaceNodeManager & operator=( EmbeddedSurfaceNodeManager const & ) = delete;
-
-
-  EmbeddedSurfaceNodeManager & operator=( EmbeddedSurfaceNodeManager && ) = delete;
-  /// @endcond
 
   ///@}
 
@@ -132,8 +102,8 @@ public:
    * @brief Provide a virtual access to catalogName().
    * @return string that contains the EmbeddedSurfaceNodeManager catalog name
    */
-  const string getCatalogName() const override final
-  { return EmbeddedSurfaceNodeManager::catalogName(); }
+  string getCatalogName() const override final
+  { return catalogName(); }
 
   ///@}
 

--- a/src/coreComponents/mesh/EmbeddedSurfaceSubRegion.hpp
+++ b/src/coreComponents/mesh/EmbeddedSurfaceSubRegion.hpp
@@ -79,16 +79,16 @@ public:
    * @brief Get catalog name.
    * @return the catalog name
    */
-  static const string catalogName()
+  static string catalogName()
   { return "EmbeddedSurfaceSubRegion"; }
 
   /**
    * @brief Get catalog name.
    * @return the catalog name
    */
-  virtual const string getCatalogName() const override
+  virtual string getCatalogName() const override
   {
-    return EmbeddedSurfaceSubRegion::catalogName();
+    return catalogName();
   }
 
   ///@}

--- a/src/coreComponents/mesh/FaceElementSubRegion.hpp
+++ b/src/coreComponents/mesh/FaceElementSubRegion.hpp
@@ -48,16 +48,16 @@ public:
    * @brief Get catalog name.
    * @return the catalog name
    */
-  static const string catalogName()
+  static string catalogName()
   { return "FaceElementSubRegion"; }
 
   /**
    * @brief Get catalog name.
    * @return the catalog name
    */
-  virtual const string getCatalogName() const override
+  virtual string getCatalogName() const override
   {
-    return FaceElementSubRegion::catalogName();
+    return catalogName();
   }
 
   ///@}

--- a/src/coreComponents/mesh/FaceManager.cpp
+++ b/src/coreComponents/mesh/FaceManager.cpp
@@ -16,16 +16,18 @@
  * @file FaceManager.cpp
  */
 
-#include "mesh/ExtrinsicMeshData.hpp"
 #include "FaceManager.hpp"
-#include "NodeManager.hpp"
-#include "BufferOps.hpp"
-#include "common/TimingMacros.hpp"
-#include "ElementRegionManager.hpp"
-#include "utilities/ComputationalGeometry.hpp"
+
 #include "common/GEOS_RAJA_Interface.hpp"
 #include "common/Logger.hpp"
+#include "common/TimingMacros.hpp"
 #include "LvArray/src/tensorOps.hpp"
+#include "mesh/BufferOps.hpp"
+#include "mesh/ElementRegionManager.hpp"
+#include "mesh/ExtrinsicMeshData.hpp"
+#include "mesh/NodeManager.hpp"
+#include "mesh/utilities/MeshMapUtilities.hpp"
+#include "utilities/ComputationalGeometry.hpp"
 
 namespace geosx
 {
@@ -34,8 +36,8 @@ using namespace dataRepository;
 FaceManager::FaceManager( string const &, Group * const parent ):
   ObjectManagerBase( "FaceManager", parent )
 {
-  this->registerWrapper( viewKeyStruct::nodeListString(), &m_nodeList );
-  this->registerWrapper( viewKeyStruct::edgeListString(), &m_edgeList );
+  this->registerWrapper( viewKeyStruct::nodeListString(), &m_toNodesRelation );
+  this->registerWrapper( viewKeyStruct::edgeListString(), &m_toEdgesRelation );
 
   this->registerWrapper( viewKeyStruct::elementRegionListString(), &m_toElements.m_toElementRegion ).
     setApplyDefaultValue( -1 );
@@ -65,114 +67,22 @@ FaceManager::FaceManager( string const &, Group * const parent ):
 
 }
 
-FaceManager::~FaceManager()
-{}
-
 void FaceManager::resize( localIndex const newSize )
 {
-  m_nodeList.resize( newSize, 2 * nodeMapExtraSpacePerFace() );
-  m_edgeList.resize( newSize, 2 * edgeMapExtraSpacePerFace() );
+  m_toNodesRelation.resize( newSize, 2 * nodeMapOverallocation() );
+  m_toEdgesRelation.resize( newSize, 2 * edgeMapOverallocation() );
   ObjectManagerBase::resize( newSize );
-}
-
-/**
- * @brief Populates the face to element region and face to element subregion mappings.
- * @param [in] elementRegionManager The ElementRegionManager associated with this mesh level. Regions and subregions come from it.
- * @param [in] f2e The face to element maps (on face may belong to up to 2 elements).
- * @param [in,out] f2er The face to element region map (on face may belong to up to 2 regions).
- * @param [in,out] f2esr The face to element subregion map (on face may belong to up to 2 sub-regions).
- *
- * @warning @p f2er and @p f2esr need to have the correct dimensions (numFaces, 2). Values are all overwritten.
- * @note When a face only points to single one region/sub-region, the second element will equal -1.
- */
-void populateRegions( ElementRegionManager const & elementRegionManager,
-                      arrayView2d< localIndex const > const & f2e,
-                      arrayView2d< localIndex > const & f2er,
-                      arrayView2d< localIndex > const & f2esr )
-{
-  GEOSX_ERROR_IF_NE( f2e.size( 0 ), f2er.size( 0 ) );
-  GEOSX_ERROR_IF_NE( f2e.size( 0 ), f2esr.size( 0 ) );
-  GEOSX_ERROR_IF_NE( 2, f2er.size( 1 ) );
-  GEOSX_ERROR_IF_NE( 2, f2esr.size( 1 ) );
-
-  // -1 is a dummy value meaning there is no region or sub-region associated.
-  // It is possible that a face belongs to one unique region and sub-region.
-  // But the array has length 2 so in that case we put 0.
-  f2er.setValues< serialPolicy >( -1 );
-  f2esr.setValues< serialPolicy >( -1 );
-
-  // The algorithm is equivalent to the algorithm described
-  // in the `populateRegions` in the `NodeManager.cpp` file.
-  // Instead of faces, we'll have nodes.
-  // Please refer to this implementation for thorough explanations.
-  //
-  // Since the algorithm is quite short, and because of slight variations
-  // (e.g. the different allocation between faces and nodes implementation),
-  // I considered acceptable to duplicate it a bit.
-  // This is surely disputable
-
-  // This function `f` will be applied on every sub-region.
-  auto f = [&f2e, &f2er, &f2esr]( localIndex er,
-                                  localIndex esr,
-                                  ElementRegionBase const &,
-                                  CellElementSubRegion const & subRegion ) -> void
-  {
-    for( localIndex iElement = 0; iElement < subRegion.size(); ++iElement )
-    {
-      for( localIndex iFaceLoc = 0; iFaceLoc < subRegion.numFacesPerElement(); ++iFaceLoc )
-      {
-        // iFaceLoc is the node index in the referential of each cell (0 to 5 for a cube, e.g.).
-        // While iFace is the global index of the node.
-        localIndex const & iFace = subRegion.faceList( iElement, iFaceLoc );
-
-        // In standard meshes, a face always belongs to 2 elements.
-        localIndex const numElementsLoc = f2e[iFace].size();
-        for( localIndex iElementLoc = 0; iElementLoc < numElementsLoc; ++iElementLoc )
-        {
-          // We only consider the elements that match the mapping.
-          if( f2e( iFace, iElementLoc ) != iElement )
-          {
-            continue;
-          }
-
-          // Here we fill the mapping iff it has not already been inserted.
-          if( f2er( iFace, iElementLoc ) < 0 or f2esr( iFace, iElementLoc ) < 0 )
-          {
-            f2er( iFace, iElementLoc ) = er;
-            f2esr( iFace, iElementLoc ) = esr;
-
-            // We only want to insert one unique index that has not been inserted,
-            // so we quit the loop on indices here.
-            break;
-          }
-        }
-      }
-    }
-  };
-
-  elementRegionManager.forElementSubRegionsComplete< CellElementSubRegion >( f );
-}
-
-void FaceManager::buildRegionMaps( ElementRegionManager const & elementRegionManager )
-{
-  GEOSX_MARK_FUNCTION;
-
-  // Delegating to a free function.
-  populateRegions( elementRegionManager,
-                   m_toElements.m_toElementIndex.toViewConst(),
-                   m_toElements.m_toElementRegion,
-                   m_toElements.m_toElementSubRegion );
 }
 
 void FaceManager::buildSets( NodeManager const & nodeManager )
 {
+  GEOSX_MARK_FUNCTION;
+
   // First create the sets
   auto const & nodeSets = nodeManager.sets().wrappers();
-  for( localIndex i = 0; i < nodeSets.size(); ++i )
+  for( auto const & setWrapper : nodeSets )
   {
-    auto const & setWrapper = nodeSets[i];
-    string const & setName = setWrapper->getName();
-    createSet( setName );
+    createSet( setWrapper.second->getName() );
   }
 
   // Then loop over them in parallel and fill them in.
@@ -180,19 +90,22 @@ void FaceManager::buildSets( NodeManager const & nodeManager )
   {
     auto const & setWrapper = nodeSets[i];
     string const & setName = setWrapper->getName();
-    SortedArrayView< localIndex const > const & targetSet = nodeManager.sets().getReference< SortedArray< localIndex > >( setName ).toViewConst();
-    constructSetFromSetAndMap( targetSet, m_nodeList.toViewConst(), setName );
+    SortedArrayView< localIndex const > const targetSet =
+      nodeManager.sets().getReference< SortedArray< localIndex > >( setName ).toViewConst();
+    constructSetFromSetAndMap( targetSet, m_toNodesRelation.toViewConst(), setName );
   } );
 }
 
 void FaceManager::setDomainBoundaryObjects()
 {
-  arrayView1d< integer > const & isFaceOnDomainBoundary = getDomainBoundaryIndicator();
+  arrayView1d< integer > const isFaceOnDomainBoundary = getDomainBoundaryIndicator();
   isFaceOnDomainBoundary.zero();
 
-  forAll< parallelHostPolicy >( size(), [&]( localIndex const kf )
+  arrayView2d< localIndex const > const toElementRegion = m_toElements.m_toElementRegion.toViewConst();
+
+  forAll< parallelHostPolicy >( size(), [=]( localIndex const kf )
   {
-    if( m_toElements.m_toElementRegion[kf][1] == -1 )
+    if( toElementRegion( kf, 1 ) == -1 )
     {
       isFaceOnDomainBoundary( kf ) = 1;
     }
@@ -200,14 +113,21 @@ void FaceManager::setDomainBoundaryObjects()
 }
 
 void FaceManager::setGeometricalRelations( CellBlockManagerABC const & cellBlockManager,
+                                           ElementRegionManager const & elemRegionManager,
                                            NodeManager const & nodeManager )
 {
+  GEOSX_MARK_FUNCTION;
+
   resize( cellBlockManager.numFaces() );
 
-  m_nodeList.base() = cellBlockManager.getFaceToNodes();
-  m_edgeList.base() = cellBlockManager.getFaceToEdges();
+  m_toNodesRelation.base() = cellBlockManager.getFaceToNodes();
+  m_toEdgesRelation.base() = cellBlockManager.getFaceToEdges();
 
-  m_toElements.m_toElementIndex = cellBlockManager.getFaceToElements();
+  ToCellRelation< array2d< localIndex > > const toCellBlock = cellBlockManager.getFaceToElements();
+  array2d< localIndex > const blockToSubRegion = elemRegionManager.getCellBlockToSubRegionMap( cellBlockManager );
+  meshMapUtilities::transformCellBlockToRegionMap< parallelHostPolicy >( blockToSubRegion.toViewConst(),
+                                                                         toCellBlock,
+                                                                         m_toElements );
 
   computeGeometry( nodeManager );
 }
@@ -216,8 +136,8 @@ void FaceManager::setupRelatedObjectsInRelations( NodeManager const & nodeManage
                                                   EdgeManager const & edgeManager,
                                                   ElementRegionManager const & elementRegionManager )
 {
-  m_nodeList.setRelatedObject( nodeManager );
-  m_edgeList.setRelatedObject( edgeManager );
+  m_toNodesRelation.setRelatedObject( nodeManager );
+  m_toEdgesRelation.setRelatedObject( edgeManager );
 
   m_toElements.setElementRegionManager( elementRegionManager );
 }
@@ -227,12 +147,12 @@ void FaceManager::computeGeometry( NodeManager const & nodeManager )
   arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const & X = nodeManager.referencePosition();
 
   // loop over faces and calculate faceArea, faceNormal and faceCenter
-  forAll< parallelHostPolicy >( this->size(), [&]( localIndex const faceID )
+  forAll< parallelHostPolicy >( this->size(), [&]( localIndex const faceIndex )
   {
-    m_faceArea[ faceID ] = computationalGeometry::centroid_3DPolygon( m_nodeList[ faceID ],
-                                                                      X,
-                                                                      m_faceCenter[ faceID ],
-                                                                      m_faceNormal[ faceID ] );
+    m_faceArea[ faceIndex ] = computationalGeometry::centroid_3DPolygon( m_toNodesRelation[ faceIndex ],
+                                                                         X,
+                                                                         m_faceCenter[ faceIndex ],
+                                                                         m_faceNormal[ faceIndex ] );
 
   } );
 }
@@ -251,18 +171,6 @@ void FaceManager::setIsExternal()
   }
 }
 
-localIndex FaceManager::getMaxFaceNodes() const
-{
-  localIndex maxSize = 0;
-  ArrayOfArraysView< localIndex const > const & faceToNodeMap = nodeList().toViewConst();
-  for( localIndex kf =0; kf < size(); ++kf )
-  {
-    maxSize = std::max( maxSize, faceToNodeMap.sizeOfArray( kf ) );
-  }
-
-  return maxSize;
-}
-
 void FaceManager::sortAllFaceNodes( NodeManager const & nodeManager,
                                     ElementRegionManager const & elemManager )
 {
@@ -271,53 +179,54 @@ void FaceManager::sortAllFaceNodes( NodeManager const & nodeManager,
   arrayView2d< localIndex const > const facesToElementRegions = elementRegionList();
   arrayView2d< localIndex const > const facesToElementSubRegions = elementSubRegionList();
   arrayView2d< localIndex const > const facesToElements = elementList();
-  arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const & X = nodeManager.referencePosition();
+  arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const X = nodeManager.referencePosition();
 
-  ArrayOfArraysView< localIndex > const & facesToNodes = nodeList().toView();
-
-  GEOSX_ERROR_IF( getMaxFaceNodes() >= MAX_FACE_NODES, "More nodes on a face than expected!" );
+  ArrayOfArraysView< localIndex > const facesToNodes = nodeList().toView();
 
   elemManager.forElementSubRegions< CellElementSubRegion >( [&] ( CellElementSubRegion const & subRegion )
-  { subRegion.calculateElementCenters( X ); } );
+  {
+    subRegion.calculateElementCenters( X );
+  } );
 
-  forAll< parallelHostPolicy >( size(), [&]( localIndex const iFace ) -> void
+  ElementRegionManager::ElementViewAccessor< arrayView2d< real64 const > > elemCenter =
+    elemManager.constructArrayViewAccessor< real64, 2 >( ElementSubRegionBase::viewKeyStruct::elementCenterString() );
+
+  forAll< parallelHostPolicy >( size(), [=, elemCenter = elemCenter.toNestedViewConst()]( localIndex const faceIndex )
   {
     // The face should be connected to at least one element.
-    if( facesToElements( iFace, 0 ) != -1 or facesToElements( iFace, 1 ) != -1 )
+    if( facesToElements( faceIndex, 0 ) < 0 && facesToElements( faceIndex, 1 ) < 0 )
     {
-      // Take the first defined face-to-(elt/region/sub region) to sorting direction.
-      localIndex const iElemLoc = facesToElements( iFace, 0 ) > -1 ? 0 : 1;
+      GEOSX_ERROR( "Face " << faceIndex << " is not connected to an element." );
+    }
 
-      localIndex const er = facesToElementRegions[iFace][iElemLoc], esr = facesToElementSubRegions[iFace][iElemLoc], ei = facesToElements( iFace, iElemLoc );
-      if( er != -1 and esr != -1 and ei != -1 )
-      {
-        CellElementSubRegion const & subRegion = elemManager.getRegion( er ).getSubRegion< CellElementSubRegion >( esr );
-        arrayView2d< real64 const > const elemCenter = subRegion.getElementCenter();
-        localIndex const numFaceNodes = facesToNodes.sizeOfArray( iFace );
-        sortFaceNodes( X, elemCenter[ei], facesToNodes[iFace], numFaceNodes );
-      }
-      else
-      {
-        GEOSX_ERROR( "Face " << iFace << " is connected to at least one invalid region (" << er << "), sub-region (" << esr << ") or element (" << ei << ")." );
-      }
-    }
-    else
+    // Take the first defined face-to-(elt/region/sub region) to sorting direction.
+    localIndex const iElemLoc = facesToElements( faceIndex, 0 ) >= 0 ? 0 : 1;
+
+    localIndex const er = facesToElementRegions( faceIndex, iElemLoc );
+    localIndex const esr = facesToElementSubRegions( faceIndex, iElemLoc );
+    localIndex const ei = facesToElements( faceIndex, iElemLoc );
+
+    if( er < 0 || esr < 0 || ei < 0 )
     {
-      GEOSX_ERROR( "Face " << iFace << " does not seem connected to any element." );
+      GEOSX_ERROR( GEOSX_FMT( "Face {} is connected to an invalid element ({}/{}/{}).", faceIndex, er, esr, ei ) );
     }
+
+    sortFaceNodes( X, elemCenter[er][esr][ei], facesToNodes[faceIndex] );
   } );
 }
 
 void FaceManager::sortFaceNodes( arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const & X,
                                  arraySlice1d< real64 const > const elementCenter,
-                                 localIndex * const faceNodes,
-                                 localIndex const numFaceNodes )
+                                 Span< localIndex > const faceNodes )
 {
+  localIndex const numFaceNodes = LvArray::integerConversion< localIndex >( faceNodes.size() );
+  GEOSX_ERROR_IF_GT_MSG( numFaceNodes, MAX_FACE_NODES, "Node per face limit exceeded" );
+
   localIndex const firstNodeIndex = faceNodes[0];
 
   // get face center (average vertex location)
   real64 fc[3] = { 0 };
-  for( localIndex n =0; n < numFaceNodes; ++n )
+  for( localIndex n = 0; n < numFaceNodes; ++n )
   {
     LvArray::tensorOps::add< 3 >( fc, X[faceNodes[n]] );
   }
@@ -362,7 +271,7 @@ void FaceManager::sortFaceNodes( arrayView2d< real64 const, nodes::REFERENCE_POS
     std::pair< real64, localIndex > thetaOrder[MAX_FACE_NODES];
 
     // Sort nodes counterclockwise around face center
-    for( localIndex n =0; n < numFaceNodes; ++n )
+    for( localIndex n = 0; n < numFaceNodes; ++n )
     {
       real64 v[3] = LVARRAY_TENSOROPS_INIT_LOCAL_3( X[faceNodes[n]] );
       LvArray::tensorOps::subtract< 3 >( v, fc );
@@ -372,7 +281,7 @@ void FaceManager::sortFaceNodes( arrayView2d< real64 const, nodes::REFERENCE_POS
     std::sort( thetaOrder, thetaOrder + numFaceNodes );
 
     // Reorder nodes on face
-    for( localIndex n =0; n < numFaceNodes; ++n )
+    for( localIndex n = 0; n < numFaceNodes; ++n )
     {
       faceNodes[n] = thetaOrder[n].second;
     }
@@ -380,7 +289,7 @@ void FaceManager::sortFaceNodes( arrayView2d< real64 const, nodes::REFERENCE_POS
     localIndex tempFaceNodes[MAX_FACE_NODES];
 
     localIndex firstIndexIndex = 0;
-    for( localIndex n =0; n < numFaceNodes; ++n )
+    for( localIndex n = 0; n < numFaceNodes; ++n )
     {
       tempFaceNodes[n] = thetaOrder[n].second;
       if( tempFaceNodes[n] == firstNodeIndex )
@@ -389,9 +298,9 @@ void FaceManager::sortFaceNodes( arrayView2d< real64 const, nodes::REFERENCE_POS
       }
     }
 
-    for( localIndex n=0; n < numFaceNodes; ++n )
+    for( localIndex n = 0; n < numFaceNodes; ++n )
     {
-      const localIndex index = (firstIndexIndex + n) % numFaceNodes;
+      localIndex const index = (firstIndexIndex + n) % numFaceNodes;
       faceNodes[n] = tempFaceNodes[index];
     }
   }
@@ -409,18 +318,18 @@ void FaceManager::extractMapFromObjectForAssignGlobalIndexNumbers( NodeManager c
 
   globalFaceNodes.resize( numFaces );
 
-  forAll< parallelHostPolicy >( numFaces, [&]( localIndex const & faceID )
+  forAll< parallelHostPolicy >( numFaces, [&]( localIndex const & faceIndex )
   {
-    std::vector< globalIndex > & curFaceGlobalNodes = globalFaceNodes[ faceID ];
+    std::vector< globalIndex > & curFaceGlobalNodes = globalFaceNodes[ faceIndex ];
 
-    if( isDomainBoundary( faceID ) )
+    if( isDomainBoundary( faceIndex ) )
     {
-      localIndex const numNodes = faceToNodeMap.sizeOfArray( faceID );
+      localIndex const numNodes = faceToNodeMap.sizeOfArray( faceIndex );
       curFaceGlobalNodes.resize( numNodes );
 
       for( localIndex a = 0; a < numNodes; ++a )
       {
-        curFaceGlobalNodes[ a ]= nodeManager.localToGlobalMap()( faceToNodeMap( faceID, a ) );
+        curFaceGlobalNodes[ a ]= nodeManager.localToGlobalMap()( faceToNodeMap( faceIndex, a ) );
       }
 
       std::sort( curFaceGlobalNodes.begin(), curFaceGlobalNodes.end() );
@@ -454,19 +363,19 @@ localIndex FaceManager::packUpDownMapsImpl( buffer_unit_type * & buffer,
   packedSize += bufferOps::Pack< DO_PACKING >( buffer, string( viewKeyStruct::nodeListString() ) );
 
   packedSize += bufferOps::Pack< DO_PACKING >( buffer,
-                                               m_nodeList.base().toViewConst(),
+                                               m_toNodesRelation.base().toViewConst(),
                                                m_unmappedGlobalIndicesInToNodes,
                                                packList,
                                                this->localToGlobalMap(),
-                                               m_nodeList.relatedObjectLocalToGlobal() );
+                                               m_toNodesRelation.relatedObjectLocalToGlobal() );
 
   packedSize += bufferOps::Pack< DO_PACKING >( buffer, string( viewKeyStruct::edgeListString() ) );
   packedSize += bufferOps::Pack< DO_PACKING >( buffer,
-                                               m_edgeList.base().toViewConst(),
+                                               m_toEdgesRelation.base().toViewConst(),
                                                m_unmappedGlobalIndicesInToEdges,
                                                packList,
                                                this->localToGlobalMap(),
-                                               m_edgeList.relatedObjectLocalToGlobal() );
+                                               m_toEdgesRelation.relatedObjectLocalToGlobal() );
 
   packedSize += bufferOps::Pack< DO_PACKING >( buffer, string( viewKeyStruct::elementListString() ) );
   packedSize += bufferOps::Pack< DO_PACKING >( buffer,
@@ -491,22 +400,22 @@ localIndex FaceManager::unpackUpDownMaps( buffer_unit_type const * & buffer,
   GEOSX_ERROR_IF_NE( nodeListString, viewKeyStruct::nodeListString() );
 
   unPackedSize += bufferOps::Unpack( buffer,
-                                     m_nodeList,
+                                     m_toNodesRelation,
                                      packList,
                                      m_unmappedGlobalIndicesInToNodes,
                                      this->globalToLocalMap(),
-                                     m_nodeList.relatedObjectGlobalToLocal() );
+                                     m_toNodesRelation.relatedObjectGlobalToLocal() );
 
   string edgeListString;
   unPackedSize += bufferOps::Unpack( buffer, edgeListString );
   GEOSX_ERROR_IF_NE( edgeListString, viewKeyStruct::edgeListString() );
 
   unPackedSize += bufferOps::Unpack( buffer,
-                                     m_edgeList,
+                                     m_toEdgesRelation,
                                      packList,
                                      m_unmappedGlobalIndicesInToEdges,
                                      this->globalToLocalMap(),
-                                     m_edgeList.relatedObjectGlobalToLocal() );
+                                     m_toEdgesRelation.relatedObjectGlobalToLocal() );
 
   string elementListString;
   unPackedSize += bufferOps::Unpack( buffer, elementListString );
@@ -523,19 +432,19 @@ localIndex FaceManager::unpackUpDownMaps( buffer_unit_type const * & buffer,
 
 void FaceManager::fixUpDownMaps( bool const clearIfUnmapped )
 {
-  ObjectManagerBase::fixUpDownMaps( m_nodeList,
+  ObjectManagerBase::fixUpDownMaps( m_toNodesRelation,
                                     m_unmappedGlobalIndicesInToNodes,
                                     clearIfUnmapped );
 
-  ObjectManagerBase::fixUpDownMaps( m_edgeList,
+  ObjectManagerBase::fixUpDownMaps( m_toEdgesRelation,
                                     m_unmappedGlobalIndicesInToEdges,
                                     clearIfUnmapped );
 }
 
 void FaceManager::compressRelationMaps()
 {
-  m_nodeList.compress();
-  m_edgeList.compress();
+  m_toNodesRelation.compress();
+  m_toEdgesRelation.compress();
 }
 
 void FaceManager::enforceStateFieldConsistencyPostTopologyChange( std::set< localIndex > const & targetIndices )

--- a/src/coreComponents/mesh/FaceManager.hpp
+++ b/src/coreComponents/mesh/FaceManager.hpp
@@ -61,15 +61,15 @@ public:
    * @brief Return the name of the FaceManager in the object catalog.
    * @return string that contains the catalog name of the FaceManager
    */
-  static const string catalogName()
+  static string catalogName()
   { return "FaceManager"; }
 
   /**
    * @brief Provide a virtual access to catalogName().
    * @return string that contains the catalog name of the FaceManager
    */
-  virtual const string getCatalogName() const override
-  { return FaceManager::catalogName(); }
+  virtual string getCatalogName() const override
+  { return catalogName(); }
   ///@}
 
   /**
@@ -78,7 +78,7 @@ public:
    *
    * @note Value forwarding is due to refactoring.
    */
-  static constexpr localIndex nodeMapExtraSpacePerFace()
+  static constexpr localIndex nodeMapOverallocation()
   { return CellBlockManagerABC::nodeMapExtraSpacePerFace(); }
 
   /**
@@ -87,7 +87,7 @@ public:
    *
    * @note Value forwarding is due to refactoring.
    */
-  static constexpr localIndex edgeMapExtraSpacePerFace()
+  static constexpr localIndex edgeMapOverallocation()
   { return CellBlockManagerABC::edgeMapExtraSpacePerFace(); }
 
   /**
@@ -102,52 +102,24 @@ public:
    */
   FaceManager( string const & name, Group * const parent );
 
-  /**
-   * @brief Destructor override from ObjectManager
-   */
-  virtual ~FaceManager() override;
-
-  /**
-   * @brief Deleted default constructor
-   */
-  FaceManager() = delete;
-
-  /**
-   * @brief Deleted copy constructor
-   */
-  FaceManager( FaceManager const & ) = delete;
-
-
-  /**
-   * @brief Deleted move constructor
-   */
-  FaceManager( FaceManager && ) = delete;
-
   ///@}
 
   /**
-   * @brief Extend base class resize method resizing  m_nodeList, m_edgeList member containers.
+   * @brief Extend base class resize method resizing  m_toNodesRelation, m_toEdgesRelation member containers.
    * @details the \p newSize of this FaceManager is the number of faces it will contain
    * @param[in] newsize new size the FaceManager.
    */
   virtual void resize( localIndex const newsize ) override;
 
   /**
-   * @brief Builds the faces to regions and faces to sub-regions mappings.
-   * @param [in] elementRegionManager the ElementRegionManager.
-   *
-   * @note Requires the sub-regions of the @p elementRegionManager to be fully defined.
-   * As well as the faces to elements mappings of the @p FaceManager.
-   */
-  void buildRegionMaps( ElementRegionManager const & elementRegionManager );
-
-  /**
    * @brief Copies the nodes positions and the faces to (nodes|edges|elements) mappings from @p cellBlockManager.
    * Computes the faces center, area and normal too.
    * @param[in] cellBlockManager Provides the mappings.
+   * @param[in] elemRegionManager element region manager, needed to map blocks to subregion
    * @param[in] nodeManager Provides the nodes positions.
    */
   void setGeometricalRelations( CellBlockManagerABC const & cellBlockManager,
+                                ElementRegionManager const & elemRegionManager,
                                 NodeManager const & nodeManager );
 
   /**
@@ -180,13 +152,7 @@ public:
   void buildSets( NodeManager const & nodeManager );
 
   /**
-   * @brief Return the number of nodes of the faces with the greatest number of nodes.
-   * @return the maximum number of nodes a face have
-   */
-  localIndex getMaxFaceNodes() const;
-
-  /**
-   * @brief Sort all faces nodes counterclockwisely in m_nodeList.
+   * @brief Sort all faces nodes counterclockwisely in m_toNodesRelation.
    * @param[in] nodeManager node manager allowing access to face nodes coordinates
    * @param[in] elemManager element manager allowing access to the cell elements
    */
@@ -198,12 +164,10 @@ public:
    * @param[in] X array view of mesh nodes coordinates
    * @param[in] elementCenter coordinate of the element center
    * @param[in,out] faceNodes reordered local label list of nodes
-   * @param[in] numFaceNodes number of nodes for the face
    */
-  void sortFaceNodes( arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const & X,
-                      arraySlice1d< real64 const > const elementCenter,
-                      localIndex * const faceNodes,
-                      localIndex const numFaceNodes );
+  static void sortFaceNodes( arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const & X,
+                             arraySlice1d< real64 const > const elementCenter,
+                             Span< localIndex > const faceNodes );
 
   /**
    * @brief Flag faces on boundary or external to the DomainPartition.
@@ -367,25 +331,25 @@ public:
    * @brief Get a mutable accessor to a map containing the list of each nodes for each faces.
    * @return non-const reference to a map containing the list of each nodes for each faces
    */
-  NodeMapType & nodeList()                    { return m_nodeList; }
+  NodeMapType & nodeList()                    { return m_toNodesRelation; }
 
   /**
    * @brief Get an immutable accessor to a map containing the list of each nodes for each faces
    * @return const reference to a map containing the list of each nodes for each faces
    */
-  NodeMapType const & nodeList() const { return m_nodeList; }
+  NodeMapType const & nodeList() const { return m_toNodesRelation; }
 
   /**
    * @brief Get a mutable accessor to a map containing the list of each edges for each faces
    * @return non-const reference to a map containing the list of each edges for each faces
    */
-  EdgeMapType & edgeList()       { return m_edgeList; }
+  EdgeMapType & edgeList()       { return m_toEdgesRelation; }
 
   /**
    * @brief Get an immutable accessor to a map containing the list of each edges for each faces.
    * @return const reference to a map containing the list of each edges for each faces
    */
-  EdgeMapType const & edgeList() const { return m_edgeList; }
+  EdgeMapType const & edgeList() const { return m_toEdgesRelation; }
 
   /**
    * @brief Get a mutable accessor to the faces-to-ElementRegion relation.
@@ -474,10 +438,10 @@ private:
                                  arrayView1d< localIndex const > const & packList ) const;
 
   /// face keyed map containing face-to-node relation
-  NodeMapType m_nodeList;
+  NodeMapType m_toNodesRelation;
 
   /// face keyed map containing face-to-edge relation
-  EdgeMapType m_edgeList;
+  EdgeMapType m_toEdgesRelation;
 
   /// face keyed map containing face-to-element relation
   ElemMapType m_toElements;

--- a/src/coreComponents/mesh/MeshLevel.cpp
+++ b/src/coreComponents/mesh/MeshLevel.cpp
@@ -129,11 +129,11 @@ void MeshLevel::generateAdjacencyLists( arrayView1d< localIndex const > const & 
           {
             faceAdjacencySet.insert( elemsToFaces[elementIndex][a] );
 
-            localIndex const faceID = elemsToFaces[elementIndex][a];
-            localIndex const numEdges = faceToEdges.sizeOfArray( faceID );
+            localIndex const faceIndex = elemsToFaces[elementIndex][a];
+            localIndex const numEdges = faceToEdges.sizeOfArray( faceIndex );
             for( localIndex b=0; b<numEdges; ++b )
             {
-              edgeAdjacencySet.insert( faceToEdges( faceID, b ));
+              edgeAdjacencySet.insert( faceToEdges( faceIndex, b ));
             }
 
           }

--- a/src/coreComponents/mesh/NodeManager.cpp
+++ b/src/coreComponents/mesh/NodeManager.cpp
@@ -17,12 +17,14 @@
  */
 
 #include "NodeManager.hpp"
-#include "FaceManager.hpp"
-#include "EdgeManager.hpp"
-#include "ToElementRelation.hpp"
-#include "BufferOps.hpp"
+
 #include "common/TimingMacros.hpp"
-#include "ElementRegionManager.hpp"
+#include "mesh/BufferOps.hpp"
+#include "mesh/EdgeManager.hpp"
+#include "mesh/ElementRegionManager.hpp"
+#include "mesh/FaceManager.hpp"
+#include "mesh/ToElementRelation.hpp"
+#include "mesh/utilities/MeshMapUtilities.hpp"
 
 namespace geosx
 {
@@ -55,10 +57,6 @@ NodeManager::NodeManager( string const & name,
 }
 
 
-NodeManager::~NodeManager()
-{}
-
-
 void NodeManager::resize( localIndex const newSize )
 {
   m_toFacesRelation.resize( newSize, 2 * getFaceMapOverallocation() );
@@ -76,161 +74,11 @@ void NodeManager::constructGlobalToLocalMap( CellBlockManagerABC const & cellBlo
   ObjectManagerBase::constructGlobalToLocalMap();
 }
 
-/**
- * @brief Populates the node to element region and node to element subregion mappings.
- * @param [in] elementRegionMgr The ElementRegionManager associated with this mesh level. Regions and subregions come from it.
- * @param [in] n2e The node to element maps.
- * @param [in,out] n2er The face to element region map.
- * @param [in,out] n2esr The face to element subregion map.
- *
- * @warning The @p n2e, @p n2er and @p n2esr need to be allocated at the correct dimensions, but need to be empty.
- */
-void populateRegions( ElementRegionManager const & elementRegionMgr,
-                      ArrayOfArraysView< localIndex const > const & n2e,
-                      ArrayOfArraysView< localIndex > const & n2er,
-                      ArrayOfArraysView< localIndex > const & n2esr )
-{
-  GEOSX_ERROR_IF_NE( n2e.size(), n2er.size() );
-  GEOSX_ERROR_IF_NE( n2e.size(), n2esr.size() );
-
-  // There is an implicit convention in the (n2e, n2er, n2esr) triplet.
-  // The node to element mapping (n2e) binds node indices to multiple element indices (like `n -> (e0, e1,...)`).
-  // The node to regions (n2r) and sub-regions (n2sr) respectively bind
-  // node indices to the regions/sub-regions: `n -> (er0, er1)` and `n -> (esr0, esr1)`.
-  //
-  // It is assumed in the code that triplets obtained at indices 0, 1,... of all these relations,
-  // (respectively `(e0, er0, esr0)`, `(e1, er1, esr1)`,...) are consistent:
-  // `e0` should belong to both `er0` and `esr0`.
-  //
-  // But in some configuration (multi-regions, multi-subregions, parallel computing, ghost cells),
-  // it may happen that a same element index appear multiple times in a same entry of the node to elements mapping.
-  // For example `n0 -> (e0, e1, e2, e0)` where `e0` appears twice.
-  // These duplicated elements will in fact belong to multiple regions/sub-regions.
-  // This implies a specific care when filling the nodes to regions and sub-regions mappings.
-  //
-  // Thus, the algorithm is the following.
-  //
-  // For each sub-region of each region, we consider each node of each element.
-  // We list all the elements connected to this node.
-  // Then we take the first element that has not already been inserted in the mappings
-  // (we check if the value is still -1), and we insert it using the `er` and `esr` values,
-  // before moving to another node.
-  //
-  // The same node index with the same elements will eventually come back during the iterative process.
-  // But this time with another region/sub-region combination.
-  //
-  // It must be noted that we can take the duplicated elements in any order,
-  // as long as the insertions are consistent!
-
-  // The algorithm is equivalent to the algorithm described
-  // in the `populateRegions` in the `FaceManager.cpp` file.
-  // Instead of nodes, we'll have faces.
-  //
-  // Since the algorithm is quite short, and because of slight variations
-  // (e.g. the different allocation between faces and nodes implementation),
-  // I considered acceptable to duplicate it a bit.
-  // This is surely disputable.
-
-  // This function `f` will be applied on every sub-region.
-  auto f = [&n2e, &n2er, &n2esr]( localIndex er,
-                                  localIndex esr,
-                                  ElementRegionBase const &,
-                                  CellElementSubRegion const & subRegion ) -> void
-  {
-    for( localIndex iElement = 0; iElement < subRegion.size(); ++iElement )
-    {
-      for( localIndex iNodeLoc = 0; iNodeLoc < subRegion.numNodesPerElement(); ++iNodeLoc )
-      {
-        // iNodeLoc is the node index in the referential of each cell (0 to 7 for a cube, e.g.).
-        // While iNode is the global index of the node.
-        localIndex const & iNode = subRegion.nodeList( iElement, iNodeLoc );
-
-        // A node may be attached to `numElementsLoc` elements.
-        localIndex const numElementsLoc = n2e[iNode].size();
-        for( localIndex iElementLoc = 0; iElementLoc < numElementsLoc; ++iElementLoc )
-        {
-          // We only consider the elements that match the mapping.
-          if( n2e( iNode, iElementLoc ) != iElement )
-          {
-            continue;
-          }
-
-          // This loop is a small hack to back insert/allocate dummy elements
-          // that will eventually be replaced by the correct values.
-          for( localIndex i = n2er[iNode].size(); i < iElementLoc + 1; ++i )
-          {
-            // By construction n2er and n2esr have the same size, so we use the same loop.
-            n2er.emplaceBack( iNode, -1 );
-            n2esr.emplaceBack( iNode, -1 );
-          }
-
-          // Here we fill the mapping iff it has not already been inserted.
-          if( n2er( iNode, iElementLoc ) < 0 or n2esr( iNode, iElementLoc ) < 0 )
-          {
-            n2er( iNode, iElementLoc ) = er;
-            n2esr( iNode, iElementLoc ) = esr;
-
-            // We only want to insert one unique index that has not been inserted,
-            // so we quit the loop on indices here.
-            break;
-          }
-        }
-      }
-    }
-  };
-
-  elementRegionMgr.forElementSubRegionsComplete< CellElementSubRegion >( f );
-}
-
-void NodeManager::buildRegionMaps( ElementRegionManager const & elementRegionManager )
-{
-  GEOSX_MARK_FUNCTION;
-
-  ArrayOfArrays< localIndex > & toElementRegionList = m_toElements.m_toElementRegion;
-  ArrayOfArrays< localIndex > & toElementSubRegionList = m_toElements.m_toElementSubRegion;
-  ArrayOfArraysView< localIndex const > const & toElementList = m_toElements.m_toElementIndex.toViewConst();
-  localIndex const numNodes = size();
-
-  // Resize the node to elem map.
-  toElementRegionList.resize( 0 );
-  toElementSubRegionList.resize( 0 );
-
-  // TODO Since there is a strong requirement that `toElementRegionList` and `toElementSubRegionList`
-  //      share the same capacities as `toElementList`, then it's should be interesting
-  //      to retrieve this information from `toElementList` instead.
-
-  // Reserve space for the number of current faces plus some extra.
-  double const overAllocationFactor = 0.3;
-  localIndex const entriesToReserve = ( 1 + overAllocationFactor ) * numNodes;
-  toElementRegionList.reserve( entriesToReserve );
-  toElementSubRegionList.reserve( entriesToReserve );
-
-  // Reserve space for the total number of face nodes + extra space for existing faces + even more space for new faces.
-  localIndex const valuesToReserve = numNodes + numNodes * getElemMapOverAllocation() * ( 1 + 2 * overAllocationFactor );
-  toElementRegionList.reserveValues( valuesToReserve );
-  toElementSubRegionList.reserveValues( valuesToReserve );
-
-  // Append an array for each node with capacity to hold the appropriate number of elements plus some wiggle room.
-  for( localIndex nodeID = 0; nodeID < numNodes; ++nodeID )
-  {
-    toElementRegionList.appendArray( 0 );
-    toElementSubRegionList.appendArray( 0 );
-
-    const localIndex numElementsPerNode = toElementList[nodeID].size() + getElemMapOverAllocation();
-    toElementRegionList.setCapacityOfArray( nodeID, numElementsPerNode );
-    toElementSubRegionList.setCapacityOfArray( nodeID, numElementsPerNode );
-  }
-
-  // Delegate the computation to a free function.
-  populateRegions( elementRegionManager,
-                   toElementList,
-                   toElementRegionList.toView(),
-                   toElementSubRegionList.toView() );
-}
-
 void NodeManager::buildSets( CellBlockManagerABC const & cellBlockManager,
                              GeometricObjectManager const & geometries )
 {
+  GEOSX_MARK_FUNCTION;
+
   // Let's first copy the sets from the cell block manager.
   for( const auto & nameArray: cellBlockManager.getNodeSets() )
   {
@@ -242,8 +90,7 @@ void NodeManager::buildSets( CellBlockManagerABC const & cellBlockManager,
   arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const X = this->referencePosition();
   localIndex const numNodes = this->size();
 
-  geometries.forSubGroups< SimpleGeometricObjectBase >(
-    [&]( SimpleGeometricObjectBase const & object ) -> void
+  geometries.forSubGroups< SimpleGeometricObjectBase >( [&]( SimpleGeometricObjectBase const & object )
   {
     string const & name = object.getName();
     SortedArray< localIndex > & targetSet = m_sets.registerWrapper< SortedArray< localIndex > >( name ).reference();
@@ -260,35 +107,43 @@ void NodeManager::buildSets( CellBlockManagerABC const & cellBlockManager,
 
 void NodeManager::setDomainBoundaryObjects( FaceManager const & faceManager )
 {
-  arrayView1d< integer const > const & isFaceOnDomainBoundary = faceManager.getDomainBoundaryIndicator();
-  arrayView1d< integer > const & isNodeOnDomainBoundary = getDomainBoundaryIndicator();
+  arrayView1d< integer const > const isFaceOnDomainBoundary = faceManager.getDomainBoundaryIndicator();
+  arrayView1d< integer > const isNodeOnDomainBoundary = getDomainBoundaryIndicator();
   isNodeOnDomainBoundary.zero();
 
   ArrayOfArraysView< localIndex const > const faceToNodes = faceManager.nodeList().toViewConst();
 
-  forAll< parallelHostPolicy >( faceManager.size(), [&]( localIndex const k )
+  forAll< parallelHostPolicy >( faceManager.size(), [=]( localIndex const faceIndex )
   {
-    if( isFaceOnDomainBoundary[k] == 1 )
+    if( isFaceOnDomainBoundary[faceIndex] == 1 )
     {
-      localIndex const numNodes = faceToNodes.sizeOfArray( k );
-      for( localIndex a = 0; a < numNodes; ++a )
+      for( localIndex const nodeIndex : faceToNodes[faceIndex] )
       {
-        isNodeOnDomainBoundary[faceToNodes( k, a )] = 1;
+        isNodeOnDomainBoundary[nodeIndex] = 1;
       }
     }
   } );
 }
 
-void NodeManager::setGeometricalRelations( CellBlockManagerABC const & cellBlockManager )
+void NodeManager::setGeometricalRelations( CellBlockManagerABC const & cellBlockManager,
+                                           ElementRegionManager const & elemRegionManager )
 {
+  GEOSX_MARK_FUNCTION;
+
   resize( cellBlockManager.numNodes() );
 
-  m_referencePosition = cellBlockManager.getNodesPositions();
+  m_referencePosition = cellBlockManager.getNodePositions();
 
-  m_toEdgesRelation.base() = cellBlockManager.getNodeToEdges();
-  m_toFacesRelation.base() = cellBlockManager.getNodeToFaces();
+  m_toEdgesRelation.base().assimilate< parallelHostPolicy >( cellBlockManager.getNodeToEdges(),
+                                                             LvArray::sortedArrayManipulation::UNSORTED_NO_DUPLICATES );
+  m_toFacesRelation.base().assimilate< parallelHostPolicy >( cellBlockManager.getNodeToFaces(),
+                                                             LvArray::sortedArrayManipulation::UNSORTED_NO_DUPLICATES );
 
-  m_toElements.m_toElementIndex = cellBlockManager.getNodeToElements();
+  ToCellRelation< ArrayOfArrays< localIndex > > const toCellBlock = cellBlockManager.getNodeToElements();
+  array2d< localIndex > const blockToSubRegion = elemRegionManager.getCellBlockToSubRegionMap( cellBlockManager );
+  meshMapUtilities::transformCellBlockToRegionMap< parallelHostPolicy >( blockToSubRegion.toViewConst(),
+                                                                         toCellBlock,
+                                                                         m_toElements );
 }
 
 void NodeManager::setupRelatedObjectsInRelations( EdgeManager const & edgeManager,

--- a/src/coreComponents/mesh/NodeManager.hpp
+++ b/src/coreComponents/mesh/NodeManager.hpp
@@ -63,8 +63,8 @@ public:
    *
    * @note Value forwarding is due to refactoring.
    */
-  static constexpr inline localIndex getEdgeMapOverallocation()
-  { return CellBlockManagerABC::getEdgeMapOverallocation(); }
+  static constexpr localIndex getEdgeMapOverallocation()
+  { return CellBlockManagerABC::edgeMapExtraSpacePerNode(); }
 
   /**
    * @brief return default size of the value in the node-to-face mapping
@@ -72,19 +72,19 @@ public:
    *
    * @note Value forwarding is due to refactoring.
    */
-  static constexpr inline localIndex getFaceMapOverallocation()
-  { return CellBlockManagerABC::getEdgeMapOverallocation(); }
+  static constexpr localIndex getFaceMapOverallocation()
+  { return CellBlockManagerABC::faceMapExtraSpacePerNode(); }
 
   /**
    * @brief return default size of the value array in the node-to-element mapping
    * @return default size of value array in the node-to-element mapping
    */
-  static constexpr inline localIndex getElemMapOverAllocation()
-  { return CellBlockManagerABC::getElemMapOverAllocation(); }
+  static constexpr localIndex getElemMapOverAllocation()
+  { return CellBlockManagerABC::elemMapExtraSpacePerNode(); }
 
-/**
- * @name Constructors/destructor
- */
+  /**
+   * @name Constructors/destructor
+   */
   ///@{
 
   /**
@@ -94,28 +94,6 @@ public:
    */
   NodeManager( string const & name,
                dataRepository::Group * const parent );
-
-  /**
-   * @brief The default NodeManager destructor.
-   */
-  ~NodeManager() override;
-
-  /// @cond DO_NOT_DOCUMENT
-  /**
-   * @brief deleted constructor
-   */
-  NodeManager() = delete;
-
-  /**
-   * @brief deleted copy constructor
-   */
-  NodeManager( const NodeManager & init ) = delete;
-
-  /**
-   * @brief deleted assignement operator
-   */
-  NodeManager & operator=( const NodeManager & ) = delete;
-  /// @endcond
 
   ///@}
 
@@ -142,19 +120,10 @@ public:
    * @brief Provide a virtual access to catalogName().
    * @return string that contains the NodeManager catalog name
    */
-  const string getCatalogName() const override final
-  { return NodeManager::catalogName(); }
+  string getCatalogName() const override final
+  { return catalogName(); }
 
   ///@}
-
-  /**
-   * @brief Builds the nodes to regions and nodes to sub-regions mappings.
-   * @param [in] elementRegionManager the ElementRegionManager.
-   *
-   * @note Requires the sub-regions of the @p elementRegionManager to be fully defined.
-   * As well as the node to elements mappings of the @p NodeManager.
-   */
-  void buildRegionMaps( ElementRegionManager const & elementRegionManager );
 
   /**
    * @brief Copies the local to global mapping from @p cellBlockManager and invert to create the global to local mapping.
@@ -172,16 +141,18 @@ public:
 
   /**
    * @brief Builds the node-on-domain-boundary indicator.
-   * @param[in] faceManager The computation is based on the face-on-domain-boundary indicator.
+   * @param[in] faceIndex The computation is based on the face-on-domain-boundary indicator.
    * @see ObjectManagerBase::getDomainBoundaryIndicator()
    */
-  void setDomainBoundaryObjects( FaceManager const & faceManager );
+  void setDomainBoundaryObjects( FaceManager const & faceIndex );
 
   /**
    * @brief Copies the nodes positions and the nodes to (edges|faces|elements) mappings from @p cellBlockManager.
    * @param[in] cellBlockManager Will provide the mappings.
+   * @param[in] elemRegionManager element region manager, needed to map blocks to subregion
    */
-  void setGeometricalRelations( CellBlockManagerABC const & cellBlockManager );
+  void setGeometricalRelations( CellBlockManagerABC const & cellBlockManager,
+                                ElementRegionManager const & elemRegionManager );
 
   /**
    * @brief Link the current manager to other managers.

--- a/src/coreComponents/mesh/ObjectManagerBase.cpp
+++ b/src/coreComponents/mesh/ObjectManagerBase.cpp
@@ -147,30 +147,28 @@ void ObjectManagerBase::constructSetFromSetAndMap( SortedArrayView< localIndex c
                                                    ArrayOfArraysView< localIndex const > const & map,
                                                    const string & setName )
 {
-  SortedArray< localIndex > & newset = m_sets.getReference< SortedArray< localIndex > >( setName );
-  newset.clear();
+  SortedArray< localIndex > & newSet = m_sets.getReference< SortedArray< localIndex > >( setName );
+  newSet.clear();
 
   localIndex const numObjects = size();
-  GEOSX_ERROR_IF( map.size() != numObjects, "Size mismatch. " << map.size() << " != " << numObjects );
+  GEOSX_ERROR_IF_NE_MSG( map.size(), numObjects, "Map size does not match number of objects." );
 
   if( setName == "all" )
   {
-    newset.reserve( numObjects );
-
-    for( localIndex ka=0; ka<numObjects; ++ka )
+    newSet.reserve( numObjects );
+    for( localIndex ka = 0; ka < numObjects; ++ka )
     {
-      newset.insert( ka );
+      newSet.insert( ka );
     }
   }
   else
   {
-    for( localIndex ka=0; ka<numObjects; ++ka )
+    for( localIndex ka = 0; ka < numObjects; ++ka )
     {
-      localIndex const * const values = map[ka];
-      localIndex const numValues = map.sizeOfArray( ka );
-      if( std::all_of( values, values + numValues, [&]( localIndex const i ) { return inputSet.contains( i ); } ) )
+      arraySlice1d< localIndex const > const values = map[ka];
+      if( std::all_of( values.begin(), values.end(), [&]( localIndex const i ) { return inputSet.contains( i ); } ) )
       {
-        newset.insert( ka );
+        newSet.insert( ka );
       }
     }
   }

--- a/src/coreComponents/mesh/ObjectManagerBase.hpp
+++ b/src/coreComponents/mesh/ObjectManagerBase.hpp
@@ -69,7 +69,7 @@ public:
    * @brief Get the name of the catalog.
    * @return The name.
    */
-  virtual const string getCatalogName() const = 0;
+  virtual string getCatalogName() const = 0;
   ///@}
 
   using dataRepository::Group::packSize;

--- a/src/coreComponents/mesh/PerforationData.hpp
+++ b/src/coreComponents/mesh/PerforationData.hpp
@@ -99,7 +99,7 @@ public:
   /**
    * @copydoc catalogName()
    */
-  virtual const string getCatalogName() const override { return catalogName(); }
+  virtual string getCatalogName() const override { return catalogName(); }
 
   ///@}
 

--- a/src/coreComponents/mesh/SurfaceElementRegion.cpp
+++ b/src/coreComponents/mesh/SurfaceElementRegion.cpp
@@ -146,13 +146,13 @@ localIndex SurfaceElementRegion::addToFractureMesh( real64 const time_np1,
 
   // Add the edges that compose the faceElement to the edge map. This is essentially a copy of
   // the facesToEdges entry.
-  localIndex const faceID = faceIndices[0];
-  localIndex const numEdges = originalFaceToEdgeMap.sizeOfArray( faceID );
+  localIndex const faceIndex = faceIndices[0];
+  localIndex const numEdges = originalFaceToEdgeMap.sizeOfArray( faceIndex );
   edgeMap.resizeArray( kfe, numEdges );
   for( localIndex a=0; a<numEdges; ++a )
   {
-    edgeMap[kfe][a] = originalFaceToEdgeMap( faceID, a );
-    connectedEdges.insert( originalFaceToEdgeMap( faceID, a ) );
+    edgeMap[kfe][a] = originalFaceToEdgeMap( faceIndex, a );
+    connectedEdges.insert( originalFaceToEdgeMap( faceIndex, a ) );
   }
 
   // Add the cell region/subregion/index to the faceElementToCells map
@@ -199,8 +199,7 @@ localIndex SurfaceElementRegion::addToFractureMesh( real64 const time_np1,
     SortedArray< localIndex > & faceElementSet = subRegion.sets().registerWrapper< SortedArray< localIndex > >( setIter.first ).reference();
     for( localIndex a=0; a<faceMap.size( 0 ); ++a )
     {
-      localIndex const faceIndex = faceMap[a][0];
-      if( faceSet.count( faceIndex ) )
+      if( faceSet.count( faceMap[a][0] ) )
       {
         faceElementSet.insert( a );
       }

--- a/src/coreComponents/mesh/SurfaceElementRegion.hpp
+++ b/src/coreComponents/mesh/SurfaceElementRegion.hpp
@@ -84,11 +84,11 @@ public:
    * @brief Get the key name for the SurfaceElementRegion in the object catalog.
    * @return A string containing the key name.
    */
-  static const string catalogName()
+  static string catalogName()
   { return "SurfaceElementRegion"; }
 
-  virtual const string getCatalogName() const override final
-  { return SurfaceElementRegion::catalogName(); }
+  virtual string getCatalogName() const override final
+  { return catalogName(); }
 
   ///@}
 

--- a/src/coreComponents/mesh/SurfaceElementSubRegion.hpp
+++ b/src/coreComponents/mesh/SurfaceElementSubRegion.hpp
@@ -53,16 +53,16 @@ public:
    * @brief Get catalog name.
    * @return the catalog name
    */
-  static const string catalogName()
+  static string catalogName()
   { return "SurfaceElementSubRegion"; }
 
   /**
    * @brief Get catalog name.
    * @return the catalog name
    */
-  virtual const string getCatalogName() const override
+  virtual string getCatalogName() const override
   {
-    return SurfaceElementSubRegion::catalogName();
+    return catalogName();
   }
 
   ///@}

--- a/src/coreComponents/mesh/ToElementRelation.hpp
+++ b/src/coreComponents/mesh/ToElementRelation.hpp
@@ -39,11 +39,6 @@ public:
   /// The type of the underlying relationship storage object.
   using base_type = BASETYPE;
 
-  /// The default constructor
-  ToElementRelation();
-  /// The default destructor
-  ~ToElementRelation();
-
   /**
    * @brief Resize the underlying relationship storage.
    * @tparam DIMS The types of each dimensions resize parameter.
@@ -51,7 +46,12 @@ public:
    *                dimension of the relationship storage.
    */
   template< typename ... DIMS >
-  void resize( DIMS... newdims );
+  void resize( DIMS... newdims )
+  {
+    m_toElementRegion.resize( newdims ... );
+    m_toElementSubRegion.resize( newdims ... );
+    m_toElementIndex.resize( newdims ... );
+  }
 
   /**
    * @brief Get the current size of the relationship storage.
@@ -98,31 +98,8 @@ public:
   BASETYPE m_toElementIndex;
 
   /// The current ElementRegionManager
-  ElementRegionManager const * m_elemRegionManager;
+  ElementRegionManager const * m_elemRegionManager{};
 };
-
-/// @cond DO_NOT_DOCUMENT
-template< typename BASETYPE >
-ToElementRelation< BASETYPE >::ToElementRelation():
-  m_toElementRegion(),
-  m_toElementSubRegion(),
-  m_toElementIndex(),
-  m_elemRegionManager( nullptr )
-{}
-
-template< typename BASETYPE >
-ToElementRelation< BASETYPE >::~ToElementRelation()
-{}
-
-template< typename BASETYPE >
-template< typename ... DIMS >
-void ToElementRelation< BASETYPE >::resize( DIMS... newdims )
-{
-  m_toElementRegion.resize( newdims ... );
-  m_toElementSubRegion.resize( newdims ... );
-  m_toElementIndex.resize( newdims ... );
-}
-/// @endcond
 
 /// @brief A ToElementRelation where each object is related to the same number of elements.
 typedef ToElementRelation< array2d< localIndex > > FixedToManyElementRelation;

--- a/src/coreComponents/mesh/WellElementRegion.hpp
+++ b/src/coreComponents/mesh/WellElementRegion.hpp
@@ -71,14 +71,14 @@ public:
    * @brief Get the catalog name.
    * @return the name of this class in the catalog
    */
-  static const string catalogName()
+  static string catalogName()
   { return "WellElementRegion"; }
 
   /**
    * @copydoc catalogName()
    */
-  virtual const string getCatalogName() const override final
-  { return WellElementRegion::catalogName(); }
+  virtual string getCatalogName() const override final
+  { return catalogName(); }
 
   ///@}
 

--- a/src/coreComponents/mesh/WellElementSubRegion.hpp
+++ b/src/coreComponents/mesh/WellElementSubRegion.hpp
@@ -72,12 +72,12 @@ public:
    * @brief Get the catalog name.
    * @return the name of this class in the catalog
    */
-  static const string catalogName() { return "wellElementSubRegion"; }
+  static string catalogName() { return "wellElementSubRegion"; }
 
   /**
    * @copydoc catalogName()
    */
-  virtual const string getCatalogName() const override { return WellElementSubRegion::catalogName(); }
+  virtual string getCatalogName() const override { return catalogName(); }
 
   ///@}
 

--- a/src/coreComponents/mesh/generators/CellBlock.cpp
+++ b/src/coreComponents/mesh/generators/CellBlock.cpp
@@ -83,11 +83,15 @@ void CellBlock::resize( dataRepository::indexType const numElements )
   m_elementsToFaces.resize( numElements );
 }
 
-void CellBlock::getFaceNodes( localIndex iElement,
-                              localIndex iFace,
-                              array1d< localIndex > & nodesInFaces ) const
+localIndex CellBlock::getFaceNodes( localIndex const cellIndex,
+                                    localIndex const faceNum,
+                                    Span< localIndex > const nodesInFaces ) const
 {
-  geosx::getFaceNodes( m_elementType, iElement, iFace, m_elementsToNodes, nodesInFaces );
+  return geosx::getFaceNodes( m_elementType,
+                              cellIndex,
+                              faceNum,
+                              m_elementsToNodes,
+                              nodesInFaces );
 }
 
 }

--- a/src/coreComponents/mesh/generators/CellBlock.hpp
+++ b/src/coreComponents/mesh/generators/CellBlock.hpp
@@ -37,25 +37,12 @@ public:
    */
   ///@{
 
-  CellBlock() = delete;
-
   /**
    * @brief Constructor for this class.
    * @param[in] name the name of this object manager
    * @param[in] parent the parent Group
    */
   CellBlock( string const & name, Group * const parent );
-
-  /**
-   * @brief Copy constructor.
-   * @param[in] init the source to copy
-   */
-  CellBlock( const CellBlock & init ) = delete;
-
-  /**
-   * @brief Default destructor.
-   */
-  ~CellBlock() override = default;
 
   ///@}
 
@@ -94,26 +81,34 @@ public:
   { return size(); }
 
   /**
-   * @brief Puts the nodes of face @p iFace of element @p iElement inside vector @p nodesInFaces.
-   * @param[in] iElement The element index.
-   * @param[in] iFace The local face index (not the global index). E.g. an hexahedron have face 6 indices from 0 to 5.
-   * @param[out] nodesInFaces The result vector gets resized to the appropriate dimensions before getting filled.
+   * @brief Puts the nodes of face @p faceNum of element @p cellIndex inside vector @p nodesInFaces.
+   * @param[in] cellIndex The element index.
+   * @param[in] faceNum the face number within an element
+   * @param[out] nodesInFace space for result, must have enough space to fit all nodes
+   * @return the number of nodes written into @p nodesInFace
    *
    * @p nodesInFaces is sorted from lower to larger node indices values.
    * @p nodesInFaces is exactly the size of the number of nodes.
    */
-  void getFaceNodes( localIndex iElement,
-                     localIndex iFace,
-                     array1d< localIndex > & nodesInFaces ) const;
+  localIndex getFaceNodes( localIndex const cellIndex,
+                           localIndex const faceNum,
+                           Span< localIndex > nodesInFace ) const;
 
   /**
    * @brief Get the element to nodes mapping, non-const version.
-   * @return The mapping relationship as a array.
+   * @return The mapping relationship as an array.
    *
    * @deprecated This accessor is meant to be used like a setter even though it's a bit like having public attribute...
    * Use a real setter instead.
    */
-  array2d< localIndex, cells::NODE_MAP_PERMUTATION > & getElemToNode()
+  arrayView2d< localIndex, cells::NODE_MAP_USD > getElemToNode()
+  { return m_elementsToNodes; }
+
+  /**
+   * @brief Get the element to nodes mapping, const version.
+   * @return The mapping relationship as an array view
+   */
+  arrayView2d< localIndex const, cells::NODE_MAP_USD > getElemToNode() const
   { return m_elementsToNodes; }
 
   array2d< localIndex, cells::NODE_MAP_PERMUTATION > getElemToNodes() const override
@@ -134,45 +129,45 @@ public:
 
   /**
    * @brief Sets an entry in the element to faces mapping.
-   * @param[in] iElement Index of the element
-   * @param[in] iFaceLoc Local index of the face of the element @p iElement (typically from 0 to 5 for an hexahedron).
-   * @param[in] iFace The face index.
+   * @param[in] cellIndex Index of the element
+   * @param[in] faceNum Local index of the face of the element @p iElement (typically from 0 to 5 for an hexahedron).
+   * @param[in] faceIndex The face index.
    */
-  void setElementToFaces( localIndex iElement,
-                          localIndex iFaceLoc,
-                          localIndex iFace )
+  void setElementToFaces( localIndex const cellIndex,
+                          localIndex const faceNum,
+                          localIndex const faceIndex )
   {
-    m_elementsToFaces( iElement, iFaceLoc ) = iFace;
+    m_elementsToFaces( cellIndex, faceNum ) = faceIndex;
   }
 
   /**
    * @brief Sets an entry in the element to edges mapping.
-   * @param[in] iElement Index of the element.
-   * @param[in] iEdgeLoc Local index of the edge of the element @p iElement (typically from 0 to 11 for an hexahedron).
-   * @param[in] iEdge Index of the edge.
+   * @param[in] cellIndex Index of the element.
+   * @param[in] edgeNum Local index of the edge of the element @p iElement (typically from 0 to 11 for an hexahedron).
+   * @param[in] edgeIndex Index of the edge.
    *
    * In the element to edges mapping, element @p iElement has a given number of edges (typically 12 for a hexahedron).
-   * Then edge @p iEdgeLoc of this local indexing (typically 0 to 11) is meant to have global indexing of @p iEdge.
+   * Then edge @p edgeNum of this local indexing (typically 0 to 11) is meant to have global indexing of @p edgeIndex.
    */
-  void setElementToEdges( localIndex iElement,
-                          localIndex iEdgeLoc,
-                          localIndex iEdge )
+  void setElementToEdges( localIndex const cellIndex,
+                          localIndex const edgeNum,
+                          localIndex const edgeIndex )
   {
-    m_elementsToEdges( iElement, iEdgeLoc ) = iEdge;
+    m_elementsToEdges( cellIndex, edgeNum ) = edgeIndex;
   }
 
   /**
-   * @brief Checks if edge @p iEdge of element @p iElement has been defined.
-   * @param[in] iElement Index of the element
-   * @param[in] iEdgeLoc Index of the edge of the element @p iElement (typically from 0 to 11 for an hexahedron).
-   * @param[in] iEdge The edge index.
+   * @brief Checks if edge @p edgeIndex of element @p cellIndex has been defined.
+   * @param[in] cellIndex Index of the element
+   * @param[in] edgeNum Index of the edge of the element @p cellIndex (typically from 0 to 11 for an hexahedron).
+   * @param[in] edgeIndex The edge index.
    * @return True if the entry is already there in the mapping. False otherwise.
    */
-  bool hasElementToEdges( localIndex iElement,
-                          localIndex iEdgeLoc,
-                          localIndex iEdge ) const
+  bool hasElementToEdges( localIndex const cellIndex,
+                          localIndex const edgeNum,
+                          localIndex const edgeIndex ) const
   {
-    return m_elementsToEdges( iElement, iEdgeLoc ) == iEdge;
+    return m_elementsToEdges( cellIndex, edgeNum ) == edgeIndex;
   }
 
   /**

--- a/src/coreComponents/mesh/generators/CellBlockManager.cpp
+++ b/src/coreComponents/mesh/generators/CellBlockManager.cpp
@@ -14,7 +14,8 @@
 
 #include "CellBlockManager.hpp"
 
-#include "CellBlockUtilities.hpp"
+#include "mesh/generators/CellBlockUtilities.hpp"
+#include "mesh/utilities/MeshMapUtilities.hpp"
 
 #include <algorithm>
 
@@ -44,253 +45,284 @@ Group * CellBlockManager::createChild( string const & GEOSX_UNUSED_PARAM( childK
   return nullptr;
 }
 
-ArrayOfArrays< localIndex > CellBlockManager::getNodeToElements() const
+/// Element identifier containing (block index, cell index).
+using CellBlockIndexPair = std::pair< localIndex, localIndex >;
+
+template< typename POLICY >
+void convertFromCellBlockPairMap( ArrayOfArraysView< CellBlockIndexPair const > const & srcMap,
+                                  ToCellRelation< ArrayOfArrays< localIndex > > & dstMap )
 {
-  // The function works in three steps.
-  // First finds the number of elements attached to each node.
-  // Then second step allocates the vectors, including extra allocations.
-  // Last, the output vector is filled.
+  ArrayOfArrays< localIndex > & toBlock = dstMap.toBlockIndex;
+  ArrayOfArrays< localIndex > & toCell = dstMap.toCellIndex;
 
-  // First step: how many elements for each node, stored in the elemsPerNode array.
-  array1d< localIndex > elemsPerNode( m_numNodes );
-  RAJA::ReduceSum< parallelHostReduce, localIndex > totalNodeElems = 0;
+  localIndex const numObjects = srcMap.size();
 
-  for( localIndex iCellBlock = 0; iCellBlock < numCellBlocks(); ++iCellBlock )
+  toBlock.resizeFromOffsets( numObjects, srcMap.toViewConst().getOffsets() );
+  toCell.resizeFromOffsets( numObjects, srcMap.toViewConst().getOffsets() );
+
+  forAll< parallelHostPolicy >( numObjects, [toBlock = toBlock.toView(),
+                                             toCell = toCell.toView(),
+                                             srcMap]( localIndex const objIndex )
   {
-    const CellBlockABC & cb = this->getCellBlock( iCellBlock );
-    array2d< localIndex, cells::NODE_MAP_PERMUTATION > const & elemToNode = cb.getElemToNodes();
-    forAll< parallelHostPolicy >( cb.numElements(), [&elemsPerNode, totalNodeElems, &elemToNode, &cb] ( localIndex const k )
+    arraySlice1d< CellBlockIndexPair const > const cells = srcMap[ objIndex ];
+    for( CellBlockIndexPair const & e : cells )
     {
-      localIndex const numNodesPerElement = cb.numNodesPerElement();
-      totalNodeElems += numNodesPerElement;
-      for( localIndex a = 0; a < numNodesPerElement; ++a )
+      toBlock.emplaceBack( objIndex, std::get< 0 >( e ) );
+      toCell.emplaceBack( objIndex, std::get< 1 >( e ) );
+    }
+  } );
+}
+
+template< typename POLICY >
+void convertFromCellBlockPairMap( ArrayOfArraysView< CellBlockIndexPair const > const & srcMap,
+                                  ToCellRelation< array2d< localIndex > > & dstMap )
+{
+  array2d< localIndex > & toBlock = dstMap.toBlockIndex;
+  array2d< localIndex > & toCell = dstMap.toCellIndex;
+
+  localIndex const numObjects = srcMap.size();
+  localIndex const maxNumElem = toCell.size( 1 );
+
+  GEOSX_ERROR_IF_NE( toBlock.size( 1 ), maxNumElem );
+  GEOSX_ERROR_IF_NE( toCell.size( 1 ), maxNumElem );
+
+  toBlock.resizeDimension< 0 >( numObjects );
+  toCell.resizeDimension< 0 >( numObjects );
+
+  // We allow a fixed-size map to represent a variable relationship, as long as
+  // the number of elements does not exceed the fixed size (set by the caller).
+  // In this case, a dummy value "-1" is used to represent non-present elements.
+  toBlock.setValues< POLICY >( -1 );
+  toCell.setValues< POLICY >( -1 );
+
+  forAll< parallelHostPolicy >( numObjects, [=, // needed to optionally capture maxNumElem in Debug
+                                             toBlock = toBlock.toView(),
+                                             toCell = toCell.toView()]( localIndex const objIndex )
+  {
+    arraySlice1d< CellBlockIndexPair const > const cells = srcMap[ objIndex ];
+    GEOSX_ASSERT_GE( maxNumElem, cells.size() );
+    localIndex count = 0;
+    for( CellBlockIndexPair const & e : cells )
+    {
+      toBlock( objIndex, count ) = std::get< 0 >( e );
+      toCell( objIndex, count ) = std::get< 1 >( e );
+      ++count;
+    }
+  } );
+}
+
+/**
+ * @brief Build to-cell map by inverting existing maps in cell blocks.
+ * @tparam BASEMAP underlying type of to-cell map
+ * @tparam FUNC type of @p cellToObjectGetter
+ * @param cellIndex number of objects (nodes, faces, etc.) for which maps are built
+ * @param toCells container for to-cell (block, index) maps
+ * @param cellToObjectGetter function used to extract maps from subregions
+ * @param overAlloc overallocation for the resulting maps
+ *                  (extra capacity per row, only meaningful for variable-secondary-size containers)
+ */
+template< typename BASEMAP, typename FUNC >
+void CellBlockManager::buildToCellMap( localIndex const numObjects,
+                                       ToCellRelation< BASEMAP > & toCells,
+                                       FUNC cellToObjectGetter,
+                                       localIndex const overAlloc ) const
+{
+  // Calculate the number of entries in each sub-array
+  array1d< localIndex > counts( numObjects );
+  counts.setValues< serialPolicy >( overAlloc );
+
+  for( localIndex blockIndex = 0; blockIndex < numCellBlocks(); ++blockIndex )
+  {
+    CellBlock const & cb = getCellBlock( blockIndex );
+
+    auto const cellToObject = cellToObjectGetter( cb );
+    forAll< parallelHostPolicy >( cb.size(), [counts = counts.toView(),
+                                              cellToObject]( localIndex const ei )
+    {
+      auto const objects = cellToObject[ ei ];
+      // can't use range-based for loop when slice is not contiguous
+      for( localIndex i = 0; i < objects.size(); ++i )
       {
-        localIndex const nodeIndex = elemToNode( k, a );
-        RAJA::atomicInc< parallelHostAtomic >( &elemsPerNode[ nodeIndex ] );
+        RAJA::atomicInc< parallelHostAtomic >( &counts[ objects[i] ] );
       }
     } );
   }
+  ;
 
-  // Second, allocation.
-  ArrayOfArrays< localIndex > result;
+  // Allocate memory
+  ArrayOfArrays< CellBlockIndexPair > cellBlockPairList;
+  cellBlockPairList.resizeFromCapacities< parallelHostPolicy >( numObjects, counts.data() );
 
-  double const overAllocationFactor = 0.3;
-  localIndex const entriesToReserve = ( 1 + overAllocationFactor ) * m_numNodes;
-  result.reserve( entriesToReserve );
-
-  localIndex const valuesToReserve = totalNodeElems.get() + m_numNodes * getElemMapOverAllocation() * ( 1 + 2 * overAllocationFactor );
-  result.reserveValues( valuesToReserve );
-
-  // Append an array for each node with capacity to hold the appropriate number of elements plus some wiggle room.
-  for( localIndex nodeID = 0; nodeID < m_numNodes; ++nodeID )
+  // Populate map of tuples in parallel
+  for( localIndex blockIndex = 0; blockIndex < numCellBlocks(); ++blockIndex )
   {
-    result.appendArray( 0 );
-    result.setCapacityOfArray( nodeID, elemsPerNode[ nodeID ] + getElemMapOverAllocation() );
-  }
+    CellBlock const & cb = getCellBlock( blockIndex );
 
-  // Third, filling the result.
-  for( localIndex iCellBlock = 0; iCellBlock < numCellBlocks(); ++iCellBlock )// Do not need index
-  {
-    const CellBlockABC & cb = this->getCellBlock( iCellBlock );
-    array2d< localIndex, cells::NODE_MAP_PERMUTATION > const elemToNode = cb.getElemToNodes();
-    for( localIndex iElem = 0; iElem < cb.numElements(); ++iElem )
+    auto const cellToObject = cellToObjectGetter( cb );
+    forAll< parallelHostPolicy >( cb.size(), [cellBlockPairList = cellBlockPairList.toView(),
+                                              cellToObject,
+                                              blockIndex]( localIndex const cellIndex )
     {
-      for( localIndex iNode = 0; iNode < cb.numNodesPerElement(); ++iNode )
+      auto const objects = cellToObject[ cellIndex ];
+      // can't use range-based for loop when slice is not contiguous
+      for( localIndex i = 0; i < objects.size(); ++i )
       {
-        localIndex const nodeIndex = elemToNode( iElem, iNode );
-        result.emplaceBack( nodeIndex, iElem );
+        cellBlockPairList.emplaceBackAtomic< parallelHostAtomic >( objects[i], blockIndex, cellIndex );
       }
-    }
+    } );
   }
+  ;
 
+  // Sort each element list to ensure unique race-condition-free map order
+  forAll< parallelHostPolicy >( numObjects, [cellBlockPairList = cellBlockPairList.toView()]( localIndex const objIndex )
+  {
+    arraySlice1d< CellBlockIndexPair > const cells = cellBlockPairList[ objIndex ];
+    LvArray::sortedArrayManipulation::makeSorted( cells.begin(), cells.end() );
+  } );
+
+  // Finally, split arrays-of-tuples into separate arrays
+  convertFromCellBlockPairMap< parallelHostPolicy >( cellBlockPairList.toViewConst(), toCells );
+}
+
+ToCellRelation< ArrayOfArrays< localIndex > > CellBlockManager::getNodeToElements() const
+{
+  ToCellRelation< ArrayOfArrays< localIndex > > result;
+  buildToCellMap( m_numNodes,
+                  result,
+                  []( CellBlock const & cb ) { return cb.getElemToNode(); },
+                  elemMapExtraSpacePerNode() );
   return result;
 }
 
 /**
- * @brief Convenience programming structure that holds the nodes for a given Face. No information about which cell though.
+ * @brief Holds information about face used in face map construction.
  *
- * This structure holds `<` and `==` operators such that equal instances in a sorted array
- * are meant to be consecutive. (see `std::unique` for example).
- * Two instances with same nodes in different order are considered equal.
- * Such a case often happen since the same surface is shared by two adjacent elements
- * in conformal meshes.
+ * These records are created and stored when visiting faces through cells.
+ * Organizing and sorting them by node lists enables identification of
+ * matching faces of different cells. Cell and block indices are preserved
+ * so that cell-face maps may be constructed.
  */
 struct NodesAndElementOfFace
 {
-  NodesAndElementOfFace( array1d< localIndex > nodes_, localIndex element_, localIndex iCellBlock_, localIndex iFace_ ):
-    nodes( nodes_ ),
-    element( element_ ),
-    iCellBlock( iCellBlock_ ),
-    iFace( iFace_ ),
-    sortedNodes( nodes_ )
-  {
-    std::sort( sortedNodes.begin(), sortedNodes.end() );
-  }
+  NodesAndElementOfFace( Span< localIndex const > const sortedNodes,
+                         localIndex const cell,
+                         localIndex const block,
+                         localIndex const faceNum ):
+    n1( sortedNodes[1] ),
+    n2( sortedNodes[2] ),
+    numNodes( static_cast< localIndex >( sortedNodes.size() ) ),
+    cellIndex( cell ),
+    blockIndex( block ),
+    faceNumber( faceNum )
+  {}
+
+  /// Second highest node index in the face
+  localIndex n1;
+
+  /// Third highest node index in the face
+  localIndex n2;
+
+  /// Number of nodes in the face (saved here to simplify map resizing)
+  localIndex numNodes;
 
   /**
-   * @brief Imposes an ordering on NodesAndElementOfFace.
-   * @param [in] rhs the NodesAndElementOfFace to compare against.
-   * @return a boolean.
-   */
-  bool operator<( NodesAndElementOfFace const & rhs ) const
-  {
-    // Using some standard comparison like vector::operator<.
-    // Two subsequent NodesAndElementOfFace may still be equal
-    // We are consistent with operator==, which is what we require.
-    return std::lexicographical_compare( sortedNodes.begin(), sortedNodes.end(),
-                                         rhs.sortedNodes.begin(), rhs.sortedNodes.end() );
-  }
-
-  /**
-   * @brief Two NodesAndElementOfFace instances are considered equal if they share the same node set, whatever the order.
-   * @param [in] rhs the NodesAndElementOfFace to compare against.
-   * @return a boolean.
-   */
-  bool operator==( NodesAndElementOfFace const & rhs ) const
-  {
-    // Comparing term by term like STL does.
-    return ( sortedNodes.size() == rhs.sortedNodes.size() && std::equal( sortedNodes.begin(), sortedNodes.end(), rhs.sortedNodes.begin() ) );
-  }
-
-  /// The list of nodes describing the face.
-  array1d< localIndex > nodes;
-
-  /**
-   * @brief The element to which this face belongs.
+   * @brief Index of the cell to which this face belongs.
    *
    * Each face may belong to multiple elements.
    * But during the identification process (we loop on each face of each element),
    * we store the cell we are iterating on.
    * The we'll be able to identify the duplicated faces because we also have the nodes.
    */
-  localIndex element;
+  localIndex cellIndex;
 
-  /**
-   * @brief Cell block index
-   *
-   * During the process, we need to know form which cell block the instance was created.
-   */
-  localIndex iCellBlock;
+  /// Cell block index of the cell to which this face belongs.
+  localIndex blockIndex;
 
-  /**
-   * @brief Face index
-   *
-   * During the process, we need to know what was the face index when this instance was created.
-   */
-  localIndex iFace;
+  /// Face number within a cell
+  localIndex faceNumber;
 
 private:
-  /// Sorted nodes describing the face; only for comparison/sorting reasons.
-  array1d< localIndex > sortedNodes;
-};
 
-/**
- * @brief Return the total number of unique faces and fill in the uniqueFaceOffsets array.
- * @param [in] lowestNodeToFaces An array of size numNodes of arrays of NodesAndElementOfFace associated with each node.
- * @param [out] uniqueFaceOffsets An array of size numNodes + 1. After this function returns node i contains
- *              faces with IDs ranging from uniqueFaceOffsets[ i ] to uniqueFaceOffsets[ i + 1 ] - 1.
- * @return return total number of faces
- */
-localIndex calculateTotalNumberOfFaces( ArrayOfArraysView< NodesAndElementOfFace const > const & lowestNodeToFaces,
-                                        arrayView1d< localIndex > const & uniqueFaceOffsets )
-{
-  localIndex const numNodes = lowestNodeToFaces.size();
-  GEOSX_ERROR_IF_NE( numNodes, uniqueFaceOffsets.size() - 1 );
-  uniqueFaceOffsets.setValues< serialPolicy >( 0. );
-
-  // Loop over all the nodes.
-  forAll< parallelHostPolicy >( numNodes, [&]( localIndex const nodeID )
+  /**
+   * @brief Equality comparison operator.
+   * @param [in] lhs left-hand side of the comparison
+   * @param [in] rhs right-hand side of the comparison
+   * @return true iff objects represent the same face
+   *
+   * Two faces are considered equal if they share 3 nodes (in a conforming mesh).
+   * Because the other data structure already groups entries by lowest node,
+   * here we only store and compare the second and third lowest index nodes.
+   */
+  friend bool operator==( NodesAndElementOfFace const & lhs, NodesAndElementOfFace const & rhs )
   {
-    localIndex const numFaces = lowestNodeToFaces.sizeOfArray( nodeID );
-    // Since lowestNodeToFaces[ nodeID ] is sorted we can compare subsequent entries
-    // count up the unique entries. Since each face can appear at most twice if we find a match we
-    // can skip the next entry as well.
-    localIndex & numUniqueFaces = uniqueFaceOffsets[ nodeID + 1 ];
-    for( localIndex j = 0; j < numFaces; ++j )
-    {
-      ++numUniqueFaces;
-      if( j < numFaces - 1 )
-      {
-        if( lowestNodeToFaces( nodeID, j ) == lowestNodeToFaces( nodeID, j + 1 ) )
-        {
-          ++j;
-        }
-      }
-    }
-  } );
-  // At this point uniqueFaceOffsets[ i ] holds the number of unique face associated with node i - 1.
-  // Perform an inplace prefix-sum to get the unique face offset.
-  RAJA::inclusive_scan_inplace< parallelHostPolicy >( uniqueFaceOffsets.begin(), uniqueFaceOffsets.end() );
-  return uniqueFaceOffsets.back();
-}
-
-/**
- * @brief Copies the nodes from @p nodesAndElementOfFace into @p faceToNodes[@p faceID ].
- * @param [in] faceID The face index.
- * @param [in] nodesAndElementOfFace The nodes and element for @p faceID.
- * @param [out] faceToNodes No input data is used.
- */
-void insertFaceToNodesEntry( localIndex const faceID,
-                             NodesAndElementOfFace const & nodesAndElementOfFace,
-                             ArrayOfArrays< localIndex > & faceToNodes )
-{
-  localIndex const numFaceNodes = nodesAndElementOfFace.nodes.size();
-  // FIXME The size should be OK because it's been allocated previously.
-  for( localIndex i = 0; i < numFaceNodes; ++i )
-  {
-    faceToNodes[faceID][i] = nodesAndElementOfFace.nodes[i];
+    return lhs.n1 == rhs.n1 && lhs.n2 == rhs.n2;
   }
-  GEOSX_ASSERT_EQ( numFaceNodes, faceToNodes.sizeOfArray( faceID ) );
-  GEOSX_DEBUG_VAR( numFaceNodes );
-}
+};
 
 /**
  * @brief Fills the face to nodes map and face to element maps
  * @param [in] lowestNodeToFaces and array of size numNodes of arrays of NodesAndElementOfFace associated with each node.
  * @param [in] uniqueFaceOffsets an array containing the unique ID of the first face associated with each node.
- * @param [inout] faceToElements the face to element map.
+ * @param [inout] faceToCells the face to element map.
  * @param [inout] faceToNodes the face to node map.
  */
-void populateFaceMaps( ArrayOfArraysView< NodesAndElementOfFace const > const & lowestNodeToFaces,
+void populateFaceMaps( Group const & cellBlocks,
+                       ArrayOfArraysView< NodesAndElementOfFace const > const & lowestNodeToFaces,
                        arrayView1d< localIndex const > const & uniqueFaceOffsets,
-                       ArrayOfArrays< localIndex > & faceToNodes,
-                       arrayView2d< localIndex > & faceToElements )
+                       ArrayOfArraysView< localIndex > const & faceToNodes,
+                       arrayView2d< localIndex > const & faceToCells,
+                       arrayView2d< localIndex > const & faceToBlocks )
 {
-  GEOSX_MARK_FUNCTION;
-
   localIndex const numNodes = lowestNodeToFaces.size();
   localIndex const numUniqueFaces = uniqueFaceOffsets.back();
-  GEOSX_ERROR_IF_NE( numNodes, uniqueFaceOffsets.size() - 1 );
-  GEOSX_ERROR_IF_NE( numUniqueFaces, faceToNodes.size() );
-  GEOSX_ERROR_IF_NE( numUniqueFaces, faceToElements.size( 0 ) );
-  GEOSX_ERROR_IF_NE( 2, faceToElements.size( 1 ) );
+  GEOSX_ERROR_IF_NE( uniqueFaceOffsets.size() - 1, numNodes );
+  GEOSX_ERROR_IF_NE( faceToNodes.size(), numUniqueFaces );
+  GEOSX_ERROR_IF_NE( faceToCells.size( 0 ), numUniqueFaces );
+  GEOSX_ERROR_IF_NE( faceToCells.size( 1 ), 2 );
+  GEOSX_ERROR_IF_NE( faceToBlocks.size( 0 ), numUniqueFaces );
+  GEOSX_ERROR_IF_NE( faceToBlocks.size( 1 ), 2 );
 
   // loop over all the nodes.
-  forAll< parallelHostPolicy >( numNodes, [&]( localIndex const nodeID )
+  forAll< parallelHostPolicy >( numNodes, [uniqueFaceOffsets,
+                                           lowestNodeToFaces,
+                                           faceToNodes,
+                                           faceToCells,
+                                           faceToBlocks,
+                                           &cellBlocks]( localIndex const nodeIndex )
   {
-    localIndex const numFaces = lowestNodeToFaces.sizeOfArray( nodeID );
-    // loop over all the `NodesAndElementOfFace` associated with the node.
-    for( localIndex j = 0, curFaceID = uniqueFaceOffsets[nodeID]; j < numFaces; ++j, ++curFaceID )
+    localIndex nodesInFace[ CellBlockManager::maxNodesPerFace() ];
+    localIndex curFaceID = uniqueFaceOffsets[nodeIndex];
+    arraySlice1d< NodesAndElementOfFace const > const faces = lowestNodeToFaces[ nodeIndex ];
+    forEqualRanges( faces.begin(), faces.end(), [&]( auto first, auto last )
     {
-      // If two subsequent `NodesAndElementOfFace` compare equal then they describe an interior face.
-      // It must therefore be considered "twice".
-      // Otherwise it's a boundary face, and "once" is enough.
-      NodesAndElementOfFace const & f0 = lowestNodeToFaces( nodeID, j );
-      insertFaceToNodesEntry( curFaceID, f0, faceToNodes );
-      faceToElements( curFaceID, 0 ) = f0.element;
-      faceToElements( curFaceID, 1 ) = -1; // TODO Make a constant
+      NodesAndElementOfFace const & f0 = *first;
+      CellBlock const & cb = cellBlocks.getGroup< CellBlock >( f0.blockIndex );
+      localIndex const numNodesInFace = cb.getFaceNodes( f0.cellIndex, f0.faceNumber, nodesInFace );
+      GEOSX_ASSERT_EQ( numNodesInFace, f0.numNodes );
 
-      // This is where we check for the two subsequent faces (when they exist).
-      if( j < numFaces - 1 )
+      for( localIndex i = 0; i < numNodesInFace; ++i )
       {
-        NodesAndElementOfFace const & f1 = lowestNodeToFaces( nodeID, j + 1 );
-        if( f0 == f1 )
-        {
-          faceToElements( curFaceID, 1 ) = f1.element;
-          ++j;
-        }
+        faceToNodes.emplaceBack( curFaceID, nodesInFace[i] );
       }
-    }
+
+      faceToCells( curFaceID, 0 ) = f0.cellIndex;
+      faceToBlocks( curFaceID, 0 ) = f0.blockIndex;
+
+      if( ++first != last )
+      {
+        NodesAndElementOfFace const & f1 = *first++;
+        faceToCells( curFaceID, 1 ) = f1.cellIndex;
+        faceToBlocks( curFaceID, 1 ) = f1.blockIndex;
+      }
+      else
+      {
+        faceToCells( curFaceID, 1 ) = -1;
+        faceToBlocks( curFaceID, 1 ) = -1;
+      }
+      GEOSX_ASSERT( first == last ); // Should not be more than 2 faces
+
+      ++curFaceID;
+    } );
   } );
 }
 
@@ -300,63 +332,38 @@ void populateFaceMaps( ArrayOfArraysView< NodesAndElementOfFace const > const & 
  * @param [in] lowestNodeToFaces and array of size numNodes of arrays of NodesAndElementOfFace associated with each node.
  * @param [in] uniqueFaceOffsets an containing the unique face IDs for each node in lowestNodeToFaces.
  * @param [out] faceToNodeMap the map from faces to nodes. This function resizes the array appropriately.
- * @param [out] faceToElemMap the map from faces to elements. This function resizes the array appropriately.
+ * @param [out] faceToCellMap the map from faces to elements. This function resizes the array appropriately.
  */
 void resizeFaceMaps( ArrayOfArraysView< NodesAndElementOfFace const > const & lowestNodeToFaces,
                      arrayView1d< localIndex const > const & uniqueFaceOffsets,
                      ArrayOfArrays< localIndex > & faceToNodeMap,
                      ArrayOfArrays< localIndex > & faceToEdgesMap,
-                     array2d< localIndex > & faceToElemMap )
+                     array2d< localIndex > & faceToCellMap,
+                     array2d< localIndex > & faceToBlockMap )
 {
-  GEOSX_MARK_FUNCTION;
-
   localIndex const numNodes = lowestNodeToFaces.size();
   localIndex const numUniqueFaces = uniqueFaceOffsets.back();
   array1d< localIndex > numNodesPerFace( numUniqueFaces );
-  RAJA::ReduceSum< parallelHostReduce, localIndex > totalFaceNodes( 0.0 );
 
   // loop over all the nodes.
-  forAll< parallelHostPolicy >( numNodes, [&]( localIndex const nodeID )
+  forAll< parallelHostPolicy >( numNodes, [uniqueFaceOffsets,
+                                           lowestNodeToFaces,
+                                           numNodesPerFace = numNodesPerFace.toView()]( localIndex const nodeIndex )
   {
-    localIndex const numFaces = lowestNodeToFaces.sizeOfArray( nodeID );
-    // loop over all the NodesAndElementOfFace associated with the node
-    for( localIndex j = 0, curFaceID = uniqueFaceOffsets[ nodeID ]; j < numFaces; ++j, ++curFaceID )
+    localIndex curFaceID = uniqueFaceOffsets[ nodeIndex ];
+    arraySlice1d< NodesAndElementOfFace const > const faces = lowestNodeToFaces[ nodeIndex ];
+    forUniqueValues( faces.begin(), faces.end(), [&]( NodesAndElementOfFace const & f, localIndex )
     {
-      const NodesAndElementOfFace & f0 = lowestNodeToFaces( nodeID, j );
-      numNodesPerFace[curFaceID] = f0.nodes.size();
-      totalFaceNodes += numNodesPerFace[curFaceID];
-
-      if( ( j < numFaces - 1 ) and ( f0 == lowestNodeToFaces( nodeID, j + 1 ) ) )
-      {
-        ++j;
-      }
-    }
+      numNodesPerFace[ curFaceID++ ] = f.numNodes + CellBlockManager::nodeMapExtraSpacePerFace();
+    } );
   } );
 
-  // Resize the face to node map.
-  faceToNodeMap.resize( 0 );
-
-  // Reserve space for the number of current faces plus some extra.
-  double const overAllocationFactor = 0.3;
-  localIndex const entriesToReserve = ( 1 + overAllocationFactor ) * numUniqueFaces; //TODO why this allocation factor
-  faceToNodeMap.reserve( entriesToReserve );
-
-  // Reserve space for the total number of face nodes + extra space for existing faces + even more space for new faces.
-  localIndex const valuesToReserve = totalFaceNodes.get() + numUniqueFaces * CellBlockManager::nodeMapExtraSpacePerFace() * ( 1 + 2 * overAllocationFactor );
-  faceToNodeMap.reserveValues( valuesToReserve );
-  faceToNodeMap.reserveValues( 2 * entriesToReserve ); //TODO I don"t undertand anythin about LVARRAY :@
-
-  // Append the individual arrays.
-  for( localIndex faceID = 0; faceID < numUniqueFaces; ++faceID )
-  {
-    faceToNodeMap.appendArray( numNodesPerFace[ faceID ] );
-    faceToNodeMap.setCapacityOfArray( faceToNodeMap.size() - 1,
-                                      numNodesPerFace[ faceID ] + CellBlockManager::nodeMapExtraSpacePerFace() );
-  }
+  faceToNodeMap.resizeFromCapacities< parallelHostPolicy >( numUniqueFaces, numNodesPerFace.data() );
 
   // Each face may belong to _maximum_ 2 elements.
   // If it belongs to only one, we put `-1` for the undefined value.
-  faceToElemMap.resize( numUniqueFaces, 2 );
+  faceToCellMap.resize( numUniqueFaces, 2 );
+  faceToBlockMap.resize( numUniqueFaces, 2 );
 
   // TODO I'm really not sure.
   faceToEdgesMap.resize( numUniqueFaces, 2 * CellBlockManager::edgeMapExtraSpacePerFace() );
@@ -375,38 +382,69 @@ void resizeFaceMaps( ArrayOfArraysView< NodesAndElementOfFace const > const & lo
  * E.g. faces {3, 5, 6, 2} and {4, 2, 9, 7} will both be stored in "bucket" of node 2.
  * Also, bucket of faces information are sorted (@see NodesAndElementOfFace) to make specific computations possible.
  */
-ArrayOfArrays< NodesAndElementOfFace > createLowestNodeToFaces( localIndex numNodes, const Group & cellBlocks )
+ArrayOfArrays< NodesAndElementOfFace >
+createLowestNodeToFaces( localIndex const numNodes, const Group & cellBlocks )
 {
-  ArrayOfArrays< NodesAndElementOfFace > lowestNodeToFaces( numNodes, 2 * CellBlockManager::maxFacesPerNode() );
-
-  // The function is a bit simplified and is not run in parallel anymore.
-  // Can be improved.
-  for( localIndex iCellBlock = 0; iCellBlock < cellBlocks.numSubGroups(); ++iCellBlock )
+  array1d< localIndex > faceCounts( numNodes );
+  for( localIndex blockIndex = 0; blockIndex < cellBlocks.numSubGroups(); ++blockIndex )
   {
-    const CellBlock & cb = cellBlocks.getGroup< CellBlock >( iCellBlock );
+    CellBlock const & cb = cellBlocks.getGroup< CellBlock >( blockIndex );
     localIndex const numFacesPerElement = cb.numFacesPerElement();
     localIndex const numElements = cb.numElements();
 
-    for( localIndex iElement = 0; iElement < numElements; ++iElement )
+    forAll< parallelHostPolicy >( numElements, [&cb, numFacesPerElement,
+                                                counts = faceCounts.toView()]( localIndex const elemID )
     {
-      // Looping on the faces of the cell
-      for( localIndex iFace = 0; iFace < numFacesPerElement; ++iFace )
+      localIndex nodesInFace[ CellBlockManager::maxNodesPerFace() ];
+      for( localIndex faceNum = 0; faceNum < numFacesPerElement; ++faceNum )
       {
         // Get all the nodes of the face
-        array1d< localIndex > nodesInFace;
-        cb.getFaceNodes( iElement, iFace, nodesInFace );
-        // Fill the result with the collected data.
-        localIndex const & lowestNode = *std::min_element( nodesInFace.begin(), nodesInFace.end() );
-        lowestNodeToFaces.emplaceBack( lowestNode, nodesInFace, iElement, iCellBlock, iFace );
+        localIndex const numNodesInFace = cb.getFaceNodes( elemID, faceNum, nodesInFace );
+        localIndex const lowestNode = *std::min_element( nodesInFace, nodesInFace + numNodesInFace );
+        RAJA::atomicInc< parallelHostAtomic >( &counts[ lowestNode ] );
       }
-    }
+    } );
   }
 
-  // Loop over all the nodes and sort the associated faces.
-  forAll< parallelHostPolicy >( numNodes, [&]( localIndex const nodeID )
+  ArrayOfArrays< NodesAndElementOfFace > lowestNodeToFaces;
+  lowestNodeToFaces.resizeFromCapacities< parallelHostPolicy >( numNodes, faceCounts.data() );
+
+  for( localIndex blockIndex = 0; blockIndex < cellBlocks.numSubGroups(); ++blockIndex )
   {
-    NodesAndElementOfFace * const faces = lowestNodeToFaces[ nodeID ];
-    std::sort( faces, faces + lowestNodeToFaces.sizeOfArray( nodeID ) );
+    CellBlock const & cb = cellBlocks.getGroup< CellBlock >( blockIndex );
+    localIndex const numFacesPerElement = cb.numFacesPerElement();
+    localIndex const numElements = cb.numElements();
+
+    forAll< parallelHostPolicy >( numElements, [&cb, numFacesPerElement, blockIndex,
+                                                lowestNodeToFaces = lowestNodeToFaces.toView()]( localIndex const elemID )
+    {
+      localIndex nodesInFace[ CellBlockManager::maxNodesPerFace() ];
+      for( localIndex faceNum = 0; faceNum < numFacesPerElement; ++faceNum )
+      {
+        // Get all the nodes of the face and find 3 lowest indices
+        localIndex const numNodesInFace = cb.getFaceNodes( elemID, faceNum, nodesInFace );
+        std::partial_sort( nodesInFace, nodesInFace + 3, nodesInFace + numNodesInFace );
+
+        lowestNodeToFaces.emplaceBackAtomic< parallelHostAtomic >( nodesInFace[0],
+                                                                   Span< localIndex >( nodesInFace, numNodesInFace ),
+                                                                   elemID,
+                                                                   blockIndex,
+                                                                   faceNum );
+      }
+    } );
+  }
+
+  auto const comp = []( NodesAndElementOfFace const & lhs, NodesAndElementOfFace const & rhs )
+  {
+    return std::tie( lhs.n1, lhs.n2, lhs.blockIndex, lhs.cellIndex ) < std::tie( rhs.n1, rhs.n2, rhs.blockIndex, rhs.cellIndex );
+  };
+
+  // Loop over all the nodes and sort the associated faces.
+  forAll< parallelHostPolicy >( numNodes, [lowestNodeToFaces = lowestNodeToFaces.toView(),
+                                           comp]( localIndex const nodeIndex )
+  {
+    arraySlice1d< NodesAndElementOfFace > const faces = lowestNodeToFaces[ nodeIndex ];
+    std::sort( faces.begin(), faces.end(), comp );
   } );
 
   return lowestNodeToFaces;
@@ -421,35 +459,29 @@ ArrayOfArrays< NodesAndElementOfFace > createLowestNodeToFaces( localIndex numNo
  *
  * @note @p lowestNodeToFaces and @p uniqueFaceOffsets are better described in the documentations of the functions that build them.
  */
-void fillElementToFacesOfCellBlocks( ArrayOfArrays< NodesAndElementOfFace > const & lowestNodeToFaces,
-                                     array1d< localIndex > const & uniqueFaceOffsets,
+void fillElementToFacesOfCellBlocks( ArrayOfArraysView< NodesAndElementOfFace const > const & lowestNodeToFaces,
+                                     arrayView1d< localIndex const > const & uniqueFaceOffsets,
                                      Group & cellBlocks )
 {
   localIndex const numNodes = lowestNodeToFaces.size();
-  for( localIndex nodeID = 0; nodeID < numNodes; ++nodeID )
+  forAll< parallelHostPolicy >( numNodes, [lowestNodeToFaces,
+                                           uniqueFaceOffsets,
+                                           &cellBlocks]( localIndex const nodeIndex )
   {
-    localIndex const numFaces = lowestNodeToFaces.sizeOfArray( nodeID );
-    for( localIndex j = 0, curFaceID = uniqueFaceOffsets[nodeID]; j < numFaces; ++j, ++curFaceID )
-    {
-      const NodesAndElementOfFace & f0 = lowestNodeToFaces( nodeID, j );
-      CellBlock & cb0 = cellBlocks.getGroup< CellBlock >( f0.iCellBlock );
-      cb0.setElementToFaces( f0.element, f0.iFace, curFaceID );
+    arraySlice1d< NodesAndElementOfFace const > const faces = lowestNodeToFaces[ nodeIndex ];
+    localIndex curFaceID = uniqueFaceOffsets[nodeIndex];
 
-      // If the following face exists and is identical to the current one,
-      // Then we insert the following face with the same face id
-      // and remove it from the next iteration (it's already inserted).
-      if( j < numFaces - 1 )
+    forEqualRanges( faces.begin(), faces.end(), [&]( auto first, auto last )
+    {
+      while( first != last )
       {
-        const NodesAndElementOfFace & f1 = lowestNodeToFaces( nodeID, j + 1 );
-        if( f0 == f1 )
-        {
-          CellBlock & cb1 = cellBlocks.getGroup< CellBlock >( f1.iCellBlock );
-          cb1.setElementToFaces( f1.element, f1.iFace, curFaceID );
-          ++j;
-        }
+        NodesAndElementOfFace const & f = *first++;
+        CellBlock & cb0 = cellBlocks.getGroup< CellBlock >( f.blockIndex );
+        cb0.setElementToFaces( f.cellIndex, f.faceNumber, curFaceID );
       }
-    }
-  }
+      ++curFaceID;
+    } );
+  } );
 }
 
 /**
@@ -457,12 +489,12 @@ void fillElementToFacesOfCellBlocks( ArrayOfArrays< NodesAndElementOfFace > cons
  * @param faceToEdges We need the face to edges mapping to get some edge index.
  * @param cellBlocks The cell blocks for which the mappings will be constructed.
  */
-void fillElementToEdgesOfCellBlocks( ArrayOfArrays< localIndex > const & faceToEdges,
+void fillElementToEdgesOfCellBlocks( ArrayOfArraysView< localIndex const > const & faceToEdges,
                                      Group & cellBlocks )
 {
-  for( localIndex iCellBlock = 0; iCellBlock < cellBlocks.numSubGroups(); ++iCellBlock )
+  for( localIndex blockIndex = 0; blockIndex < cellBlocks.numSubGroups(); ++blockIndex )
   {
-    CellBlock & cellBlock = cellBlocks.getGroup< CellBlock >( iCellBlock );
+    CellBlock & cellBlock = cellBlocks.getGroup< CellBlock >( blockIndex );
     arrayView2d< localIndex const > const cellToFaces = cellBlock.getElemToFacesConstView();
 
     // We build the edges of each face of each cell,
@@ -472,20 +504,22 @@ void fillElementToEdgesOfCellBlocks( ArrayOfArrays< localIndex > const & faceToE
     // to remove the duplicates.
 
     // Loop over the cells
-    for( localIndex kc = 0; kc < cellBlock.numElements(); kc++ )
+    forAll< parallelHostPolicy >( cellBlock.numElements(), [cellToFaces,
+                                                            faceToEdges,
+                                                            &cellBlock]( localIndex const kc )
     {
       int count = 0;
-      for( localIndex kf = 0; kf < cellBlock.numFacesPerElement(); kf++ )
+      for( localIndex kf = 0; kf < cellBlock.numFacesPerElement(); ++kf )
       {
         // Loop over edges of each face
         localIndex const faceIndex = cellToFaces[kc][kf];
-        for( localIndex ke = 0; ke < faceToEdges.sizeOfArray( faceIndex ); ke++ )
+        for( localIndex ke = 0; ke < faceToEdges.sizeOfArray( faceIndex ); ++ke )
         {
           bool isUnique = true;
-          localIndex edgeIndex = faceToEdges[faceIndex][ke];
+          localIndex const edgeIndex = faceToEdges[faceIndex][ke];
 
           // Loop over edges that have already been added to the element.
-          for( localIndex kec = 0; kec < count + 1; kec++ )
+          for( localIndex kec = 0; kec < count + 1; ++kec )
           {
             // make sure that the edge has not been counted yet
             if( cellBlock.hasElementToEdges( kc, kec, edgeIndex ) )
@@ -501,73 +535,51 @@ void fillElementToEdgesOfCellBlocks( ArrayOfArrays< localIndex > const & faceToE
           }
         } // end edge loop
       } // end face loop
-    } // end cell loop
+    } ); // end cell loop
   }
 }
 
 void CellBlockManager::buildFaceMaps()
 {
-  const ArrayOfArrays< NodesAndElementOfFace > lowestNodeToFaces = createLowestNodeToFaces( m_numNodes, this->getCellBlocks() );
+  GEOSX_MARK_FUNCTION;
 
-  array1d< localIndex > uniqueFaceOffsets( m_numNodes + 1 );
-  m_numFaces = calculateTotalNumberOfFaces( lowestNodeToFaces.toViewConst(), uniqueFaceOffsets );
+  ArrayOfArrays< NodesAndElementOfFace > const lowestNodeToFaces =
+    createLowestNodeToFaces( m_numNodes, this->getCellBlocks() );
+
+  array1d< localIndex > const uniqueFaceOffsets =
+    computeUniqueValueOffsets< parallelHostPolicy >( lowestNodeToFaces.toViewConst() );
+  m_numFaces = uniqueFaceOffsets.back();
 
   resizeFaceMaps( lowestNodeToFaces.toViewConst(),
                   uniqueFaceOffsets,
                   m_faceToNodes,
                   m_faceToEdges,
-                  m_faceToElements );
+                  m_faceToCells.toCellIndex,
+                  m_faceToCells.toBlockIndex );
 
-  populateFaceMaps( lowestNodeToFaces.toViewConst(),
+  populateFaceMaps( getCellBlocks(),
+                    lowestNodeToFaces.toViewConst(),
                     uniqueFaceOffsets,
-                    m_faceToNodes,
-                    m_faceToElements );
+                    m_faceToNodes.toView(),
+                    m_faceToCells.toCellIndex,
+                    m_faceToCells.toBlockIndex );
 
-  fillElementToFacesOfCellBlocks( lowestNodeToFaces, uniqueFaceOffsets, this->getCellBlocks() );
+  fillElementToFacesOfCellBlocks( lowestNodeToFaces.toViewConst(),
+                                  uniqueFaceOffsets,
+                                  this->getCellBlocks() );
 }
 
 void CellBlockManager::buildNodeToEdges()
 {
-  ArrayOfArrays< localIndex > toEdgesTemp( m_numNodes, maxEdgesPerNode() );
-  RAJA::ReduceSum< parallelHostReduce, localIndex > totalNodeEdges = 0;
-
-  forAll< parallelHostPolicy >( m_numEdges, [&]( localIndex const edgeID )
-  {
-    toEdgesTemp.emplaceBackAtomic< parallelHostAtomic >( m_edgeToNodes( edgeID, 0 ), edgeID );
-    toEdgesTemp.emplaceBackAtomic< parallelHostAtomic >( m_edgeToNodes( edgeID, 1 ), edgeID );
-    totalNodeEdges += 2;
-  } );
-
-  // Resize the node to edge map.
-  m_nodeToEdges.resize( 0 );
-
-  // Reserve space for the number of current nodes plus some extra.
-  double const overAllocationFactor = 0.3;
-  localIndex const entriesToReserve = ( 1 + overAllocationFactor ) * m_numNodes;
-  m_nodeToEdges.reserve( entriesToReserve );
-
-  // Reserve space for the total number of face nodes + extra space for existing faces + even more space for new faces.
-  localIndex const valuesToReserve = totalNodeEdges.get() + m_numNodes * getEdgeMapOverallocation() * ( 1 + 2 * overAllocationFactor );
-  m_nodeToEdges.reserveValues( valuesToReserve );
-
-  // Append the individual sets.
-  for( localIndex nodeID = 0; nodeID < m_numNodes; ++nodeID )
-  {
-    m_nodeToEdges.appendSet( toEdgesTemp.sizeOfArray( nodeID ) + getEdgeMapOverallocation() );
-  }
-
-  ArrayOfSetsView< localIndex > const & toEdgesView = m_nodeToEdges.toView(); // FIXME why a view here?
-  forAll< parallelHostPolicy >( m_numNodes, [&]( localIndex const nodeID )
-  {
-    localIndex * const edges = toEdgesTemp[ nodeID ];
-    localIndex const numNodeEdges = toEdgesTemp.sizeOfArray( nodeID );
-    localIndex const numUniqueEdges = LvArray::sortedArrayManipulation::makeSortedUnique( edges, edges + numNodeEdges );
-    toEdgesView.insertIntoSet( nodeID, edges, edges + numUniqueEdges );
-  } );
+  m_nodeToEdges = meshMapUtilities::transposeIndexMap< parallelHostPolicy >( m_edgeToNodes.toViewConst(),
+                                                                             m_numNodes,
+                                                                             edgeMapExtraSpacePerNode() );
 }
 
 void CellBlockManager::buildMaps()
 {
+  GEOSX_MARK_FUNCTION;
+
   buildFaceMaps();
   m_numEdges = buildEdgeMaps( m_numNodes,
                               m_faceToNodes.toViewConst(),
@@ -576,7 +588,7 @@ void CellBlockManager::buildMaps()
                               m_edgeToNodes );
   buildNodeToEdges();
 
-  fillElementToEdgesOfCellBlocks( m_faceToEdges, this->getCellBlocks() );
+  fillElementToEdgesOfCellBlocks( m_faceToEdges.toViewConst(), this->getCellBlocks() );
 }
 
 ArrayOfArrays< localIndex > CellBlockManager::getFaceToNodes() const
@@ -584,56 +596,16 @@ ArrayOfArrays< localIndex > CellBlockManager::getFaceToNodes() const
   return m_faceToNodes;
 }
 
-ArrayOfSets< localIndex > CellBlockManager::getNodeToFaces() const
+ArrayOfArrays< localIndex > CellBlockManager::getNodeToFaces() const
 {
-  localIndex const numFaces = m_faceToNodes.size();
-  ArrayOfArrays< localIndex > nodeToFacesTemp( m_numNodes, maxFacesPerNode() );
-  RAJA::ReduceSum< parallelHostReduce, localIndex > totalNodeFaces = 0;
-
-  forAll< parallelHostPolicy >( numFaces, [&]( localIndex const faceID )
-  {
-    localIndex const numFaceNodes = m_faceToNodes.sizeOfArray( faceID );
-    totalNodeFaces += numFaceNodes;
-    for( localIndex a = 0; a < numFaceNodes; ++a )
-    {
-      nodeToFacesTemp.emplaceBackAtomic< parallelHostAtomic >( m_faceToNodes( faceID, a ), faceID );
-    }
-  } );
-
-  ArrayOfSets< localIndex > result;
-
-  // Resize the node to face map.
-  result.resize( 0 );
-
-  // Reserve space for the number of nodes faces plus some extra.
-  double const overAllocationFactor = 0.3;
-  localIndex const entriesToReserve = ( 1 + overAllocationFactor ) * m_numNodes;
-  result.reserve( entriesToReserve );
-
-  // Reserve space for the total number of node faces + extra space for existing nodes + even more space for new nodes.
-  localIndex const valuesToReserve = totalNodeFaces.get() + m_numNodes * nodeMapExtraSpacePerFace() * ( 1 + 2 * overAllocationFactor );
-  result.reserveValues( valuesToReserve );
-
-  // Append the individual arrays.
-  for( localIndex nodeID = 0; nodeID < m_numNodes; ++nodeID )
-  {
-    result.appendSet( nodeToFacesTemp.sizeOfArray( nodeID ) + getFaceMapOverallocation() );
-  }
-
-  forAll< parallelHostPolicy >( m_numNodes, [&]( localIndex const nodeID )
-  {
-    localIndex * const faces = nodeToFacesTemp[ nodeID ];
-    localIndex const numNodeFaces = nodeToFacesTemp.sizeOfArray( nodeID );
-    localIndex const numUniqueFaces = LvArray::sortedArrayManipulation::makeSortedUnique( faces, faces + numNodeFaces );
-    result.insertIntoSet( nodeID, faces, faces + numUniqueFaces );
-  } );
-
-  return result;
+  return meshMapUtilities::transposeIndexMap< parallelHostPolicy >( m_faceToNodes.toViewConst(),
+                                                                    m_numNodes,
+                                                                    faceMapExtraSpacePerNode() );
 }
 
-array2d< localIndex > CellBlockManager::getFaceToElements() const
+ToCellRelation< array2d< localIndex > > CellBlockManager::getFaceToElements() const
 {
-  return m_faceToElements;
+  return m_faceToCells;
 }
 
 const Group & CellBlockManager::getCellBlocks() const
@@ -656,9 +628,9 @@ localIndex CellBlockManager::numCellBlocks() const
   return this->getCellBlocks().numSubGroups();
 }
 
-const CellBlockABC & CellBlockManager::getCellBlock( localIndex iCellBlock ) const
+CellBlock const & CellBlockManager::getCellBlock( localIndex const blockIndex ) const
 {
-  return this->getCellBlocks().getGroup< const CellBlockABC >( iCellBlock );
+  return this->getCellBlocks().getGroup< CellBlock >( blockIndex );
 }
 
 localIndex CellBlockManager::numFaces() const
@@ -666,7 +638,7 @@ localIndex CellBlockManager::numFaces() const
   return m_numFaces;
 }
 
-ArrayOfSets< localIndex > CellBlockManager::getEdgeToFaces() const
+ArrayOfArrays< localIndex > CellBlockManager::getEdgeToFaces() const
 {
   return m_edgeToFaces;
 }
@@ -681,9 +653,11 @@ ArrayOfArrays< localIndex > CellBlockManager::getFaceToEdges() const
   return m_faceToEdges;
 }
 
-ArrayOfSets< localIndex > CellBlockManager::getNodeToEdges() const
+ArrayOfArrays< localIndex > CellBlockManager::getNodeToEdges() const
 {
-  return m_nodeToEdges;
+  return meshMapUtilities::transposeIndexMap< parallelHostPolicy >( m_edgeToNodes.toViewConst(),
+                                                                    m_numNodes,
+                                                                    edgeMapExtraSpacePerNode() );
 }
 
 localIndex CellBlockManager::numEdges() const
@@ -691,17 +665,17 @@ localIndex CellBlockManager::numEdges() const
   return m_numEdges;
 }
 
-CellBlock & CellBlockManager::registerCellBlock( string name )
+CellBlock & CellBlockManager::registerCellBlock( string const & name )
 {
   return this->getCellBlocks().registerGroup< CellBlock >( name );
 }
 
-array2d< real64, nodes::REFERENCE_POSITION_PERM > CellBlockManager::getNodesPositions() const
+array2d< real64, nodes::REFERENCE_POSITION_PERM > CellBlockManager::getNodePositions() const
 {
   return m_nodesPositions;
 }
 
-arrayView2d< real64, nodes::REFERENCE_POSITION_USD > CellBlockManager::getNodesPositions()
+arrayView2d< real64, nodes::REFERENCE_POSITION_USD > CellBlockManager::getNodePositions()
 {
   return m_nodesPositions.toView();
 }

--- a/src/coreComponents/mesh/generators/CellBlockManager.hpp
+++ b/src/coreComponents/mesh/generators/CellBlockManager.hpp
@@ -43,20 +43,13 @@ public:
   virtual Group * createChild( string const & childKey, string const & childName ) override;
 
   /**
-   * @brief Maximum number of faces allowed (in memory) per each node.
+   * @brief Maximum number of nodes allowed (in memory) per each face.
    * @return The number as an integer.
    */
-  static constexpr int maxFacesPerNode()
-  { return 200; }
+  static constexpr int maxNodesPerFace()
+  { return 64; }
 
-  /**
-   * @brief Extra space for node to faces mapping.
-   * @return Number of extra values as an integer.
-   */
-  static constexpr localIndex getFaceMapOverallocation()
-  { return 8; }
-
-  array2d< real64, nodes::REFERENCE_POSITION_PERM > getNodesPositions() const override;
+  array2d< real64, nodes::REFERENCE_POSITION_PERM > getNodePositions() const override;
 
   /**
    * @brief Returns a view to the vector holding the nodes coordinates
@@ -64,23 +57,23 @@ public:
    *
    * @note This is meant to be used as a values setter.
    */
-  arrayView2d< real64, nodes::REFERENCE_POSITION_USD > getNodesPositions();
+  arrayView2d< real64, nodes::REFERENCE_POSITION_USD > getNodePositions();
 
-  ArrayOfSets< localIndex > getNodeToEdges() const override;
+  ArrayOfArrays< localIndex > getNodeToEdges() const override;
 
-  ArrayOfSets< localIndex > getNodeToFaces() const override;
+  ArrayOfArrays< localIndex > getNodeToFaces() const override;
 
-  ArrayOfArrays< localIndex > getNodeToElements() const override;
+  ToCellRelation< ArrayOfArrays< localIndex > > getNodeToElements() const override;
 
   array2d< localIndex > getEdgeToNodes() const override;
 
-  ArrayOfSets< localIndex > getEdgeToFaces() const override;
+  ArrayOfArrays< localIndex > getEdgeToFaces() const override;
 
   ArrayOfArrays< localIndex > getFaceToNodes() const override;
 
   ArrayOfArrays< localIndex > getFaceToEdges() const override;
 
-  array2d< localIndex > getFaceToElements() const override;
+  ToCellRelation< array2d< localIndex > > getFaceToElements() const override;
 
   array1d< globalIndex > getNodeLocalToGlobal() const override;
 
@@ -156,7 +149,7 @@ public:
    * @param name The name of the created cell block.
    * @return A reference to the new cell block. The CellBlockManager owns this new instance.
    */
-  CellBlock & registerCellBlock( string name );
+  CellBlock & registerCellBlock( string const & name );
 
   /**
    * @brief Launch kernel function over all the sub-regions
@@ -178,13 +171,13 @@ private:
   };
 
   /**
-   * @brief Get cell block at index @p iCellBlock.
-   * @param[in] iCellBlock The cell block index.
+   * @brief Get cell block at index @p blockIndex.
+   * @param[in] blockIndex The cell block index.
    * @return Const reference to the instance.
    *
    * @note Mainly useful for iteration purposes.
    */
-  const CellBlockABC & getCellBlock( localIndex iCellBlock ) const;
+  CellBlock const & getCellBlock( localIndex const blockIndex ) const;
 
   /**
    * @brief Returns the number of cells blocks
@@ -202,14 +195,20 @@ private:
    */
   void buildFaceMaps();
 
+  template< typename BASEMAP, typename FUNC >
+  void buildToCellMap( localIndex const cellIndex,
+                       ToCellRelation< BASEMAP > & toCells,
+                       FUNC cellToObjectGetter,
+                       localIndex const overAlloc = 0 ) const;
+
   array2d< real64, nodes::REFERENCE_POSITION_PERM > m_nodesPositions;
 
-  ArrayOfSets< localIndex > m_nodeToEdges;
-  ArrayOfSets< localIndex > m_edgeToFaces;
+  ArrayOfArrays< localIndex > m_nodeToEdges;
+  ArrayOfArrays< localIndex > m_edgeToFaces;
   array2d< localIndex > m_edgeToNodes;
   ArrayOfArrays< localIndex >  m_faceToNodes;
   ArrayOfArrays< localIndex > m_faceToEdges;
-  array2d< localIndex >  m_faceToElements;
+  ToCellRelation< array2d< localIndex > > m_faceToCells;
 
   array1d< globalIndex >  m_nodeLocalToGlobal;
 

--- a/src/coreComponents/mesh/generators/CellBlockManagerABC.hpp
+++ b/src/coreComponents/mesh/generators/CellBlockManagerABC.hpp
@@ -23,6 +23,17 @@ namespace geosx
 {
 
 /**
+ * @brief Container for maps from a mesh object (node, edge or face) to cells.
+ * @tparam BASETYPE underlying map type
+ */
+template< typename BASETYPE >
+struct ToCellRelation
+{
+  BASETYPE toBlockIndex; ///< Map containing a list of cell block indices for each object
+  BASETYPE toCellIndex;  ///< Map containing cell indices, same shape as above
+};
+
+/**
  * @brief Abstract base class for CellBlockManager.
  */
 class CellBlockManagerABC : public dataRepository::Group
@@ -41,24 +52,24 @@ public:
   }
 
   /**
-   * @brief Maximum number of edges allowed (in memory) per each node.
-   * @return The number as an integer.
-   */
-  static constexpr int maxEdgesPerNode()
-  { return 200; }
-
-  /**
    * @brief Extra space for node to edges mapping.
    * @return Number of extra values as an integer.
    */
-  static constexpr localIndex getEdgeMapOverallocation()
+  static constexpr localIndex edgeMapExtraSpacePerNode()
+  { return 8; }
+
+  /**
+   * @brief Extra space for node to faces mapping.
+   * @return Number of extra values as an integer.
+   */
+  static constexpr localIndex faceMapExtraSpacePerNode()
   { return 8; }
 
   /**
    * @brief Extra space for node to elements mapping.
    * @return Number of extra values as an integer.
    */
-  static constexpr localIndex getElemMapOverAllocation()
+  static constexpr localIndex elemMapExtraSpacePerNode()
   { return 8; }
 
   /**
@@ -120,28 +131,25 @@ public:
    * @brief Returns the node coordinates in a (numNodes, 3) 2d array.
    * @return A const view to the array.
    */
-  virtual array2d< real64, nodes::REFERENCE_POSITION_PERM > getNodesPositions() const = 0;
+  virtual array2d< real64, nodes::REFERENCE_POSITION_PERM > getNodePositions() const = 0;
 
   /**
    * @brief Returns the node to edges mapping.
    * @return The one to many relationship.
    */
-  virtual ArrayOfSets< localIndex > getNodeToEdges() const = 0;
+  virtual ArrayOfArrays< localIndex > getNodeToEdges() const = 0;
 
   /**
    * @brief Returns the face to nodes mappings.
    * @return The one to many relationship.
    */
-  virtual ArrayOfSets< localIndex > getNodeToFaces() const = 0;
+  virtual ArrayOfArrays< localIndex > getNodeToFaces() const = 0;
 
   /**
    * @brief Returns the node to elements mapping.
    * @return A one to many relationship.
-   *
-   * @note The mapping is computed on the fly and returned. It is not stored in the instance.
    */
-  virtual ArrayOfArrays< localIndex > getNodeToElements() const = 0;
-
+  virtual ToCellRelation< ArrayOfArrays< localIndex > > getNodeToElements() const = 0;
   /**
    * @brief Returns the edge to nodes mapping.
    * @return A 1 to 2 relationship. The result is meant to have size (numEdges, 2).
@@ -152,7 +160,7 @@ public:
    * @brief Returns the edge to faces mapping.
    * @return A one to many relationship.
    */
-  virtual ArrayOfSets< localIndex > getEdgeToFaces() const = 0;
+  virtual ArrayOfArrays< localIndex > getEdgeToFaces() const = 0;
 
   /**
    * @brief Returns the face to nodes mapping.
@@ -167,12 +175,12 @@ public:
   virtual ArrayOfArrays< localIndex > getFaceToEdges() const = 0;
 
   /**
-   * @brief Returns the face to elements mappings.
+   * @brief Returns the face to elements mapping.
    * @return A 1 to 2 relationship. The result is meant to have size (numFaces, 2).
    *
    * In case the face only belongs to one single element, the second value of the table is -1.
    */
-  virtual array2d< localIndex > getFaceToElements() const = 0;
+  virtual ToCellRelation< array2d< localIndex > > getFaceToElements() const = 0;
 
   /**
    * @brief The node to global mapping for nodes.

--- a/src/coreComponents/mesh/generators/CellBlockUtilities.cpp
+++ b/src/coreComponents/mesh/generators/CellBlockUtilities.cpp
@@ -14,418 +14,375 @@
 
 #include "CellBlockUtilities.hpp"
 
-#include "CellBlockManagerABC.hpp"
-
+#include "codingUtilities/Utilities.hpp"
 #include "common/GEOS_RAJA_Interface.hpp"
 #include "common/TimingMacros.hpp"
+#include "mesh/generators/CellBlockManagerABC.hpp"
 
 namespace geosx
 {
 
-void getFaceNodes( ElementType const & elementType,
-                   localIndex const iElement,
-                   localIndex const iFace,
-                   array2d< localIndex, cells::NODE_MAP_PERMUTATION > const & elementToNodes,
-                   array1d< localIndex > & nodeIndices )
+static localIndex getFaceNodesHex( localIndex const faceNum,
+                                   arraySlice1d< localIndex const, cells::NODE_MAP_USD-1 > const & elemNodes,
+                                   Span< localIndex > const faceNodes )
+{
+  GEOSX_ERROR_IF_LT( faceNodes.size(), 4 );
+  switch( faceNum )
+  {
+    case 0:
+    {
+      faceNodes[0] = elemNodes[0];
+      faceNodes[1] = elemNodes[1];
+      faceNodes[2] = elemNodes[5];
+      faceNodes[3] = elemNodes[4];
+      break;
+    }
+    case 1:
+    {
+      faceNodes[0] = elemNodes[0];
+      faceNodes[1] = elemNodes[2];
+      faceNodes[2] = elemNodes[3];
+      faceNodes[3] = elemNodes[1];
+      break;
+    }
+    case 2:
+    {
+      faceNodes[0] = elemNodes[0];
+      faceNodes[1] = elemNodes[4];
+      faceNodes[2] = elemNodes[6];
+      faceNodes[3] = elemNodes[2];
+      break;
+    }
+    case 3:
+    {
+      faceNodes[0] = elemNodes[1];
+      faceNodes[1] = elemNodes[3];
+      faceNodes[2] = elemNodes[7];
+      faceNodes[3] = elemNodes[5];
+      break;
+    }
+    case 4:
+    {
+      faceNodes[0] = elemNodes[3];
+      faceNodes[1] = elemNodes[2];
+      faceNodes[2] = elemNodes[6];
+      faceNodes[3] = elemNodes[7];
+      break;
+    }
+    case 5:
+    {
+      faceNodes[0] = elemNodes[4];
+      faceNodes[1] = elemNodes[5];
+      faceNodes[2] = elemNodes[7];
+      faceNodes[3] = elemNodes[6];
+      break;
+    }
+    default:
+    {
+      GEOSX_ERROR( "Invalid local face index for element of type Hexahedron: " << faceNum );
+    }
+  }
+  return 4;
+}
+
+static localIndex getFaceNodesPrism( localIndex const faceNum,
+                                     arraySlice1d< localIndex const, cells::NODE_MAP_USD - 1 > const & elemNodes,
+                                     Span< localIndex > const faceNodes )
+{
+  switch( faceNum )
+  {
+    case 0:
+    {
+      GEOSX_ERROR_IF_LT( faceNodes.size(), 4 );
+      faceNodes[0] = elemNodes[0];
+      faceNodes[1] = elemNodes[1];
+      faceNodes[2] = elemNodes[5];
+      faceNodes[3] = elemNodes[4];
+      return 4;
+    }
+    case 1:
+    {
+      GEOSX_ERROR_IF_LT( faceNodes.size(), 4 );
+      faceNodes[0] = elemNodes[0];
+      faceNodes[1] = elemNodes[2];
+      faceNodes[2] = elemNodes[3];
+      faceNodes[3] = elemNodes[1];
+      return 4;
+    }
+    case 2:
+    {
+      GEOSX_ERROR_IF_LT( faceNodes.size(), 3 );
+      faceNodes[0] = elemNodes[0];
+      faceNodes[1] = elemNodes[2];
+      faceNodes[2] = elemNodes[4];
+      return 3;
+    }
+    case 3:
+    {
+      GEOSX_ERROR_IF_LT( faceNodes.size(), 3 );
+      faceNodes[0] = elemNodes[1];
+      faceNodes[1] = elemNodes[3];
+      faceNodes[2] = elemNodes[5];
+      return 3;
+    }
+    case 4:
+    {
+      GEOSX_ERROR_IF_LT( faceNodes.size(), 4 );
+      faceNodes[0] = elemNodes[2];
+      faceNodes[1] = elemNodes[3];
+      faceNodes[2] = elemNodes[5];
+      faceNodes[3] = elemNodes[4];
+      return 4;
+    }
+    default:
+    {
+      GEOSX_ERROR( "Invalid local face index for element of type Prism: " << faceNum );
+      return 0;
+    }
+  }
+}
+
+static localIndex getFaceNodesTet( localIndex const faceNum,
+                                   arraySlice1d< localIndex const, cells::NODE_MAP_USD-1 > const & elemNodes,
+                                   Span< localIndex > const faceNodes )
+{
+  GEOSX_ERROR_IF_LT( faceNodes.size(), 3 );
+  switch( faceNum )
+  {
+    case 0:
+    {
+      faceNodes[0] = elemNodes[0];
+      faceNodes[1] = elemNodes[2];
+      faceNodes[2] = elemNodes[1];
+      break;
+    }
+    case 1:
+    {
+      faceNodes[0] = elemNodes[0];
+      faceNodes[1] = elemNodes[1];
+      faceNodes[2] = elemNodes[3];
+      break;
+    }
+    case 2:
+    {
+      faceNodes[0] = elemNodes[0];
+      faceNodes[1] = elemNodes[3];
+      faceNodes[2] = elemNodes[2];
+      break;
+    }
+    case 3:
+    {
+      faceNodes[0] = elemNodes[1];
+      faceNodes[1] = elemNodes[2];
+      faceNodes[2] = elemNodes[3];
+      break;
+    }
+    default:
+    {
+      GEOSX_ERROR( "Invalid local face index for element of type Tetrahedron: " << faceNum );
+    }
+  }
+  return 3;
+}
+
+static localIndex getFaceNodesPyramid( localIndex const faceNum,
+                                       arraySlice1d< localIndex const, cells::NODE_MAP_USD - 1 > const & elemNodes,
+                                       Span< localIndex > const faceNodes )
+{
+  switch( faceNum )
+  {
+    case 0:
+    {
+      GEOSX_ERROR_IF_LT( faceNodes.size(), 4 );
+      faceNodes[0] = elemNodes[0];
+      faceNodes[1] = elemNodes[1];
+      faceNodes[2] = elemNodes[2];
+      faceNodes[3] = elemNodes[3];
+      return 4;
+    }
+    case 1:
+    {
+      GEOSX_ERROR_IF_LT( faceNodes.size(), 4 );
+      faceNodes[0] = elemNodes[0];
+      faceNodes[1] = elemNodes[1];
+      faceNodes[2] = elemNodes[4];
+      return 3;
+    }
+    case 2:
+    {
+      GEOSX_ERROR_IF_LT( faceNodes.size(), 4 );
+      faceNodes[0] = elemNodes[1];
+      faceNodes[1] = elemNodes[2];
+      faceNodes[2] = elemNodes[4];
+      return 3;
+    }
+    case 3:
+    {
+      GEOSX_ERROR_IF_LT( faceNodes.size(), 4 );
+      faceNodes[0] = elemNodes[2];
+      faceNodes[1] = elemNodes[3];
+      faceNodes[2] = elemNodes[4];
+      return 3;
+    }
+    case 4:
+    {
+      GEOSX_ERROR_IF_LT( faceNodes.size(), 4 );
+      faceNodes[0] = elemNodes[3];
+      faceNodes[1] = elemNodes[0];
+      faceNodes[2] = elemNodes[4];
+      return 3;
+    }
+    default:
+    {
+      GEOSX_ERROR( "Invalid local face index for element of type Pyramid: " << faceNum );
+      return 0;
+    }
+  }
+}
+
+localIndex getFaceNodes( ElementType const elementType,
+                         localIndex const elemIdx,
+                         localIndex const faceNumber,
+                         arrayView2d< localIndex const, cells::NODE_MAP_USD > const & elementToNodes,
+                         Span< localIndex > const faceNodes )
 {
   switch( elementType )
   {
     case ElementType::Hexahedron:
     {
-      nodeIndices.resize( 4 );
-      switch( iFace )
-      {
-        case 0:
-        {
-          nodeIndices[0] = elementToNodes[iElement][0];
-          nodeIndices[1] = elementToNodes[iElement][1];
-          nodeIndices[2] = elementToNodes[iElement][5];
-          nodeIndices[3] = elementToNodes[iElement][4];
-          break;
-        }
-        case 1:
-        {
-          nodeIndices[0] = elementToNodes[iElement][0];
-          nodeIndices[1] = elementToNodes[iElement][2];
-          nodeIndices[2] = elementToNodes[iElement][3];
-          nodeIndices[3] = elementToNodes[iElement][1];
-          break;
-        }
-        case 2:
-        {
-          nodeIndices[0] = elementToNodes[iElement][0];
-          nodeIndices[1] = elementToNodes[iElement][4];
-          nodeIndices[2] = elementToNodes[iElement][6];
-          nodeIndices[3] = elementToNodes[iElement][2];
-          break;
-        }
-        case 3:
-        {
-          nodeIndices[0] = elementToNodes[iElement][1];
-          nodeIndices[1] = elementToNodes[iElement][3];
-          nodeIndices[2] = elementToNodes[iElement][7];
-          nodeIndices[3] = elementToNodes[iElement][5];
-          break;
-        }
-        case 4:
-        {
-          nodeIndices[0] = elementToNodes[iElement][3];
-          nodeIndices[1] = elementToNodes[iElement][2];
-          nodeIndices[2] = elementToNodes[iElement][6];
-          nodeIndices[3] = elementToNodes[iElement][7];
-          break;
-        }
-        case 5:
-        {
-          nodeIndices[0] = elementToNodes[iElement][4];
-          nodeIndices[1] = elementToNodes[iElement][5];
-          nodeIndices[2] = elementToNodes[iElement][7];
-          nodeIndices[3] = elementToNodes[iElement][6];
-          break;
-        }
-        default:
-        {
-          GEOSX_ERROR( "Invalid local face index: " << iFace );
-        }
-      }
-      break;
+      return getFaceNodesHex( faceNumber, elementToNodes[elemIdx], faceNodes );
     }
     case ElementType::Prism:
     {
-      switch( iFace )
-      {
-        case 0:
-        {
-          nodeIndices.resize( 4 );
-          nodeIndices[0] = elementToNodes[iElement][0];
-          nodeIndices[1] = elementToNodes[iElement][1];
-          nodeIndices[2] = elementToNodes[iElement][5];
-          nodeIndices[3] = elementToNodes[iElement][4];
-          break;
-        }
-        case 1:
-        {
-          nodeIndices.resize( 4 );
-          nodeIndices[0] = elementToNodes[iElement][0];
-          nodeIndices[1] = elementToNodes[iElement][2];
-          nodeIndices[2] = elementToNodes[iElement][3];
-          nodeIndices[3] = elementToNodes[iElement][1];
-          break;
-        }
-        case 2:
-        {
-          nodeIndices.resize( 3 );
-          nodeIndices[0] = elementToNodes[iElement][0];
-          nodeIndices[1] = elementToNodes[iElement][2];
-          nodeIndices[2] = elementToNodes[iElement][4];
-          break;
-        }
-        case 3:
-        {
-          nodeIndices.resize( 3 );
-          nodeIndices[0] = elementToNodes[iElement][1];
-          nodeIndices[1] = elementToNodes[iElement][3];
-          nodeIndices[2] = elementToNodes[iElement][5];
-          break;
-        }
-        case 4:
-        {
-          nodeIndices.resize( 4 );
-          nodeIndices[0] = elementToNodes[iElement][2];
-          nodeIndices[1] = elementToNodes[iElement][3];
-          nodeIndices[2] = elementToNodes[iElement][5];
-          nodeIndices[3] = elementToNodes[iElement][4];
-          break;
-        }
-        default:
-        {
-          GEOSX_ERROR( "Invalid local face index: " << iFace );
-        }
-      }
-      break;
+      return getFaceNodesPrism( faceNumber, elementToNodes[elemIdx], faceNodes );
     }
     case ElementType::Tetrahedron:
     {
-      nodeIndices.resize( 3 );
-      switch( iFace )
-      {
-        case 0:
-        {
-          nodeIndices[0] = elementToNodes[iElement][0];
-          nodeIndices[1] = elementToNodes[iElement][2];
-          nodeIndices[2] = elementToNodes[iElement][1];
-          break;
-        }
-        case 1:
-        {
-          nodeIndices[0] = elementToNodes[iElement][0];
-          nodeIndices[1] = elementToNodes[iElement][1];
-          nodeIndices[2] = elementToNodes[iElement][3];
-          break;
-        }
-        case 2:
-        {
-          nodeIndices[0] = elementToNodes[iElement][0];
-          nodeIndices[1] = elementToNodes[iElement][3];
-          nodeIndices[2] = elementToNodes[iElement][2];
-          break;
-        }
-        case 3:
-        {
-          nodeIndices[0] = elementToNodes[iElement][1];
-          nodeIndices[1] = elementToNodes[iElement][2];
-          nodeIndices[2] = elementToNodes[iElement][3];
-          break;
-        }
-        default:
-        {
-          GEOSX_ERROR( "Invalid local face index: " << iFace );
-        }
-      }
-      break;
+      return getFaceNodesTet( faceNumber, elementToNodes[elemIdx], faceNodes );
     }
     case ElementType::Pyramid:
     {
-      switch( iFace )
-      {
-        case 0:
-        {
-          nodeIndices.resize( 4 );
-          nodeIndices[0] = elementToNodes[iElement][0];
-          nodeIndices[1] = elementToNodes[iElement][1];
-          nodeIndices[2] = elementToNodes[iElement][2];
-          nodeIndices[3] = elementToNodes[iElement][3];
-          break;
-        }
-        case 1:
-        {
-          nodeIndices.resize( 3 );
-          nodeIndices[0] = elementToNodes[iElement][0];
-          nodeIndices[1] = elementToNodes[iElement][1];
-          nodeIndices[2] = elementToNodes[iElement][4];
-          break;
-        }
-        case 2:
-        {
-          nodeIndices.resize( 3 );
-          nodeIndices[0] = elementToNodes[iElement][1];
-          nodeIndices[1] = elementToNodes[iElement][2];
-          nodeIndices[2] = elementToNodes[iElement][4];
-          break;
-        }
-        case 3:
-        {
-          nodeIndices.resize( 3 );
-          nodeIndices[0] = elementToNodes[iElement][2];
-          nodeIndices[1] = elementToNodes[iElement][3];
-          nodeIndices[2] = elementToNodes[iElement][4];
-          break;
-        }
-        case 4:
-        {
-          nodeIndices.resize( 3 );
-          nodeIndices[0] = elementToNodes[iElement][3];
-          nodeIndices[1] = elementToNodes[iElement][0];
-          nodeIndices[2] = elementToNodes[iElement][4];
-          break;
-        }
-        default:
-        {
-          GEOSX_ERROR( "Invalid local face index: " << iFace );
-        }
-      }
-      break;
+      return getFaceNodesPyramid( faceNumber, elementToNodes[elemIdx], faceNodes );
     }
     default:
     {
       GEOSX_ERROR( "Invalid element type: " << elementType );
     }
   }
+  return 0;
 }
 
 /**
- * @class EdgeBuilder
- * @brief This class stores the data necessary to construct the various edge maps.
+ * @brief Stores the data necessary to construct the various edge maps.
+ *
+ * These records are created and stored when visiting edges through faces.
+ * Organizing and sorting them by both nodes enables identification of
+ * matching edges of different faces. Face indices are preserved
+ * so that face-edge maps may be constructed.
  */
 struct EdgeBuilder
 {
   /**
    * @brief Constructor.
-   * @param [in] n1_ the greater of the two node indices that comprise the edge.
-   * @param [in] faceID_ the ID of the face this edge came from.
-   * @param [in] faceLocalEdgeIndex_ the face local index of this edge.
+   * @param [in] node1 the greater of the two node indices that comprise the edge.
+   * @param [in] face the ID of the face this edge came from.
+   * @param [in] edgeNum the face local index of this edge.
    */
-  EdgeBuilder( localIndex const n1_,
-               localIndex const faceID_,
-               localIndex const faceLocalEdgeIndex_ ):
-    n1( int32_t( n1_ ) ),
-    faceID( int32_t( faceID_ ) ),
-    faceLocalEdgeIndex( int32_t( faceLocalEdgeIndex_ ) )
+  EdgeBuilder( localIndex const node1,
+               localIndex const face,
+               localIndex const edgeNum ):
+    n1( node1 ),
+    faceIndex( face ),
+    edgeNumber( edgeNum )
   {}
 
-  /**
-   * @brief Return true if the two EdgeBuilders share the same greatest node index.
-   * @param [in] rhs the EdgeBuilder to compare against.
-   */
-  bool operator==( EdgeBuilder const & rhs ) const
-  { return n1 == rhs.n1; }
-
-  /**
-   * @brief Return true if the two EdgeBuilders don't share the same greatest node index.
-   * @param [in] rhs the EdgeBuilder to compare against.
-   */
-  bool operator!=( EdgeBuilder const & rhs ) const
-  { return !this->operator==( rhs ); }
-
   /// The larger of the two node indices that comprise the edge.
-  int32_t n1;
+  localIndex n1;
+
   /// The face the edge came from.
-  int32_t faceID;
+  localIndex faceIndex;
+
   /// The face local index of the edge.
-  int32_t faceLocalEdgeIndex;
+  localIndex edgeNumber;
+
+private:
+
+  /**
+   * @brief Equality comparison operator.
+   * @param [in] lhs left-hand side of the comparison
+   * @param [in] rhs right-hand side of the comparison
+   *
+   * Two edges are considered equal if they share 2 nodes.
+   * Because the other data structure already groups entries by lowest node,
+   * here we only store and compare the second node.
+   */
+  friend bool operator==( EdgeBuilder const & lhs, EdgeBuilder const & rhs )
+  { return lhs.n1 == rhs.n1; }
 };
-
-/**
- * @brief Add an edge to the face to edge map, edge to face map, and edge to node map.
- * @param [in] edgesByLowestNode and array of size numNodes of arrays of EdgeBuilders associated with each node.
- * @param [in,out] faceToEdgeMap the map from face IDs to edge IDs.
- * @param [in,out] edgeToFacemap the map from edgeIDs to faceIDs.
- * @param [in,out] edgeToNodeMap the map from edgeIDs to nodeIDs.
- * @param [in] edgeID the ID of the edge to add.
- * @param [in] firstNodeID the ID of the first node of the edge.
- * @param [in] firstMatch the index of the first EdgeBuilder that describes this edge in edgesByLowestNode[ firstNodeID ].
- * @param [in] numMatches the number of EdgeBuilders that describe this edge in edgesByLowestNode[ firstNodeID ].
- */
-void addEdge( ArrayOfArraysView< EdgeBuilder const > const & edgesByLowestNode,
-              ArrayOfArraysView< localIndex > const & faceToEdgeMap,
-              ArrayOfSetsView< localIndex > const & edgeToFaceMap,
-              arrayView2d< localIndex > const & edgeToNodeMap,
-              localIndex const edgeID,
-              localIndex const firstNodeID,
-              localIndex const firstMatch,
-              localIndex const numMatches )
-{
-  GEOSX_ASSERT_GE( edgeToFaceMap.capacityOfSet( edgeID ), numMatches );
-
-  // Populate the edge to node map.
-  edgeToNodeMap( edgeID, 0 ) = firstNodeID;
-  edgeToNodeMap( edgeID, 1 ) = edgesByLowestNode( firstNodeID, firstMatch ).n1;
-
-  // Loop through all the matches and fill in the face to edge and edge to face maps.
-  for( localIndex i = 0; i < numMatches; ++i )
-  {
-    localIndex const faceID = edgesByLowestNode( firstNodeID, firstMatch + i ).faceID;
-    localIndex const faceLocalEdgeIndex = edgesByLowestNode( firstNodeID, firstMatch + i ).faceLocalEdgeIndex;
-
-    faceToEdgeMap( faceID, faceLocalEdgeIndex ) = edgeID;
-    edgeToFaceMap.insertIntoSet( edgeID, faceID );
-  }
-}
 
 /**
  * @brief Populate the edgesByLowestNode map.
  * @param [in] numNodes The number of nodes.
  * @param [in] faceToNodeMap a map that associates an ordered list of nodes with each face.
- * @param [in,out] edgesByLowestNode of size numNodes, where each sub array has been preallocated to hold
- *        *enough* space.
- * For each edge of each face, this function gets the lowest node in the edge n0, creates an EdgeBuilder
- * associated with the edge and then appends the EdgeBuilder to edgesByLowestNode[ n0 ]. Finally it sorts
- * the contents of each sub-array of edgesByLowestNode from least to greatest.
+ * @return a map of each node to edges that have it as their lowest index node, sorted by second node index.
  */
-ArrayOfArrays< EdgeBuilder > createEdgesByLowestNode( localIndex numNodes,
-                                                      ArrayOfArraysView< localIndex const > const & faceToNodeMap )
+ArrayOfArrays< EdgeBuilder >
+createEdgesByLowestNode( localIndex const numNodes,
+                         ArrayOfArraysView< localIndex const > const & faceToNodeMap )
 {
-  GEOSX_MARK_FUNCTION;
-
-  ArrayOfArrays< EdgeBuilder > edgesByLowestNode( numNodes, 2 * CellBlockManagerABC::maxEdgesPerNode() );
-
-  localIndex const numFaces = faceToNodeMap.size();
-
-  // loop over all the faces.
-  forAll< parallelHostPolicy >( numFaces, [&]( localIndex const faceID )
+  array1d< localIndex > edgeCounts( numNodes );
+  forAll< parallelHostPolicy >( faceToNodeMap.size(), [counts = edgeCounts.toView(),
+                                                       faceToNodeMap]( localIndex const faceIndex )
   {
-    localIndex const numNodesInFace = faceToNodeMap.sizeOfArray( faceID );
+    // loop over all the nodes in the face. there will be an edge for each node.
+    localIndex const numNodesInFace = faceToNodeMap.sizeOfArray( faceIndex );
+    for( localIndex a = 0; a < numNodesInFace; ++a )
+    {
+      // count the edge for its lowest index node
+      localIndex const node0 = faceToNodeMap( faceIndex, a );
+      localIndex const node1 = faceToNodeMap( faceIndex, ( a + 1 ) % numNodesInFace );
+      RAJA::atomicInc< parallelHostAtomic >( &counts[ std::min( node0, node1 ) ] );
+    }
+  } );
+
+  ArrayOfArrays< EdgeBuilder > edgesByLowestNode;
+  edgesByLowestNode.resizeFromCapacities< parallelHostPolicy >( numNodes, edgeCounts.data() );
+
+  forAll< parallelHostPolicy >( faceToNodeMap.size(), [&]( localIndex const faceIndex )
+  {
+    localIndex const numNodesInFace = faceToNodeMap.sizeOfArray( faceIndex );
 
     // loop over all the nodes in the face. there will be an edge for each node.
-    for( localIndex a=0; a< numNodesInFace; ++a )
+    for( localIndex a = 0; a < numNodesInFace; ++a )
     {
       // sort the nodes in order of index value.
-      localIndex node0 = faceToNodeMap( faceID, a );
-      localIndex node1 = faceToNodeMap( faceID, ( a + 1 ) % numNodesInFace );
+      localIndex node0 = faceToNodeMap( faceIndex, a );
+      localIndex node1 = faceToNodeMap( faceIndex, ( a + 1 ) % numNodesInFace );
       if( node0 > node1 )
+      {
         std::swap( node0, node1 );
+      }
 
       // And append the edge to edgesByLowestNode.
-      edgesByLowestNode.emplaceBackAtomic< parallelHostAtomic >( node0, node1, faceID, a );
+      edgesByLowestNode.emplaceBackAtomic< parallelHostAtomic >( node0, node1, faceIndex, a );
     }
   } );
 
   // This comparator is not attached to EdgeBuilder because of potential inconsistencies with operator==
   auto const comp = []( EdgeBuilder const & e0, EdgeBuilder const & e1 ) -> bool
   {
-    if( e0.n1 < e1.n1 )
-    {
-      return true;
-    }
-    if( e0.n1 > e1.n1 )
-    {
-      return false;
-    }
-    return e0.faceID < e1.faceID;
+    return ( e0.n1 < e1.n1 ) || ( ( e0.n1 == e1.n1 ) && ( e0.faceIndex < e1.faceIndex ) );
   };
 
   // Loop over all the nodes and sort the associated edges.
-  forAll< parallelHostPolicy >( numNodes, [&]( localIndex const nodeID )
+  forAll< parallelHostPolicy >( numNodes, [edgesByLowestNode = edgesByLowestNode.toView(),
+                                           comp]( localIndex const nodeIndex )
   {
-    EdgeBuilder * const edges = edgesByLowestNode[nodeID];
-    std::sort( edges, edges + edgesByLowestNode.sizeOfArray( nodeID ), comp );
+    arraySlice1d< EdgeBuilder > const edges = edgesByLowestNode[ nodeIndex ];
+    std::sort( edges.begin(), edges.end(), comp );
   } );
 
   return edgesByLowestNode;
-}
-
-/**
- * @brief Return the total number of unique edges and fill in the uniqueEdgeOffsets array.
- * @param [in] edgesByLowestNode and array of size numNodes of arrays of EdgeBuilders associated with each node.
- * @param [out] uniqueEdgeOffsets an array of size numNodes + 1. After this function returns node i contains
- * edges with IDs ranging from uniqueEdgeOffsets[ i ] to uniqueEdgeOffsets[ i + 1 ] - 1.
- */
-localIndex calculateTotalNumberOfEdges( ArrayOfArraysView< EdgeBuilder const > const & edgesByLowestNode,
-                                        arrayView1d< localIndex > const & uniqueEdgeOffsets )
-{
-  localIndex const numNodes = edgesByLowestNode.size();
-  GEOSX_ERROR_IF_NE( numNodes, uniqueEdgeOffsets.size() - 1 );
-
-  uniqueEdgeOffsets[0] = 0;
-
-  // Loop over all the nodes.
-  forAll< parallelHostPolicy >( numNodes, [&]( localIndex const nodeID )
-  {
-    localIndex const numEdges = edgesByLowestNode.sizeOfArray( nodeID );
-
-    // If there are no edges associated with this node we can skip it.
-    if( numEdges == 0 )
-      return;
-
-    localIndex & numUniqueEdges = uniqueEdgeOffsets[ nodeID + 1 ];
-    numUniqueEdges = 0;
-
-    // Otherwise since edgesByLowestNode[ nodeID ] is sorted we can compare subsequent entries
-    // count up the unique entries.
-    localIndex j = 0;
-    for(; j < numEdges - 1; ++j )
-    {
-      numUniqueEdges += edgesByLowestNode( nodeID, j ) != edgesByLowestNode( nodeID, j + 1 );
-    }
-
-    numUniqueEdges += j == numEdges - 1;
-  } );
-
-  // At this point uniqueEdgeOffsets[ i ] holds the number of unique edges associated with node i - 1.
-  // Perform an inplace prefix-sum to get the unique edge offset.
-  RAJA::inclusive_scan_inplace< parallelHostPolicy >( uniqueEdgeOffsets.begin(), uniqueEdgeOffsets.end() );
-
-  return uniqueEdgeOffsets.back();
 }
 
 
@@ -433,199 +390,133 @@ localIndex calculateTotalNumberOfEdges( ArrayOfArraysView< EdgeBuilder const > c
  * @brief Populate the face to edge map, edge to face map, and edge to node map.
  * @param [in] edgesByLowestNode and array of size numNodes of arrays of EdgeBuilders associated with each node.
  * @param [in] uniqueEdgeOffsets an array containing the unique ID of the first edge associated with each node.
- * @param [in] faceToNodeMap the map from faces to nodes.
- * @param [in,out] faceToEdgeMap the map from face IDs to edge IDs.
- * @param [in,out] edgeToFacemap the map from edgeIDs to faceIDs.
- * @param [in,out] edgeToNodeMap the map from edgeIDs to nodeIDs.
+ * @param [in] faceToEdgeMap the map from faces to nodes.
+ * @param [in,out] edgeToFaceMap the map from edges to faces.
+ * @param [in,out] edgeToNodeMap the map from edges to nodes.
  */
 void populateEdgeMaps( ArrayOfArraysView< EdgeBuilder const > const & edgesByLowestNode,
                        arrayView1d< localIndex const > const & uniqueEdgeOffsets,
-                       ArrayOfArraysView< localIndex const > const & faceToNodeMap,
-                       ArrayOfArrays< localIndex > & faceToEdgeMap,
-                       ArrayOfSets< localIndex > & edgeToFaceMap,
+                       ArrayOfArraysView< localIndex > const & faceToEdgeMap,
+                       ArrayOfArraysView< localIndex > const & edgeToFaceMap,
                        arrayView2d< localIndex > const & edgeToNodeMap )
 {
-  GEOSX_MARK_FUNCTION;
-
   localIndex const numNodes = edgesByLowestNode.size();
-  localIndex const numFaces = faceToNodeMap.size();
   localIndex const numUniqueEdges = uniqueEdgeOffsets.back();
   GEOSX_ERROR_IF_NE( numNodes, uniqueEdgeOffsets.size() - 1 );
-  GEOSX_ERROR_IF_NE( numFaces, faceToEdgeMap.size() );
   GEOSX_ERROR_IF_NE( numUniqueEdges, edgeToFaceMap.size() );
   GEOSX_ERROR_IF_NE( numUniqueEdges, edgeToNodeMap.size( 0 ) );
 
-  // The face to edge map has the same shape as the face to node map, so we can resize appropriately.
-  localIndex totalSize = 0;
-  for( localIndex faceID = 0; faceID < numFaces; ++faceID )
-  {
-    totalSize += faceToNodeMap.sizeOfArray( faceID );
-  }
-
-  // Resize the face to edge map
-  faceToEdgeMap.resize( 0 );
-
-  // Reserve space for the number of current faces plus some extra.
-  double const overAllocationFactor = 0.3;
-  localIndex const entriesToReserve = ( 1 + overAllocationFactor ) * numFaces;
-  faceToEdgeMap.reserve( entriesToReserve );
-
-  // Reserve space for the total number of face edges + extra space for existing faces + even more space for new faces.
-  localIndex const valuesToReserve = totalSize + numFaces * CellBlockManagerABC::edgeMapExtraSpacePerFace() * ( 1 + 2 * overAllocationFactor );
-  faceToEdgeMap.reserveValues( valuesToReserve );
-  for( localIndex faceID = 0; faceID < numFaces; ++faceID )
-  {
-    faceToEdgeMap.appendArray( faceToNodeMap.sizeOfArray( faceID ) );
-    faceToEdgeMap.setCapacityOfArray( faceToEdgeMap.size() - 1,
-                                      faceToNodeMap.sizeOfArray( faceID ) + CellBlockManagerABC::edgeMapExtraSpacePerFace() );
-  }
-
   // loop over all the nodes.
-  forAll< parallelHostPolicy >( numNodes, [&]( localIndex const nodeID )
+  forAll< parallelHostPolicy >( numNodes, [&]( localIndex const nodeIndex )
   {
-    localIndex curEdgeID = uniqueEdgeOffsets[ nodeID ];
-    localIndex const numEdges = edgesByLowestNode.sizeOfArray( nodeID );
-
-    // loop over all the EdgeBuilders associated with the node
-    localIndex j = 0;
-    while( j < numEdges - 1 )
+    localIndex curEdgeID = uniqueEdgeOffsets[ nodeIndex ];
+    arraySlice1d< EdgeBuilder const > const edges = edgesByLowestNode[ nodeIndex ];
+    forEqualRanges( edges.begin(), edges.end(), [&]( auto first, auto last )
     {
-      // Find the number of EdgeBuilders that describe the same edge
-      localIndex numMatches = 1;
-      while( edgesByLowestNode( nodeID, j ) == edgesByLowestNode( nodeID, j + numMatches ) )
+      // Populate the edge to node map.
+      edgeToNodeMap( curEdgeID, 0 ) = nodeIndex;
+      edgeToNodeMap( curEdgeID, 1 ) = first->n1;
+
+      // Loop through all the matches and fill in the face to edge and edge to face maps.
+      while( first != last )
       {
-        ++numMatches;
-        if( j + numMatches == numEdges )
-          break;
+        EdgeBuilder const & edge = *first;
+        faceToEdgeMap( edge.faceIndex, edge.edgeNumber ) = curEdgeID;
+        edgeToFaceMap.emplaceBack( curEdgeID, edge.faceIndex );
+        ++first;
       }
-      // Then add the edge.
-      addEdge( edgesByLowestNode, faceToEdgeMap.toView(), edgeToFaceMap.toView(), edgeToNodeMap, curEdgeID, nodeID, j, numMatches );
-      ++curEdgeID;
-      j += numMatches;
-    }
 
-    if( j == numEdges - 1 )
-    {
-      addEdge( edgesByLowestNode, faceToEdgeMap.toView(), edgeToFaceMap.toView(), edgeToNodeMap, curEdgeID, nodeID, j, 1 );
-    }
+      ++curEdgeID;
+    } );
   } );
 }
 
 /**
- * @brief Resize the edge to face map.
+ * @brief Resize the edge to face and edge to node maps.
  * @param [in] edgesByLowestNode and array of size numNodes of arrays of EdgeBuilders associated with each node.
  * @param [in] uniqueEdgeOffsets an containing the unique edge IDs for each node in edgesByLowestNode.
- * param [out] edgeToFaceMap the map from edges to faces. This function resizes the array appropriately.
- */
-void resizeEdgeToFaceMap( ArrayOfArraysView< EdgeBuilder const > const & edgesByLowestNode,
-                          arrayView1d< localIndex const > const & uniqueEdgeOffsets,
-                          ArrayOfSets< localIndex > & edgeToFaceMap )
-{
-  GEOSX_MARK_FUNCTION;
-
-  localIndex const numNodes = edgesByLowestNode.size();
-  localIndex const numUniqueEdges = uniqueEdgeOffsets.back();
-  array1d< localIndex > numFacesPerEdge( numUniqueEdges );
-  RAJA::ReduceSum< parallelHostReduce, localIndex > totalEdgeFaces( 0.0 );
-
-  // loop over all the nodes.
-  forAll< parallelHostPolicy >( numNodes, [&]( localIndex const nodeID )
-  {
-    localIndex curEdgeID = uniqueEdgeOffsets[ nodeID ];
-    localIndex const numEdges = edgesByLowestNode.sizeOfArray( nodeID );
-
-    // loop over all the EdgeBuilders associated with the node
-    localIndex j = 0;
-    while( j < numEdges - 1 )
-    {
-      // Find the number of EdgeBuilders that describe the same edge
-      localIndex numMatches = 1;
-      while( edgesByLowestNode( nodeID, j ) == edgesByLowestNode( nodeID, j + numMatches ) )
-      {
-        ++numMatches;
-        if( j + numMatches == numEdges )
-          break;
-      }
-
-      // The number of matches is the number of faces associated with this edge.
-      numFacesPerEdge( curEdgeID ) = numMatches;
-      totalEdgeFaces += numFacesPerEdge( curEdgeID );
-      ++curEdgeID;
-      j += numMatches;
-    }
-
-    if( j == numEdges - 1 )
-    {
-      numFacesPerEdge( curEdgeID ) = 1;
-      totalEdgeFaces += numFacesPerEdge( curEdgeID );
-    }
-  } );
-
-  // Resize the edge to face map
-  edgeToFaceMap.resize( 0 );
-
-  // Reserve space for the number of current faces plus some extra.
-  double const overAllocationFactor = 0.3;
-  localIndex const entriesToReserve = ( 1 + overAllocationFactor ) * numUniqueEdges;
-  edgeToFaceMap.reserve( entriesToReserve );
-
-  // Reserve space for the total number of edge faces + extra space for existing edges + even more space for new edges.
-  localIndex const valuesToReserve = totalEdgeFaces.get() + numUniqueEdges * CellBlockManagerABC::faceMapExtraSpacePerEdge() * ( 1 + 2 * overAllocationFactor );
-  edgeToFaceMap.reserveValues( valuesToReserve );
-
-  // Append the individual sets.
-  for( localIndex faceID = 0; faceID < numUniqueEdges; ++faceID )
-  {
-    edgeToFaceMap.appendSet( numFacesPerEdge[ faceID ] + CellBlockManagerABC::faceMapExtraSpacePerEdge() );
-  }
-}
-
-/**
- * @brief Resize the edge to face map.
- * @param [in] edgesByLowestNode and array of size numNodes of arrays of EdgeBuilders associated with each node.
- * @param [in] uniqueEdgeOffsets an containing the unique edge IDs for each node in edgesByLowestNode.
- * param [out] edgeToNodesMap the map from edges to nodes. This function resizes the array appropriately.
- * param [out] edgeToFaceMap the map from edges to faces. This function resizes the array appropriately.
+ * @param [out] faceToEdgeMap the map from faces to edges, resized appropriately and filled with dummy values.
+ * @param [out] edgeToFaceMap the map from edges to faces, resized appropriately.
+ * @param [out] edgeToNodeMap the map from edges to nodes, resized appropriately.
  */
 void resizeEdgeMaps( ArrayOfArraysView< EdgeBuilder const > const & edgesByLowestNode,
                      arrayView1d< localIndex const > const & uniqueEdgeOffsets,
-                     array2d< localIndex > & edgeToNodesMap,
-                     ArrayOfSets< localIndex > & edgeToFaceMap )
+                     ArrayOfArraysView< localIndex const > const & faceToNodeMap,
+                     ArrayOfArrays< localIndex > & faceToEdgeMap,
+                     ArrayOfArrays< localIndex > & edgeToFaceMap,
+                     array2d< localIndex > & edgeToNodeMap )
+{
+  localIndex const numFaces = faceToNodeMap.size();
+  localIndex const numNodes = edgesByLowestNode.size();
+  localIndex const numUniqueEdges = uniqueEdgeOffsets.back();
+
+  // Count the number of faces adjacent to each edge by traversing previously built data structures
+  array1d< localIndex > numFacesPerEdge( numUniqueEdges );
+  forAll< parallelHostPolicy >( numNodes, [uniqueEdgeOffsets,
+                                           edgesByLowestNode,
+                                           numFacesPerEdge = numFacesPerEdge.toView()]( localIndex const nodeIndex )
+  {
+    localIndex curEdgeID = uniqueEdgeOffsets[ nodeIndex ];
+    arraySlice1d< EdgeBuilder const > const edges = edgesByLowestNode[ nodeIndex ];
+    forUniqueValues( edges.begin(), edges.end(), [&]( EdgeBuilder const &, localIndex const numMatches )
+    {
+      numFacesPerEdge( curEdgeID++ ) = numMatches + CellBlockManagerABC::faceMapExtraSpacePerEdge();
+    } );
+  } );
+  edgeToFaceMap.resizeFromCapacities< parallelHostPolicy >( numUniqueEdges, numFacesPerEdge.data() );
+
+  // This relies on the fact that #nodes = #edges for each face.
+  // Thus, by utilizing faceToNodeMap, we can avoid atomic counting of capacity.
+  array1d< localIndex > numEdgesPerFace( numFaces );
+  forAll< parallelHostPolicy >( numFaces, [faceToNodeMap,
+                                           numEdgesPerFace = numEdgesPerFace.toView()] ( localIndex const faceIndex )
+  {
+    localIndex const numNodesInFace = faceToNodeMap.sizeOfArray( faceIndex );
+    numEdgesPerFace[ faceIndex ] = numNodesInFace + CellBlockManagerABC::edgeMapExtraSpacePerFace();
+  } );
+  faceToEdgeMap.resizeFromCapacities< parallelHostPolicy >( numFaces, numEdgesPerFace.data() );
+  forAll< parallelHostPolicy >( numFaces, [numEdgesPerFace = numEdgesPerFace.toViewConst(),
+                                           faceToEdgeMap = faceToEdgeMap.toView()] ( localIndex const faceIndex )
+  {
+    // There is no API to set size of each sub-array within its capacity in parallel
+    for( localIndex i = 0; i < numEdgesPerFace[ faceIndex ] - CellBlockManagerABC::edgeMapExtraSpacePerFace(); ++i )
+    {
+      faceToEdgeMap.emplaceBack( faceIndex, -1 );
+    }
+  } );
+
+  // Each edge is adjacent to strictly 2 nodes.
+  edgeToNodeMap.resize( numUniqueEdges, 2 );
+}
+
+localIndex buildEdgeMaps( localIndex const numNodes,
+                          ArrayOfArraysView< localIndex const > const & faceToNodeMap,
+                          ArrayOfArrays< localIndex > & faceToEdgeMap,
+                          ArrayOfArrays< localIndex > & edgeToFaceMap,
+                          array2d< localIndex > & edgeToNodeMap )
 {
   GEOSX_MARK_FUNCTION;
 
-  resizeEdgeToFaceMap( edgesByLowestNode, uniqueEdgeOffsets, edgeToFaceMap );
+  ArrayOfArrays< EdgeBuilder > const edgesByLowestNode =
+    createEdgesByLowestNode( numNodes, faceToNodeMap );
 
-  // Each face may belong to _maximum_ 2 elements.
-  // If it belongs to only one, we put `-1` for the undefined value.
-  localIndex const numUniqueEdges = uniqueEdgeOffsets.back();
-  edgeToNodesMap.resize( numUniqueEdges, 2 );
-}
-
-localIndex buildEdgeMaps( localIndex numNodes,
-                          ArrayOfArraysView< localIndex const > const & faceToNodeMap,
-                          ArrayOfArrays< localIndex > & faceToEdgeMap,
-                          ArrayOfSets< localIndex > & edgeToFaceMap,
-                          array2d< localIndex > & edgeToNodeMap )
-{
-  ArrayOfArrays< EdgeBuilder > edgesByLowestNode = createEdgesByLowestNode( numNodes, faceToNodeMap );
-
-  array1d< localIndex > uniqueEdgeOffsets( numNodes + 1 );
-  localIndex const numEdges = calculateTotalNumberOfEdges( edgesByLowestNode.toViewConst(), uniqueEdgeOffsets );
+  array1d< localIndex > const uniqueEdgeOffsets =
+    computeUniqueValueOffsets< parallelHostPolicy >( edgesByLowestNode.toViewConst() );
 
   resizeEdgeMaps( edgesByLowestNode.toViewConst(),
                   uniqueEdgeOffsets,
-                  edgeToNodeMap,
-                  edgeToFaceMap );
+                  faceToNodeMap,
+                  faceToEdgeMap,
+                  edgeToFaceMap,
+                  edgeToNodeMap );
 
   populateEdgeMaps( edgesByLowestNode.toViewConst(),
                     uniqueEdgeOffsets,
-                    faceToNodeMap,
-                    faceToEdgeMap,
-                    edgeToFaceMap,
-                    edgeToNodeMap );
+                    faceToEdgeMap.toView(),
+                    edgeToFaceMap.toView(),
+                    edgeToNodeMap.toView() );
 
-  return numEdges;
+  return uniqueEdgeOffsets.back();
 }
 
 }

--- a/src/coreComponents/mesh/generators/CellBlockUtilities.hpp
+++ b/src/coreComponents/mesh/generators/CellBlockUtilities.hpp
@@ -12,11 +12,13 @@
  * ------------------------------------------------------------------------------------------------------------
  */
 
-#ifndef GEOSX_CELLBLOCKUTILITIES_HPP
-#define GEOSX_CELLBLOCKUTILITIES_HPP
+#ifndef GEOSX_MESH_GENERATORS_CELLBLOCKUTILITIES_HPP_
+#define GEOSX_MESH_GENERATORS_CELLBLOCKUTILITIES_HPP_
 
 #include "mesh/ElementType.hpp"
 #include "common/DataTypes.hpp"
+#include "common/Span.hpp"
+#include "common/GEOS_RAJA_Interface.hpp"
 
 namespace geosx
 {
@@ -33,23 +35,58 @@ namespace geosx
 localIndex buildEdgeMaps( localIndex numNodes,
                           ArrayOfArraysView< localIndex const > const & faceToNodeMap,
                           ArrayOfArrays< localIndex > & faceToEdgeMap,
-                          ArrayOfSets< localIndex > & edgeToFaceMap,
+                          ArrayOfArrays< localIndex > & edgeToFaceMap,
                           array2d< localIndex > & edgeToNodeMap );
 
 /**
  * @brief Get the local indices of the nodes in a face of the element.
  * @param[in] elementType Type of the element
- * @param[in] iElement the local index of the target element
- * @param[in] iFace the local index of the target face in the element  (this will be 0-numFacesInElement)
+ * @param[in] elemIdx the local index of the target element
+ * @param[in] faceNumber the local index of the target face in the element  (this will be 0-numFacesInElement)
  * @param[in] elementToNodes Element to nodes mapping.
- * @param[out] nodeIndices A reference to the array of node indices of the face. Gets resized at the proper size.
+ * @param[out] faceNodes space to write node indices to, must be of sufficient size
+ * @return number of nodes in the face
  */
-void getFaceNodes( ElementType const & elementType,
-                   localIndex const iElement,
-                   localIndex const iFace,
-                   array2d< localIndex, cells::NODE_MAP_PERMUTATION > const & elementToNodes,
-                   array1d< localIndex > & nodeIndices );
+localIndex getFaceNodes( ElementType const elementType,
+                         localIndex const elemIdx,
+                         localIndex const faceNumber,
+                         arrayView2d< localIndex const, cells::NODE_MAP_USD > const & elementToNodes,
+                         Span< localIndex > const faceNodes );
+
+/**
+ * @brief Find and count ranges of repeated values in an array of sorted arrays and compute offsets.
+ * @tparam POLICY execution policy
+ * @tparam T value type of input arrays
+ * @param [in] sortedLists the input array of sorted arrays of values
+ * @return an array of size @p sortedLists.size() + 1, where element i contains starting index of
+ *         unique values from sub-array i in a global list of unique values, while the last value
+ *         contains the total number of unique edges (i.e. an exclusive scan + total reduction).
+ */
+template< typename POLICY, typename T >
+array1d< localIndex >
+computeUniqueValueOffsets( ArrayOfArraysView< T const > const & sortedLists )
+{
+  localIndex const numNodes = sortedLists.size();
+  array1d< localIndex > uniqueValueOffsets( numNodes + 1 );
+  uniqueValueOffsets[0] = 0;
+
+  // For each node, count number of unique edges that have the node as its lowest
+  arrayView1d< localIndex > const numUniqueValuesView = uniqueValueOffsets.toView();
+  forAll< POLICY >( numNodes, [sortedLists, numUniqueValuesView]( localIndex const i )
+  {
+    numUniqueValuesView[ i + 1 ] = 0;
+    arraySlice1d< T const > const list = sortedLists[ i ];
+    forEqualRanges( list.begin(), list.end(), [&]( auto, auto )
+    {
+      ++numUniqueValuesView[ i + 1 ];
+    } );
+  } );
+
+  // Perform an inplace prefix-sum to get the unique edge offset.
+  RAJA::inclusive_scan_inplace< POLICY >( uniqueValueOffsets.begin(), uniqueValueOffsets.end() );
+  return uniqueValueOffsets;
+}
 
 }
 
-#endif // include guard
+#endif // GEOSX_MESH_GENERATORS_CELLBLOCKUTILITIES_HPP_

--- a/src/coreComponents/mesh/generators/InternalMeshGenerator.cpp
+++ b/src/coreComponents/mesh/generators/InternalMeshGenerator.cpp
@@ -731,7 +731,7 @@ void InternalMeshGenerator::generateMesh( DomainPartition & domain )
 
   cellBlockManager.setNumNodes( numNodes );
 
-  arrayView2d< real64, nodes::REFERENCE_POSITION_USD > X = cellBlockManager.getNodesPositions();
+  arrayView2d< real64, nodes::REFERENCE_POSITION_USD > X = cellBlockManager.getNodePositions();
 
   arrayView1d< globalIndex > const nodeLocalToGlobal = cellBlockManager.getNodeLocalToGlobal();
 

--- a/src/coreComponents/mesh/generators/PAMELAMeshGenerator.cpp
+++ b/src/coreComponents/mesh/generators/PAMELAMeshGenerator.cpp
@@ -162,7 +162,7 @@ real64 importNodes( PAMELA::Mesh & srcMesh, // PAMELA is not const-correct,
                     CellBlockManager & cellBlockManager )
 {
   cellBlockManager.setNumNodes( srcMesh.get_PointCollection()->size_all() );
-  arrayView2d< real64, nodes::REFERENCE_POSITION_USD > X = cellBlockManager.getNodesPositions();
+  arrayView2d< real64, nodes::REFERENCE_POSITION_USD > X = cellBlockManager.getNodePositions();
 
   arrayView1d< globalIndex > const nodeLocalToGlobal = cellBlockManager.getNodeLocalToGlobal();
 

--- a/src/coreComponents/mesh/generators/VTKMeshGenerator.cpp
+++ b/src/coreComponents/mesh/generators/VTKMeshGenerator.cpp
@@ -259,7 +259,7 @@ real64 writeMeshNodes( vtkUnstructuredGrid & mesh,
 
   // Writing the points
   arrayView1d< globalIndex > const & nodeLocalToGlobal = cellBlockManager.getNodeLocalToGlobal();
-  arrayView2d< real64, nodes::REFERENCE_POSITION_USD > const & X = cellBlockManager.getNodesPositions();
+  arrayView2d< real64, nodes::REFERENCE_POSITION_USD > const & X = cellBlockManager.getNodePositions();
 
   constexpr real64 minReal = LvArray::NumericLimits< real64 >::min;
   constexpr real64 maxReal = LvArray::NumericLimits< real64 >::max;

--- a/src/coreComponents/mesh/utilities/MeshMapUtilities.hpp
+++ b/src/coreComponents/mesh/utilities/MeshMapUtilities.hpp
@@ -19,6 +19,8 @@
 #define GEOSX_MESH_UTILITIES_MESHMAPUTILITIES_HPP
 
 #include "common/DataTypes.hpp"
+#include "mesh/ElementRegionManager.hpp"
+
 
 namespace geosx
 {
@@ -36,18 +38,8 @@ namespace meshMapUtilities
 /**
  * @brief @return the size of the map along first dimension
  * @tparam T type of map element
- * @param map reference to the map
- */
-template< typename T >
-GEOSX_HOST_DEVICE
-inline localIndex size0( arrayView1d< arrayView1d< T const > const > const & map )
-{
-  return map.size();
-}
-
-/**
- * @copydoc size0(arrayView1d< arrayView1d< T const > const > const &)
  * @tparam USD unit-stride dimension of the map
+ * @param map reference to the map
  */
 template< typename T, int USD >
 GEOSX_HOST_DEVICE
@@ -57,21 +49,25 @@ inline localIndex size0( arrayView2d< T, USD > const & map )
 }
 
 /**
- * @copydoc size0(arrayView1d< arrayView1d< T const > const > const &)
+ * @brief @return the size of the map along first dimension
+ * @tparam T type of map element
+ * @param map reference to the map
  */
 template< typename T >
 GEOSX_HOST_DEVICE
-inline localIndex size0( ArrayOfArraysView< T const > const & map )
+inline localIndex size0( ArrayOfArraysView< T > const & map )
 {
   return map.size();
 }
 
 /**
- * @copydoc size0(arrayView1d< arrayView1d< T const > const > const &)
+ * @brief @return the size of the map along first dimension
+ * @tparam T type of map element
+ * @param map reference to the map
  */
 template< typename T >
 GEOSX_HOST_DEVICE
-inline localIndex size0( ArrayOfSetsView< T const > const & map )
+inline localIndex size0( ArrayOfSetsView< T > const & map )
 {
   return map.size();
 }
@@ -79,150 +75,138 @@ inline localIndex size0( ArrayOfSetsView< T const > const & map )
 //////////////////////////////////////////////////////////////////////////////////
 
 /**
- * @brief @return the size of the map along second dimension
- * @tparam T type of map element
- * @param map reference to the map
- * @param i0 first-dimension index into the map
+ * @brief Transposes an input map (array2d, ArrayOfArrays or ArrayOfSets)
+ * @tparam POLICY execution policy to use
+ * @tparam VIEW_TYPE type of view of the source map
+ * @param srcMap the source map
+ * @param dstSize number of target objects ("cols" of @p srcMap)
+ * @param overAlloc overallocation (extra capacity per row) for resulting map
+ * @return the transpose of @p srcMap stored as ArrayOfArrays (most general form)
  */
-template< typename T >
-GEOSX_HOST_DEVICE
-inline localIndex size1( arrayView1d< arrayView1d< T const > const > const & map, localIndex const i0 )
+template< typename POLICY, typename VIEW_TYPE >
+ArrayOfArrays< std::remove_const_t< typename VIEW_TYPE::ValueType > >
+transposeIndexMap( VIEW_TYPE const & srcMap,
+                   localIndex const dstSize,
+                   localIndex const overAlloc = 0 )
 {
-  return map[i0].size();
-}
-
-/**
- * @copydoc size1(arrayView1d< arrayView1d< T const > const > const &, localIndex const)
- * @tparam USD unit-stride dimension of the map
- */
-template< typename T, int USD >
-GEOSX_HOST_DEVICE
-inline localIndex size1( arrayView2d< T, USD > const & map, localIndex const i0 )
-{
-  GEOSX_UNUSED_VAR( i0 );
-  return map.size( 1 );
-}
-
-/**
- * @copydoc size1(arrayView1d< arrayView1d< T const > const > const &, localIndex const)
- */
-template< typename T >
-GEOSX_HOST_DEVICE
-inline localIndex size1( ArrayOfArraysView< T const > const & map, localIndex const i0 )
-{
-  return map.sizeOfArray( i0 );
-}
-
-/**
- * @copydoc size1(arrayView1d< arrayView1d< T const > const > const &, localIndex const)
- */
-template< typename T >
-GEOSX_HOST_DEVICE
-inline localIndex size1( ArrayOfSetsView< T const > const & map, localIndex const i0 )
-{
-  return map.sizeOfSet( i0 );
-}
-
-//////////////////////////////////////////////////////////////////////////////////
-
-/**
- * @brief @return the value of the map
- * @tparam T type of map element
- * @param map reference to the map
- * @param i0 first-dimension index into the map
- * @param i1 second-dimension index into the map
- */
-template< typename T >
-GEOSX_HOST_DEVICE
-inline T const & value( arrayView1d< arrayView1d< T const > const > const & map, localIndex const i0, localIndex const i1 )
-{
-  return map[i0][i1];
-}
-
-/**
- * @copydoc value(arrayView1d< arrayView1d< T const > const > const &, localIndex const, localIndex const)
- * @tparam USD unit-stride dimension of the map
- */
-template< typename T, int USD >
-GEOSX_HOST_DEVICE
-inline T const & value( arrayView2d< T, USD > const & map, localIndex const i0, localIndex const i1 )
-{
-  return map( i0, i1 );
-}
-
-/**
- * @copydoc value(arrayView1d< arrayView1d< T const > const > const &, localIndex const, localIndex const)
- */
-template< typename T >
-GEOSX_HOST_DEVICE
-inline T const & value( ArrayOfArraysView< T const > const & map, localIndex const i0, localIndex const i1 )
-{
-  return map( i0, i1 );
-}
-
-/**
- * @copydoc value(arrayView1d< arrayView1d< T const > const > const &, localIndex const, localIndex const)
- */
-template< typename T >
-GEOSX_HOST_DEVICE
-inline T const & value( ArrayOfSetsView< T const > const & map, localIndex const i0, localIndex const i1 )
-{
-  return map( i0, i1 );
-}
-
-//////////////////////////////////////////////////////////////////////////////////
-
-/**
- * @brief @return the total number of elements in the map
- * @tparam T type of map element
- * @param map reference to the map
- */
-template< typename T >
-GEOSX_HOST_DEVICE
-inline localIndex numElements( arrayView1d< arrayView1d< T const > const > const & map )
-{
-  return map.size();
-}
-
-/**
- * @copydoc numElements(arrayView1d< arrayView1d< T const > const > const &)
- * @tparam USD unit-stride dimension of the map
- */
-template< typename T, int USD >
-GEOSX_HOST_DEVICE
-inline localIndex numElements( arrayView2d< T, USD > const & map )
-{
-  return map.size();
-}
-
-/**
- * @copydoc numElements(arrayView1d< arrayView1d< T const > const > const &)
- */
-template< typename T >
-GEOSX_HOST_DEVICE
-inline localIndex numElements( ArrayOfArraysView< T const > const & map )
-{
-  localIndex size = 0;
-  for( localIndex i = 0; i < map.size(); ++i )
+  // Count the number of elements in each set
+  array1d< localIndex > counts( dstSize );
+  counts.setValues< POLICY >( overAlloc );
+  forAll< POLICY >( size0( srcMap ), [srcMap, counts = counts.toView()] ( localIndex const srcIndex )
   {
-    size += map.sizeOfArray( i );
-  }
-  return size;
+    for( localIndex const dstIndex : srcMap[ srcIndex ] )
+    {
+      RAJA::atomicInc< AtomicPolicy< POLICY > >( &counts[ dstIndex ] );
+    }
+  } );
+
+  // Allocate storage for the transpose map
+  ArrayOfArrays< localIndex > dstMap;
+  dstMap.resizeFromCapacities< parallelHostPolicy >( dstSize, counts.data() );
+
+  // Fill the sub-arrays with unsorted entries
+  forAll< POLICY >( size0( srcMap ), [srcMap, dstMap = dstMap.toView()] ( localIndex const srcIndex )
+  {
+    for( localIndex const dstIndex : srcMap[ srcIndex ] )
+    {
+      dstMap.emplaceBackAtomic< AtomicPolicy< POLICY > >( dstIndex, srcIndex );
+    }
+  } );
+
+  return dstMap;
 }
 
 /**
- * @copydoc numElements(arrayView1d< arrayView1d< T const > const > const &)
+ * @brief Convert ToCellRelation into ToElementRelation.
+ * @tparam POLICY execution policy
+ * @param blockToSubRegion a map from cell blocks to region/subregion pairs
+ * @param srcMap source map (object-to-cells)
+ * @param dstMap target map (object-to-elements)
  */
-template< typename T >
-GEOSX_HOST_DEVICE
-inline localIndex numElements( ArrayOfSetsView< T const > const & map )
+template< typename POLICY >
+void transformCellBlockToRegionMap( arrayView2d< localIndex const > const & blockToSubRegion,
+                                    ToCellRelation< ArrayOfArrays< localIndex > > const & srcMap,
+                                    ToElementRelation< ArrayOfArrays< localIndex > > & dstMap )
 {
-  localIndex size = 0;
-  for( localIndex i = 0; i < map.size(); ++i )
+  GEOSX_ASSERT_EQ( blockToSubRegion.size(), 2 );
+  localIndex const numObjects = srcMap.toCellIndex.size();
+
+  localIndex const * offsets = srcMap.toCellIndex.toViewConst().getOffsets();
+  dstMap.m_toElementRegion.resizeFromOffsets( numObjects, offsets );
+  dstMap.m_toElementSubRegion.resizeFromOffsets( numObjects, offsets );
+  dstMap.m_toElementIndex.resizeFromOffsets( numObjects, offsets );
+
+  forAll< POLICY >( numObjects, [toCell = srcMap.toCellIndex.toViewConst(),
+                                 toBlock = srcMap.toBlockIndex.toViewConst(),
+                                 toRegion = dstMap.m_toElementRegion.toView(),
+                                 toSubRegion = dstMap.m_toElementSubRegion.toView(),
+                                 toElement = dstMap.m_toElementIndex.toView(),
+                                 blockToSubRegion]( localIndex const objIndex )
   {
-    size += map.sizeOfSet( i );
-  }
-  return size;
+    arraySlice1d< localIndex const > const cells = toCell[objIndex];
+    for( localIndex i = 0; i < cells.size(); ++i )
+    {
+      localIndex const blockIndex = toBlock( objIndex, i );
+      localIndex const er = blockToSubRegion( blockIndex, 0 );
+      localIndex const esr = blockToSubRegion( blockIndex, 1 );
+
+      // Check needed because some blocks may remain unused
+      if( er >= 0 && esr >= 0 )
+      {
+        toRegion.emplaceBack( objIndex, er );
+        toSubRegion.emplaceBack( objIndex, esr );
+        toElement.emplaceBack( objIndex, cells[i] );
+      }
+    }
+  } );
+}
+
+/**
+ * @brief Convert ToCellRelation into ToElementRelation.
+ * @tparam POLICY execution policy
+ * @param blockToSubRegion a map from cell blocks to region/subregion pairs
+ * @param srcMap source map (object-to-cells)
+ * @param dstMap target map (object-to-elements)
+ */
+template< typename POLICY, typename PERM >
+void transformCellBlockToRegionMap( arrayView2d< localIndex const > const & blockToSubRegion,
+                                    ToCellRelation< array2d< localIndex, PERM > > const & srcMap,
+                                    ToElementRelation< array2d< localIndex, PERM > > & dstMap )
+{
+  GEOSX_ASSERT_EQ( blockToSubRegion.size(), 2 );
+  localIndex const numObjects = srcMap.toCellIndex.size( 0 );
+  localIndex const maxCellsPerObject = srcMap.toCellIndex.size( 1 );
+
+  dstMap.m_toElementRegion.resize( numObjects, maxCellsPerObject );
+  dstMap.m_toElementSubRegion.resize( numObjects, maxCellsPerObject );
+  dstMap.m_toElementIndex.resize( numObjects, maxCellsPerObject );
+
+  forAll< POLICY >( numObjects, [toCell = srcMap.toCellIndex.toViewConst(),
+                                 toBlock = srcMap.toBlockIndex.toViewConst(),
+                                 toRegion = dstMap.m_toElementRegion.toView(),
+                                 toSubRegion = dstMap.m_toElementSubRegion.toView(),
+                                 toElement = dstMap.m_toElementIndex.toView(),
+                                 blockToSubRegion,
+                                 maxCellsPerObject]( localIndex const objIndex )
+  {
+    arraySlice1d< localIndex const > const cells = toCell[objIndex];
+    localIndex cellCount = 0;
+    for( localIndex i = 0; i < maxCellsPerObject && cells[i] >= 0; ++i )
+    {
+      localIndex const blockIndex = toBlock( objIndex, i );
+      localIndex const er = blockToSubRegion( blockIndex, 0 );
+      localIndex const esr = blockToSubRegion( blockIndex, 1 );
+
+      // Check needed because some blocks may remain unused
+      if( er >= 0 && esr >= 0 )
+      {
+        toRegion( objIndex, cellCount ) = er;
+        toSubRegion( objIndex, cellCount ) = esr;
+        toElement( objIndex, cellCount ) = cells[i];
+        ++cellCount;
+      }
+    }
+  } );
 }
 
 } // namespace meshMapUtilities

--- a/src/coreComponents/mesh/utilities/MeshMapUtilities.hpp
+++ b/src/coreComponents/mesh/utilities/MeshMapUtilities.hpp
@@ -128,7 +128,7 @@ void transformCellBlockToRegionMap( arrayView2d< localIndex const > const & bloc
                                     ToCellRelation< ArrayOfArrays< localIndex > > const & srcMap,
                                     ToElementRelation< ArrayOfArrays< localIndex > > & dstMap )
 {
-  GEOSX_ASSERT_EQ( blockToSubRegion.size(), 2 );
+  GEOSX_ASSERT_EQ( blockToSubRegion.size( 1 ), 2 );
   localIndex const numObjects = srcMap.toCellIndex.size();
 
   localIndex const * offsets = srcMap.toCellIndex.toViewConst().getOffsets();
@@ -168,12 +168,12 @@ void transformCellBlockToRegionMap( arrayView2d< localIndex const > const & bloc
  * @param srcMap source map (object-to-cells)
  * @param dstMap target map (object-to-elements)
  */
-template< typename POLICY, typename PERM >
+template< typename POLICY, typename PERM1, typename PERM2 >
 void transformCellBlockToRegionMap( arrayView2d< localIndex const > const & blockToSubRegion,
-                                    ToCellRelation< array2d< localIndex, PERM > > const & srcMap,
-                                    ToElementRelation< array2d< localIndex, PERM > > & dstMap )
+                                    ToCellRelation< array2d< localIndex, PERM1 > > const & srcMap,
+                                    ToElementRelation< array2d< localIndex, PERM2 > > & dstMap )
 {
-  GEOSX_ASSERT_EQ( blockToSubRegion.size(), 2 );
+  GEOSX_ASSERT_EQ( blockToSubRegion.size( 1 ), 2 );
   localIndex const numObjects = srcMap.toCellIndex.size( 0 );
   localIndex const maxCellsPerObject = srcMap.toCellIndex.size( 1 );
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFVMKernels.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFVMKernels.cpp
@@ -204,10 +204,8 @@ CFLFluxKernel::
                                    transmissibility,
                                    dTrans_dPres );
 
-    localIndex const stencilSize = meshMapUtilities::size1( sei, iconn );
-
     CFLFluxKernel::compute< NC, numElems, maxStencilSize >( numPhases,
-                                                            stencilSize,
+                                                            sei[iconn].size(),
                                                             dt,
                                                             seri[iconn],
                                                             sesri[iconn],

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFVMKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFVMKernels.hpp
@@ -538,7 +538,7 @@ public:
    */
   GEOSX_HOST_DEVICE
   localIndex stencilSize( localIndex const iconn ) const
-  { return meshMapUtilities::size1( m_sei, iconn ); }
+  { return m_sei[iconn].size(); }
 
   /**
    * @brief Getter for the number of elements at this connection

--- a/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
@@ -2099,7 +2099,7 @@ void SurfaceGenerator::performFracture( const localIndex nodeID,
                                                         getSubRegion< CellElementSubRegion >( faceToSubRegionMap[iFace][0] );
             arrayView2d< real64 const > const subRegionElemCenter = elementSubRegion.getElementCenter();
 
-            faceManager.sortFaceNodes( X, subRegionElemCenter[ elementIndex ], faceToNodeMap[ iFace ], faceToNodeMap.sizeOfArray( iFace ) );
+            FaceManager::sortFaceNodes( X, subRegionElemCenter[ elementIndex ], faceToNodeMap[ iFace ] );
 
             //Face normal need to be updated here
             real64 fCenter[ 3 ];

--- a/src/coreComponents/unitTests/meshTests/testMeshGeneration.cpp
+++ b/src/coreComponents/unitTests/meshTests/testMeshGeneration.cpp
@@ -27,28 +27,21 @@
 
 using namespace geosx;
 
-#define STRINGIFY2( X ) #X
-#define STRINGIFY( X ) STRINGIFY2( X )
+constexpr double maxCoordInX = 1.0;
+constexpr double maxCoordInY = 2.0;
+constexpr double maxCoordInZ = 3.0;
 
-#define NX 10
-#define NY 11
-#define NZ 12
+constexpr localIndex numElemsInX = 10;
+constexpr localIndex numElemsInY = 11;
+constexpr localIndex numElemsInZ = 12;
 
-#define MAX_COORD_X 1.0
-#define MAX_COORD_Y 2.0
-#define MAX_COORD_Z 3.0
+constexpr localIndex numNodesInX = numElemsInX + 1;
+constexpr localIndex numNodesInY = numElemsInY + 1;
+constexpr localIndex numNodesInZ = numElemsInZ + 1;
 
-constexpr localIndex numElemsInX = NX;
-constexpr localIndex numElemsInY = NY;
-constexpr localIndex numElemsInZ = NZ;
-
-constexpr localIndex numNodesInX = NX + 1;
-constexpr localIndex numNodesInY = NY + 1;
-constexpr localIndex numNodesInZ = NZ + 1;
-
-constexpr double dx = MAX_COORD_X / NX;
-constexpr double dy = MAX_COORD_Y / NY;
-constexpr double dz = MAX_COORD_Z / NZ;
+constexpr double dx = maxCoordInX / numElemsInX;
+constexpr double dy = maxCoordInY / numElemsInY;
+constexpr double dz = maxCoordInZ / numElemsInZ;
 
 constexpr localIndex node_dI = numNodesInY * numNodesInZ;
 constexpr localIndex node_dJ = numNodesInZ;
@@ -62,63 +55,60 @@ protected:
 
   void SetUp() override
   {
-    m_nodeManager = &getGlobalState().getProblemManager().getDomainPartition().getMeshBody( 0 ).getMeshLevel( 0 ).getNodeManager();
-    m_faceManager = &getGlobalState().getProblemManager().getDomainPartition().getMeshBody( 0 ).getMeshLevel( 0 ).getFaceManager();
-    m_edgeManager = &getGlobalState().getProblemManager().getDomainPartition().getMeshBody( 0 ).getMeshLevel( 0 ).getEdgeManager();
+    DomainPartition & domain = getGlobalState().getProblemManager().getDomainPartition();
+    MeshLevel & mesh = domain.getMeshBody( 0 ).getMeshLevel( 0 );
 
-    ElementRegionManager & elemManager = getGlobalState().getProblemManager().getDomainPartition().getMeshBody( 0 ).getMeshLevel( 0 ).getElemManager();
-    GEOSX_ERROR_IF_NE_MSG( elemManager.getRegions().size(), 1, "Only one region should exist." );
+    m_nodeManager = &mesh.getNodeManager();
+    m_faceManager = &mesh.getFaceManager();
+    m_edgeManager = &mesh.getEdgeManager();
+
+    ElementRegionManager & elemManager = mesh.getElemManager();
+    ASSERT_EQ( elemManager.getRegions().size(), 1 );
 
     ElementRegionBase & elemRegion = elemManager.getRegion( 0 );
-    GEOSX_ERROR_IF_NE_MSG( elemRegion.getSubRegions().size(), 1, "Only one subregion should exist." );
+    ASSERT_EQ( elemRegion.getSubRegions().size(), 1 );
 
     m_subRegion = &elemRegion.getSubRegion< CellElementSubRegion >( 0 );
   }
 
-  NodeManager * m_nodeManager;
-  FaceManager * m_faceManager;
-  EdgeManager * m_edgeManager;
-  CellElementSubRegion * m_subRegion;
+  NodeManager * m_nodeManager{};
+  FaceManager * m_faceManager{};
+  EdgeManager * m_edgeManager{};
+  CellElementSubRegion * m_subRegion{};
 
   static void SetUpTestCase()
   {
-    string const inputStream =
+    string const inputStream = GEOSX_FMT(
       "<Problem>"
       "  <Mesh>"
-      "    <InternalMesh name=\"mesh1\""
-      "                  elementTypes=\"{C3D8}\""
-      "                  xCoords=\"{0, " STRINGIFY( MAX_COORD_X ) "}\""
-                                                                  "                  yCoords=\"{0, " STRINGIFY( MAX_COORD_Y ) "}\""
-                                                                                                                              "                  zCoords=\"{0, "
-      STRINGIFY( MAX_COORD_Z ) "}\""
-                               "                  nx=\"{"
-      STRINGIFY( NX ) "}\""
-                      "                  ny=\"{"
-      STRINGIFY( NY ) "}\""
-                      "                  nz=\"{"
-      STRINGIFY( NZ ) "}\""
-                      "                  cellBlockNames=\"{cb1}\"/>"
-                      "  </Mesh>"
-                      "  <ElementRegions>"
-                      "    <CellElementRegion name=\"region1\" cellBlocks=\"{cb1}\" materialList=\"{dummy_material}\" />"
-                      "  </ElementRegions>"
-                      "</Problem>";
+      "    <InternalMesh"
+      "      name=\"mesh1\""
+      "      elementTypes=\"{{C3D8}}\""
+      "      xCoords=\"{{0,{}}}\""
+      "      yCoords=\"{{0,{}}}\""
+      "      zCoords=\"{{0,{}}}\""
+      "      nx=\"{{{}}}\""
+      "      ny=\"{{{}}}\""
+      "      nz=\"{{{}}}\""
+      "      cellBlockNames=\"{{cb1}}\"/>"
+      "  </Mesh>"
+      "  <ElementRegions>"
+      "    <CellElementRegion name=\"region1\" cellBlocks=\"{{cb1}}\" materialList=\"{{}}\"/>"
+      "  </ElementRegions>"
+      "</Problem>",
+      maxCoordInX, maxCoordInY, maxCoordInZ, numElemsInX, numElemsInY, numElemsInZ );
 
     xmlWrapper::xmlDocument xmlDocument;
     xmlWrapper::xmlResult xmlResult = xmlDocument.load_buffer( inputStream.c_str(), inputStream.size() );
-    if( !xmlResult )
-    {
-      GEOSX_LOG_RANK_0( "XML parsed with errors!" );
-      GEOSX_LOG_RANK_0( "Error description: " << xmlResult.description());
-      GEOSX_LOG_RANK_0( "Error offset: " << xmlResult.offset );
-    }
+    ASSERT_TRUE( xmlResult );
 
     xmlWrapper::xmlNode xmlProblemNode = xmlDocument.child( dataRepository::keys::ProblemManager );
-    getGlobalState().getProblemManager().processInputFileRecursive( xmlProblemNode );
+    ProblemManager & problemManager = getGlobalState().getProblemManager();
+    problemManager.processInputFileRecursive( xmlProblemNode );
 
     // Open mesh levels
-    DomainPartition & domain = getGlobalState().getProblemManager().getDomainPartition();
-    MeshManager & meshManager = getGlobalState().getProblemManager().getGroup< MeshManager >( getGlobalState().getProblemManager().groupKeys.meshManager );
+    DomainPartition & domain = problemManager.getDomainPartition();
+    MeshManager & meshManager = problemManager.getGroup< MeshManager >( problemManager.groupKeys.meshManager );
     meshManager.generateMeshLevels( domain );
 
     ElementRegionManager & elementManager = domain.getMeshBody( 0 ).getMeshLevel( 0 ).getElemManager();
@@ -126,8 +116,8 @@ protected:
     elementManager.processInputFileRecursive( topLevelNode );
     elementManager.postProcessInputRecursive();
 
-    getGlobalState().getProblemManager().problemSetup();
-    getGlobalState().getProblemManager().applyInitialConditions();
+    problemManager.problemSetup();
+    problemManager.applyInitialConditions();
   }
 };
 
@@ -157,17 +147,17 @@ TEST_F( MeshGenerationTest, nodePositions )
 {
   arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const & X = m_nodeManager->referencePosition();
 
-  localIndex nodeID = 0;
+  localIndex nodeIndex = 0;
   for( localIndex i = 0; i < numNodesInX; ++i )
   {
     for( localIndex j = 0; j < numNodesInY; ++j )
     {
       for( localIndex k = 0; k < numNodesInZ; ++k )
       {
-        EXPECT_DOUBLE_EQ( X( nodeID, 0 ), i * dx );
-        EXPECT_DOUBLE_EQ( X( nodeID, 1 ), j * dy );
-        EXPECT_DOUBLE_EQ( X( nodeID, 2 ), k * dz );
-        ++nodeID;
+        EXPECT_DOUBLE_EQ( X( nodeIndex, 0 ), i * dx );
+        EXPECT_DOUBLE_EQ( X( nodeIndex, 1 ), j * dy );
+        EXPECT_DOUBLE_EQ( X( nodeIndex, 2 ), k * dz );
+        ++nodeIndex;
       }
     }
   }
@@ -230,7 +220,7 @@ TEST_F( MeshGenerationTest, nodeToElemMap )
 {
   ArrayOfArraysView< localIndex const > const & nodeToElemMap = m_nodeManager->elementList().toViewConst();
 
-  localIndex nodeID = 0;
+  localIndex nodeIndex = 0;
   for( localIndex i = 0; i < numNodesInX; ++i )
   {
     for( localIndex j = 0; j < numNodesInY; ++j )
@@ -265,9 +255,9 @@ TEST_F( MeshGenerationTest, nodeToElemMap )
         }
 
         localIndex const numElems = expectedElems.size();
-        ASSERT_EQ( numElems, nodeToElemMap.sizeOfArray( nodeID ) );
+        ASSERT_EQ( numElems, nodeToElemMap.sizeOfArray( nodeIndex ) );
 
-        localIndex const * const nodeElems = nodeToElemMap[ nodeID ];
+        localIndex const * const nodeElems = nodeToElemMap[ nodeIndex ];
         std::vector< localIndex > elems( nodeElems, nodeElems + numElems );
 
         std::sort( elems.begin(), elems.end() );
@@ -278,7 +268,7 @@ TEST_F( MeshGenerationTest, nodeToElemMap )
           EXPECT_EQ( elems[ a ], expectedElems[ a ] );
         }
 
-        ++nodeID;
+        ++nodeIndex;
       }
     }
   }
@@ -308,17 +298,17 @@ TEST_F( MeshGenerationTest, faceNodeMaps )
           m_subRegion->getFaceNodes( elemID, f, faceNodesFromElem );
           ASSERT_EQ( faceNodesFromElem.size(), 4 );
 
-          localIndex const faceID = elementToFaceMap( elemID, f );
+          localIndex const faceIndex = elementToFaceMap( elemID, f );
 
-          ASSERT_EQ( faceToNodeMap.sizeOfArray( faceID ), 4 );
+          ASSERT_EQ( faceToNodeMap.sizeOfArray( faceIndex ), 4 );
           for( localIndex a = 0; a < 4; ++a )
           {
-            faceNodesFromFace[ a ] = faceToNodeMap( faceID, a );
+            faceNodesFromFace[ a ] = faceToNodeMap( faceIndex, a );
           }
 
-          if( elemID != faceToElementMap( faceID, 0 ) )
+          if( elemID != faceToElementMap( faceIndex, 0 ) )
           {
-            EXPECT_EQ( elemID, faceToElementMap( faceID, 1 ) );
+            EXPECT_EQ( elemID, faceToElementMap( faceIndex, 1 ) );
           }
 
           std::sort( faceNodesFromElem.begin(), faceNodesFromElem.end() );
@@ -331,7 +321,7 @@ TEST_F( MeshGenerationTest, faceNodeMaps )
 
           for( localIndex a = 0; a < 4; ++a )
           {
-            EXPECT_TRUE( nodeToFaceMap.contains( faceNodesFromElem[ a ], faceID ) );
+            EXPECT_TRUE( nodeToFaceMap.contains( faceNodesFromElem[ a ], faceIndex ) );
           }
         }
         ++elemID;
@@ -358,9 +348,9 @@ TEST_F( MeshGenerationTest, faceElementMaps )
       {
         for( localIndex f = 0; f < 6; ++f )
         {
-          localIndex const faceID = elementToFaceMap( elemID, f );
+          localIndex const faceIndex = elementToFaceMap( elemID, f );
 
-          if( elemID == faceToElementMap( faceID, 0 ) )
+          if( elemID == faceToElementMap( faceIndex, 0 ) )
           {
             bool external = false;
             if( f == 0 && j == 0 )
@@ -378,17 +368,17 @@ TEST_F( MeshGenerationTest, faceElementMaps )
 
             if( external )
             {
-              EXPECT_EQ( -1, faceToElementMap( faceID, 1 ) );
+              EXPECT_EQ( -1, faceToElementMap( faceIndex, 1 ) );
             }
             else
             {
-              EXPECT_EQ( elemID + elemIDOffset[ f ], faceToElementMap( faceID, 1 ) );
+              EXPECT_EQ( elemID + elemIDOffset[ f ], faceToElementMap( faceIndex, 1 ) );
             }
           }
           else
           {
-            EXPECT_EQ( elemID, faceToElementMap( faceID, 1 ) );
-            EXPECT_EQ( elemID + elemIDOffset[ f ], faceToElementMap( faceID, 0 ) );
+            EXPECT_EQ( elemID, faceToElementMap( faceIndex, 1 ) );
+            EXPECT_EQ( elemID + elemIDOffset[ f ], faceToElementMap( faceIndex, 0 ) );
           }
         }
         ++elemID;
@@ -402,17 +392,17 @@ bool walkEdgesToFindNeighbor( localIndex const node0,
                               arraySlice1d< localIndex const > const & nodeEdges,
                               arrayView2d< localIndex const > const & edgeToNodeMap )
 {
-  for( localIndex const edgeID : nodeEdges )
+  for( localIndex const edgeIndex : nodeEdges )
   {
-    if( edgeToNodeMap[ edgeID ][ 0 ] == node0 )
+    if( edgeToNodeMap[ edgeIndex ][ 0 ] == node0 )
     {
-      if( edgeToNodeMap[ edgeID ][ 1 ] == node1 )
+      if( edgeToNodeMap[ edgeIndex ][ 1 ] == node1 )
         return true;
     }
     else
     {
-      EXPECT_EQ( edgeToNodeMap[ edgeID ][ 1 ], node0 );
-      if( edgeToNodeMap[ edgeID ][ 0 ] == node1 )
+      EXPECT_EQ( edgeToNodeMap[ edgeIndex ][ 1 ], node0 );
+      if( edgeToNodeMap[ edgeIndex ][ 0 ] == node1 )
         return true;
     }
   }
@@ -427,7 +417,7 @@ TEST_F( MeshGenerationTest, edgeNodeMaps )
 
   GEOSX_ERROR_IF_NE( edgeToNodeMap.size( 1 ), 2 );
 
-  localIndex nodeID = 0;
+  localIndex nodeIndex = 0;
   for( localIndex i = 0; i < numNodesInX; ++i )
   {
     for( localIndex j = 0; j < numNodesInY; ++j )
@@ -437,37 +427,37 @@ TEST_F( MeshGenerationTest, edgeNodeMaps )
         localIndex numEdges = 0;
         if( i != 0 )
         {
-          EXPECT_TRUE( walkEdgesToFindNeighbor( nodeID, nodeID - node_dI, nodeToEdgeMap[ nodeID ], edgeToNodeMap ) );
+          EXPECT_TRUE( walkEdgesToFindNeighbor( nodeIndex, nodeIndex - node_dI, nodeToEdgeMap[ nodeIndex ], edgeToNodeMap ) );
           ++numEdges;
         }
         if( i != numNodesInX - 1 )
         {
-          EXPECT_TRUE( walkEdgesToFindNeighbor( nodeID, nodeID + node_dI, nodeToEdgeMap[ nodeID ], edgeToNodeMap ) );
+          EXPECT_TRUE( walkEdgesToFindNeighbor( nodeIndex, nodeIndex + node_dI, nodeToEdgeMap[ nodeIndex ], edgeToNodeMap ) );
           ++numEdges;
         }
         if( j != 0 )
         {
-          EXPECT_TRUE( walkEdgesToFindNeighbor( nodeID, nodeID - node_dJ, nodeToEdgeMap[ nodeID ], edgeToNodeMap ) );
+          EXPECT_TRUE( walkEdgesToFindNeighbor( nodeIndex, nodeIndex - node_dJ, nodeToEdgeMap[ nodeIndex ], edgeToNodeMap ) );
           ++numEdges;
         }
         if( j != numNodesInY - 1 )
         {
-          EXPECT_TRUE( walkEdgesToFindNeighbor( nodeID, nodeID + node_dJ, nodeToEdgeMap[ nodeID ], edgeToNodeMap ) );
+          EXPECT_TRUE( walkEdgesToFindNeighbor( nodeIndex, nodeIndex + node_dJ, nodeToEdgeMap[ nodeIndex ], edgeToNodeMap ) );
           ++numEdges;
         }
         if( k != 0 )
         {
-          EXPECT_TRUE( walkEdgesToFindNeighbor( nodeID, nodeID - 1, nodeToEdgeMap[ nodeID ], edgeToNodeMap ) );
+          EXPECT_TRUE( walkEdgesToFindNeighbor( nodeIndex, nodeIndex - 1, nodeToEdgeMap[ nodeIndex ], edgeToNodeMap ) );
           ++numEdges;
         }
         if( k != numNodesInZ - 1 )
         {
-          EXPECT_TRUE( walkEdgesToFindNeighbor( nodeID, nodeID + 1, nodeToEdgeMap[ nodeID ], edgeToNodeMap ) );
+          EXPECT_TRUE( walkEdgesToFindNeighbor( nodeIndex, nodeIndex + 1, nodeToEdgeMap[ nodeIndex ], edgeToNodeMap ) );
           ++numEdges;
         }
 
-        EXPECT_EQ( numEdges, nodeToEdgeMap.sizeOfSet( nodeID ) );
-        ++nodeID;
+        EXPECT_EQ( numEdges, nodeToEdgeMap.sizeOfSet( nodeIndex ) );
+        ++nodeIndex;
       }
     }
   }
@@ -492,26 +482,26 @@ TEST_F( MeshGenerationTest, edgeFaceMaps )
       {
         for( localIndex f = 0; f < 6; ++f )
         {
-          localIndex const faceID = elementToFaceMap( elemID, f );
+          localIndex const faceIndex = elementToFaceMap( elemID, f );
 
-          ASSERT_EQ( faceToNodeMap.sizeOfArray( faceID ), 4 );
-          ASSERT_EQ( faceToEdgeMap.sizeOfArray( faceID ), 4 );
+          ASSERT_EQ( faceToNodeMap.sizeOfArray( faceIndex ), 4 );
+          ASSERT_EQ( faceToEdgeMap.sizeOfArray( faceIndex ), 4 );
 
           for( localIndex a = 0; a < 4; ++a )
           {
-            localIndex node0 = faceToNodeMap( faceID, a );
-            localIndex node1 = faceToNodeMap( faceID, ( a + 1 ) % 4 );
+            localIndex node0 = faceToNodeMap( faceIndex, a );
+            localIndex node1 = faceToNodeMap( faceIndex, ( a + 1 ) % 4 );
             if( node0 > node1 )
               std::swap( node0, node1 );
 
-            localIndex const edgeID = faceToEdgeMap( faceID, a );
-            EXPECT_EQ( edgeToNodeMap( edgeID, 0 ), node0 );
-            EXPECT_EQ( edgeToNodeMap( edgeID, 1 ), node1 );
+            localIndex const edgeIndex = faceToEdgeMap( faceIndex, a );
+            EXPECT_EQ( edgeToNodeMap( edgeIndex, 0 ), node0 );
+            EXPECT_EQ( edgeToNodeMap( edgeIndex, 1 ), node1 );
 
             bool foundFace = false;
-            for( localIndex const id : edgeToFaceMap[ edgeID ] )
+            for( localIndex const id : edgeToFaceMap[ edgeIndex ] )
             {
-              if( id == faceID )
+              if( id == faceIndex )
                 foundFace = true;
             }
 

--- a/src/coreComponents/unitTests/meshTests/testPAMELAImport.cpp
+++ b/src/coreComponents/unitTests/meshTests/testPAMELAImport.cpp
@@ -65,7 +65,7 @@ void TestMeshImport( string const & inputStringMesh,
   elemManager.postProcessInputRecursive();
 
   CellBlockManager & cellBlockManager = meshBody.getGroup< CellBlockManager >( keys::cellManager );
-  nodeManager.setGeometricalRelations( cellBlockManager );
+  nodeManager.setGeometricalRelations( cellBlockManager, elemManager );
 
   elemManager.generateMesh( cellBlockManager );
 

--- a/src/coreComponents/unitTests/meshTests/testVTKImport.cpp
+++ b/src/coreComponents/unitTests/meshTests/testVTKImport.cpp
@@ -92,7 +92,7 @@ TEST( VTKImport, cube )
 
     // The information in the tables is not filled yet. We can check the consistency of the sizes.
     ASSERT_EQ( cellBlockManager.getNodeToFaces().size(), expectedNumNodes );
-    ASSERT_EQ( cellBlockManager.getNodeToElements().size(), expectedNumNodes );
+    ASSERT_EQ( cellBlockManager.getNodeToElements().toCellIndex.size(), expectedNumNodes );
 
     // We have all the 4 x 4  x 4 = 64 nodes in the "all" set.
     SortedArray< localIndex > const & allNodes = cellBlockManager.getNodeSets().at( "all" );


### PR DESCRIPTION
This PR fixes performance regression of mesh map generation by:
  * removing dynamic allocations in cell-face loop
  * restoring some parallel loops that were made serial
  * removing huge over-allocations when constructing `byLowestNode` arrays (this affects memory footprint more than speed)

In addition, it restores strict total ordering for `NodesAndElementOfFace` entries, which is required to have uniquely defined (race-condition-free) maps in case of multi-threaded construction.

Timings (inclusive) for `geosx::CellBlockManager::buildMaps`, measured on an `InternalMesh` with 400k elements:

| # threads | This branch | `develop` (`9f15819`) |
| ------------ | ------------: | -----------------: |
| 1 | 0.539594 s | 28.683256 s |
| 2 | 0.328936 s | 28.594731 s |
| 4 | 0.213764 s | 28.285016 s |
| 8 | 0.171741 s | 27.934983 s |

Mesh with 5M elements:
| # threads | This branch |
| ------------ | ------------: |
| 1 | 6.532824 s |
| 2 | 3.741959 s |
| 4 | 2.423015 s |
| 8 | 1.966910 s |

(only current PR is measured, I was unable to run meshes larger than ~500k with current `develop` as it hangs indefinitely).

High watermark of mesh generation is about 2GB/1M cells (including intentional overallocations in the maps for fracture generation). I don't think we can get significantly lower than that without specialization for cell shapes.

LvArray PR: https://github.com/GEOSX/LvArray/pull/256
Rebaseline PR: https://github.com/GEOSX/integratedTests/pull/211

Rebaseline required for some of the tests (those using multiple cell blocks like "staircase" mesh, or any external meshes). No numeric diffs, but there are some changes in the order of mesh maps.