### PR TITLE
Correct Group::pack

### DIFF
--- a/src/coreComponents/dataRepository/Group.cpp
+++ b/src/coreComponents/dataRepository/Group.cpp
@@ -413,7 +413,7 @@ localIndex Group::pack( buffer_unit_type * & buffer,
                         bool onDevice,
                         parallelDeviceEvents & events ) const
 {
-  return this->packImpl< false >( buffer, wrapperNames, packList, recursive, onDevice, events );
+  return this->packImpl< true >( buffer, wrapperNames, packList, recursive, onDevice, events );
 }
 
 localIndex Group::pack( buffer_unit_type * & buffer,


### PR DESCRIPTION
A `Group::pack` member function was actually packing nothing after my wrong refactoring... 😭 😞 
It was passing the unit tests and the integrated tests, meaning that it's basically unused... 🤷 

EDIT: I think that the function is not used because of https://github.com/GEOSX/GEOSX/blob/develop/src/coreComponents/mesh/ObjectManagerBase.cpp#L288