### PR TITLE
Add an external driving force for the phase-field nucleation formulation

### DIFF
--- a/src/coreComponents/constitutive/ConstitutivePassThru.hpp
+++ b/src/coreComponents/constitutive/ConstitutivePassThru.hpp
@@ -24,6 +24,7 @@
 #include "NullModel.hpp"
 #include "solid/DamageVolDev.hpp"
 #include "solid/DamageSpectral.hpp"
+#include "solid/DamageExtDrivingForce.hpp"
 #include "solid/DruckerPrager.hpp"
 #include "solid/DruckerPragerExtended.hpp"
 #include "solid/ModifiedCamClay.hpp"
@@ -78,7 +79,8 @@ struct ConstitutivePassThru< SolidBase >
   static
   void execute( ConstitutiveBase & constitutiveRelation, LAMBDA && lambda )
   {
-    ConstitutivePassThruHandler< DamageSpectral< ElasticIsotropic >,
+    ConstitutivePassThruHandler< DamageExtDrivingForce< ElasticIsotropic >, 
+                                 DamageSpectral< ElasticIsotropic >,
                                  DamageVolDev< ElasticIsotropic >,
                                  Damage< ElasticIsotropic >,
                                  DruckerPragerExtended,
@@ -126,7 +128,8 @@ struct ConstitutivePassThru< DamageBase >
   static void execute( ConstitutiveBase & constitutiveRelation,
                        LAMBDA && lambda )
   {
-    ConstitutivePassThruHandler< DamageSpectral< ElasticIsotropic >,
+    ConstitutivePassThruHandler< DamageExtDrivingForce< ElasticIsotropic >, 
+                                 DamageSpectral< ElasticIsotropic >,
                                  DamageVolDev< ElasticIsotropic >,
                                  Damage< ElasticIsotropic > >::execute( constitutiveRelation,
                                                                         std::forward< LAMBDA >( lambda ) );

--- a/src/coreComponents/constitutive/solid/Damage.cpp
+++ b/src/coreComponents/constitutive/solid/Damage.cpp
@@ -32,6 +32,7 @@ Damage< BASE >::Damage( string const & name, Group * const parent ):
   BASE( name, parent ),
   m_damage(),
   m_strainEnergyDensity(),
+  m_extDrivingForce(), 
   m_lengthScale(),
   m_criticalFractureEnergy(),
   m_criticalStrainEnergy()
@@ -45,6 +46,11 @@ Damage< BASE >::Damage( string const & name, Group * const parent ):
     setApplyDefaultValue( 0.0 ).
     setPlotLevel( PlotLevel::LEVEL_0 ).
     setDescription( "Strain Energy Density" );
+
+  this->registerWrapper( viewKeyStruct::extDrivingForceString(), &m_extDrivingForce ).
+    setApplyDefaultValue( 0.0 ).
+    setPlotLevel( PlotLevel::LEVEL_0 ).
+    setDescription( "External Driving Force" );
 
   this->registerWrapper( viewKeyStruct::lengthScaleString(), &m_lengthScale ).
     setInputFlag( InputFlags::REQUIRED ).
@@ -72,6 +78,7 @@ void Damage< BASE >::allocateConstitutiveData( dataRepository::Group & parent,
 {
   m_damage.resize( 0, numConstitutivePointsPerParentIndex );
   m_strainEnergyDensity.resize( 0, numConstitutivePointsPerParentIndex );
+  m_extDrivingForce.resize( 0, numConstitutivePointsPerParentIndex ); 
   BASE::allocateConstitutiveData( parent, numConstitutivePointsPerParentIndex );
 }
 

--- a/src/coreComponents/constitutive/solid/Damage.hpp
+++ b/src/coreComponents/constitutive/solid/Damage.hpp
@@ -64,6 +64,7 @@ public:
   template< typename ... PARAMS >
   DamageUpdates( arrayView2d< real64 > const & inputDamage,
                  arrayView2d< real64 > const & inputStrainEnergyDensity,
+                 arrayView2d< real64 > const & inputExtDrivingForce, 
                  real64 const & inputLengthScale,
                  real64 const & inputCriticalFractureEnergy,
                  real64 const & inputcriticalStrainEnergy,
@@ -71,6 +72,7 @@ public:
     UPDATE_BASE( std::forward< PARAMS >( baseParams )... ),
     m_damage( inputDamage ),
     m_strainEnergyDensity( inputStrainEnergyDensity ),
+    m_extDrivingForce ( inputExtDrivingForce ), 
     m_lengthScale( inputLengthScale ),
     m_criticalFractureEnergy( inputCriticalFractureEnergy ),
     m_criticalStrainEnergy( inputcriticalStrainEnergy )
@@ -148,6 +150,15 @@ public:
   }
 
   GEOSX_HOST_DEVICE
+  virtual real64 getExtDrivingForce( localIndex const k, 
+                                     localIndex const q ) const
+  {
+    m_extDrivingForce( k, q ) = 0.0;
+
+    return m_extDrivingForce( k, q );  
+  }
+
+  GEOSX_HOST_DEVICE
   real64 getRegularizationLength() const
   {
     return m_lengthScale;
@@ -171,6 +182,7 @@ public:
 
   arrayView2d< real64 > const m_damage;
   arrayView2d< real64 > const m_strainEnergyDensity;
+  arrayView2d< real64 > const m_extDrivingForce; 
   real64 const m_lengthScale;
   real64 const m_criticalFractureEnergy;
   real64 const m_criticalStrainEnergy;
@@ -205,6 +217,7 @@ public:
   {
     return BASE::template createDerivedKernelUpdates< KernelWrapper >( m_damage.toView(),
                                                                        m_strainEnergyDensity.toView(),
+                                                                       m_extDrivingForce.toView(), 
                                                                        m_lengthScale,
                                                                        m_criticalFractureEnergy,
                                                                        m_criticalStrainEnergy );
@@ -214,6 +227,7 @@ public:
   {
     static constexpr char const * damageString() { return "damage"; }
     static constexpr char const * strainEnergyDensityString() { return "strainEnergyDensity"; }
+    static constexpr char const * extDrivingForceString() { return "extDrivingForce"; }
     /// string/key for regularization length
     static constexpr char const * lengthScaleString() { return "lengthScale"; }
     /// string/key for Gc
@@ -226,6 +240,7 @@ public:
 protected:
   array2d< real64 > m_damage;
   array2d< real64 > m_strainEnergyDensity;
+  array2d< real64 > m_extDrivingForce; 
   real64 m_lengthScale;
   real64 m_criticalFractureEnergy;
   real64 m_criticalStrainEnergy;

--- a/src/coreComponents/constitutive/solid/DamageExtDrivingForce.cpp
+++ b/src/coreComponents/constitutive/solid/DamageExtDrivingForce.cpp
@@ -1,0 +1,57 @@
+
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file DamageExtDrivingForce.cpp
+ */
+
+#include "Damage.hpp"
+#include "DamageExtDrivingForce.hpp"
+
+#include "ElasticIsotropic.hpp"
+
+namespace geosx
+{
+
+using namespace dataRepository;
+namespace constitutive
+{
+
+template< typename BASE >
+DamageExtDrivingForce< BASE >::DamageExtDrivingForce( string const & name, Group * const parent ):
+  Damage< BASE >( name, parent ),
+  m_tensileStrength(), 
+  m_compressStrength(), 
+{
+  this->registerWrapper( viewKeyStruct::tensileStrengthString(), &m_tensileStrength ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "Tensile strength from the uniaxial tension test" );
+
+  this->registerWrapper( viewKeyStruct::compressStrengthString(), &m_compressStrength ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "Compressive strength from the uniaxial compression test" );
+
+  this->registerWrapper( viewKeyStruct::deltaCoefficientString(), &m_deltaCoefficient ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "Coefficient in the calculation of the external driving force" );
+
+}
+
+typedef DamageExtDrivingForce< ElasticIsotropic > DamageExtDrivingForceElasticIsotropic;
+
+REGISTER_CATALOG_ENTRY( ConstitutiveBase, DamageExtDrivingForceElasticIsotropic, string const &, Group * const )
+
+}
+} /* namespace geosx */

--- a/src/coreComponents/constitutive/solid/DamageExtDrivingForce.hpp
+++ b/src/coreComponents/constitutive/solid/DamageExtDrivingForce.hpp
@@ -1,0 +1,195 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+
+/**
+ * @file DamageExtDrivingForce.hpp
+ * @brief This class overrides the SSLE constitutive updates to account for a Damage field
+ * @brief This class also introduces a new external driving force in the Damage field evolution equation 
+
+ * Reference: 
+ *
+ * Kumar, A., Bourdin, B., Francfort, G. A., & Lopez-Pamies, O. (2020). Revisiting nucleation in the phase-field 
+ * approach to brittle fracture. Journal of the Mechanics and Physics of Solids, 142, 104027.
+ */
+
+#ifndef GEOSX_CONSTITUTIVE_SOLID_DAMAGEEXTDRIVFORCE_HPP_
+#define GEOSX_CONSTITUTIVE_SOLID_DAMAGEEXTDRIVFORCE_HPP_
+
+#include "Damage.hpp"
+#include "InvariantDecompositions.hpp"
+#include "constitutive/solid/SolidBase.hpp"
+
+namespace geosx
+{
+namespace constitutive
+{
+
+template< typename UPDATE_BASE >
+class DamageExtDrivForceUpdates : public DamageUpdates< UPDATE_BASE >
+{
+public:
+  template< typename ... PARAMS >
+  DamageExtDrivForceUpdates( arrayView2d< real64 > const & inputDamage,
+                             arrayView2d< real64 > const & inputStrainEnergyDensity,
+                             arrayView2d< real64 > const & inputExtDrivingForce, 
+                             real64 const & inputLengthScale,
+                             real64 const & inputCriticalFractureEnergy,
+                             real64 const & inputcriticalStrainEnergy,
+                             real64 const & inputTensileStrength, 
+                             real64 const & inputCompressStrength,
+                             real64 const & inputDeltaCoefficient,
+                             PARAMS && ... baseParams ):
+    DamageUpdates< UPDATE_BASE >( inputDamage, inputStrainEnergyDensity, inputExtDrivingForce, inputLengthScale,
+                                  inputCriticalFractureEnergy, inputcriticalStrainEnergy,
+                                  std::forward< PARAMS >( baseParams )... ), 
+    m_tensileStrength( inputTensileStrength ), 
+    m_compressStrength( inputCompressStrength ),
+    m_deltaCoefficient( inputDeltaCoefficient )
+  {}
+
+  using DiscretizationOps = typename DamageUpdates< UPDATE_BASE >::DiscretizationOps;
+
+  using DamageUpdates< UPDATE_BASE >::smallStrainUpdate;
+  using DamageUpdates< UPDATE_BASE >::saveConvergedState;
+
+  using DamageUpdates< UPDATE_BASE >::getDegradationValue;
+  using DamageUpdates< UPDATE_BASE >::getDegradationDerivative;
+  using DamageUpdates< UPDATE_BASE >::getDegradationSecondDerivative;
+  using DamageUpdates< UPDATE_BASE >::getEnergyThreshold;
+
+  using DamageUpdates< UPDATE_BASE >::m_strainEnergyDensity;
+  using DamageUpdates< UPDATE_BASE >::m_criticalStrainEnergy;
+  using DamageUpdates< UPDATE_BASE >::m_extDrivingForce; 
+  using DamageUpdates< UPDATE_BASE >::m_criticalFractureEnergy;
+  using DamageUpdates< UPDATE_BASE >::m_lengthScale;
+
+  using UPDATE_BASE::m_bulkModulus; 
+  using UPDATE_BASE::m_shearModulus;
+
+  GEOSX_HOST_DEVICE
+  virtual void smallStrainUpdate( localIndex const k,
+                                  localIndex const q,
+                                  real64 const ( &strainIncrement )[6],
+                                  real64 ( & stress )[6],
+                                  DiscretizationOps & stiffness ) const override final
+  {
+    UPDATE_BASE::smallStrainUpdate( k, q, strainIncrement, stress, stiffness );
+    real64 factor = getDegradationValue( k, q );
+    LvArray::tensorOps::scale< 6 >( stress, factor );
+    stiffness.scaleParams( factor );
+
+    // compute volumetric and deviatoric strain invariants
+    real64 strain[6];
+    UPDATE_BASE::getElasticStrain( k, q, strain );
+
+    real64 volStrain;
+    real64 devStrain;
+    real64 deviator[6];
+
+    twoInvariant::stressDecomposition( strain,
+                                       volStrain,
+                                       devStrain,
+                                       deviator );
+
+    // compute invariants of degraded stress 
+    real64 mu    = m_shearModulus[k]; 
+    real64 kappa = m_bulkModulus[k]; 
+
+    real64 I1 = stiffness.m_bulkModulus * volStrain; 
+    real64 sqrt_J2 = sqrt(3.) * stiffness.m_shearModulus * devStrain; 
+
+    // Calculate the external driving force according to Kumar et al. 
+    real64 beta0 = m_deltaCoefficient * 0.375 * m_criticalFractureEnergy / m_lengthScale; 
+    
+    real64 beta1 = - 0.375 * m_criticalFractureEnergy / m_lengthScale * (0.5*(1 + m_deltaCoefficient)*(m_compressStrength - m_tensileStrength)/m_compressStrength/m_tensileStrength)
+                   - (8*mu + 24*kappa - 27*m_tensileStrength) * (m_compressStrength - m_tensileStrength) / 144 / mu / kappa
+                   - m_lengthScale / m_criticalFractureEnergy * ((mu + 3*kappa)*(pow(m_compressStrength, 3) - pow(m_tensileStrength, 3))*m_tensileStrength/18/(mu*mu)/(kappa*kappa)); 
+    
+    real64 beta2 = - 0.375 * m_criticalFractureEnergy / m_lengthScale * (sqrt(3)*(1 + m_deltaCoefficient)*(m_compressStrength + m_tensileStrength)/2/m_compressStrength/m_tensileStrength)
+                   - (8*mu + 24*kappa - 27*m_tensileStrength)*(m_compressStrength + m_tensileStrength) / 48 / sqrt(3) / mu / kappa
+                   - m_lengthScale / m_criticalFractureEnergy * ((mu + 3*kappa)*(pow(m_compressStrength,3) + pow(m_tensileStrength,3))*m_tensileStrength/6/sqrt(3)/(mu*mu)/(kappa*kappa)); 
+
+    real64 beta3 = (m_tensileStrength/mu/kappa) / m_criticalFractureEnergy; 
+
+    m_extDrivingForce( k, q ) = 1 / (1 + beta3*I1*I1) * (beta2 * sqrt_J2 + beta1*I1 + beta0); 
+  }
+
+  GEOSX_HOST_DEVICE
+  virtual real64 getExtDrivingForce( localIndex const k, 
+                                     localIndex const q ) const override final
+  {
+    return m_extDrivingForce( k, q );  
+  }
+
+  real64 const m_tensileStrength;
+  real64 const m_compressStrength;
+  real64 const m_deltaCoefficient; 
+};
+
+template< typename BASE >
+class DamageExtDrivingForce : public Damage< BASE >
+{
+public:
+
+  /// @typedef Alias for LinearElasticIsotropicUpdates
+  using KernelWrapper = DamageExtDrivForceUpdates< typename BASE::KernelWrapper >;
+
+  DamageExtDrivingForce( string const & name, dataRepository::Group * const parent );
+  virtual ~DamageExtDrivingForce() override = default;
+
+  static string catalogName() { return string( "DamageExtDrivingForce" ) + BASE::m_catalogNameString; }
+  virtual string getCatalogName() const override { return catalogName(); }
+
+
+  KernelWrapper createKernelUpdates() const
+  {
+    return BASE::template createDerivedKernelUpdates< KernelWrapper >( m_damage.toView(),
+                                                                       m_strainEnergyDensity.toView(),
+                                                                       m_extDrivingForce.toView(), 
+                                                                       m_lengthScale,
+                                                                       m_criticalFractureEnergy,
+                                                                       m_criticalStrainEnergy,  
+                                                                       m_tensileStrength, 
+                                                                       m_compressStrength,
+                                                                       m_deltaCoefficient);
+  }
+
+  struct viewKeyStruct : public BASE::viewKeyStruct
+  {
+    /// string/key for the uniaxial tensile strength 
+    static constexpr char const * tensileStrengthString() { return "tensileStrength"; }
+    /// string/key for the uniaxial compressive strength 
+    static constexpr char const * compressStrengthString() { return "compressiveStrength"; }
+    /// string/key for a delta coefficient in computing the external driving force  
+    static constexpr char const * deltaCoefficientString() { return "deltaCoefficient"; }
+  };
+
+
+protected:
+  array2d< real64 > m_damage;
+  array2d< real64 > m_strainEnergyDensity;
+  array2d< real64 > m_extDrivingForce; 
+  real64 m_lengthScale;
+  real64 m_criticalFractureEnergy;
+  real64 m_criticalStrainEnergy;
+  real64 m_tensileStrength; 
+  real64 m_compressStrength; 
+  real64 m_deltaCoefficient; 
+};
+
+}
+} /* namespace geosx */
+
+#endif /* GEOSX_CONSTITUTIVE_SOLID_DAMAGE_HPP_ */

--- a/src/coreComponents/constitutive/solid/DamageSpectral.hpp
+++ b/src/coreComponents/constitutive/solid/DamageSpectral.hpp
@@ -42,11 +42,12 @@ public:
   template< typename ... PARAMS >
   DamageSpectralUpdates( arrayView2d< real64 > const & inputDamage,
                          arrayView2d< real64 > const & inputStrainEnergyDensity,
+                         arrayView2d< real64 > const & inputExtDrivingForce, 
                          real64 const & inputLengthScale,
                          real64 const & inputCriticalFractureEnergy,
                          real64 const & inputcriticalStrainEnergy,
                          PARAMS && ... baseParams ):
-    DamageUpdates< UPDATE_BASE >( inputDamage, inputStrainEnergyDensity, inputLengthScale,
+    DamageUpdates< UPDATE_BASE >( inputDamage, inputStrainEnergyDensity, inputExtDrivingForce, inputLengthScale,
                                   inputCriticalFractureEnergy, inputcriticalStrainEnergy,
                                   std::forward< PARAMS >( baseParams )... )
   {}
@@ -60,9 +61,11 @@ public:
   using DamageUpdates< UPDATE_BASE >::getDegradationDerivative;
   using DamageUpdates< UPDATE_BASE >::getDegradationSecondDerivative;
   using DamageUpdates< UPDATE_BASE >::getEnergyThreshold;
+  using DamageUpdates< UPDATE_BASE >::getExtDrivingForce; 
 
   using DamageUpdates< UPDATE_BASE >::m_strainEnergyDensity;
   using DamageUpdates< UPDATE_BASE >::m_criticalStrainEnergy;
+  using DamageUpdates< UPDATE_BASE >::m_extDrivingForce; 
   using DamageUpdates< UPDATE_BASE >::m_criticalFractureEnergy;
   using DamageUpdates< UPDATE_BASE >::m_lengthScale;
   using DamageUpdates< UPDATE_BASE >::m_damage;
@@ -267,6 +270,7 @@ public:
 
   using Damage< BASE >::m_damage;
   using Damage< BASE >::m_strainEnergyDensity;
+  using Damage< BASE >::m_extDrivingForce; 
   using Damage< BASE >::m_criticalFractureEnergy;
   using Damage< BASE >::m_lengthScale;
   using Damage< BASE >::m_criticalStrainEnergy;
@@ -283,6 +287,7 @@ public:
   {
     return BASE::template createDerivedKernelUpdates< KernelWrapper >( m_damage.toView(),
                                                                        m_strainEnergyDensity.toView(),
+                                                                       m_extDrivingForce.toView(), 
                                                                        m_lengthScale,
                                                                        m_criticalFractureEnergy,
                                                                        m_criticalStrainEnergy );

--- a/src/coreComponents/constitutive/solid/DamageVolDev.hpp
+++ b/src/coreComponents/constitutive/solid/DamageVolDev.hpp
@@ -36,11 +36,12 @@ public:
   template< typename ... PARAMS >
   DamageVolDevUpdates( arrayView2d< real64 > const & inputDamage,
                        arrayView2d< real64 > const & inputStrainEnergyDensity,
+                       arrayView2d< real64 > const & inputExtDrivingForce, 
                        real64 const & inputLengthScale,
                        real64 const & inputCriticalFractureEnergy,
                        real64 const & inputcriticalStrainEnergy,
                        PARAMS && ... baseParams ):
-    DamageUpdates< UPDATE_BASE >( inputDamage, inputStrainEnergyDensity, inputLengthScale,
+    DamageUpdates< UPDATE_BASE >( inputDamage, inputStrainEnergyDensity, inputExtDrivingForce, inputLengthScale,
                                   inputCriticalFractureEnergy, inputcriticalStrainEnergy,
                                   std::forward< PARAMS >( baseParams )... )
   {}
@@ -54,9 +55,11 @@ public:
   using DamageUpdates< UPDATE_BASE >::getDegradationDerivative;
   using DamageUpdates< UPDATE_BASE >::getDegradationSecondDerivative;
   using DamageUpdates< UPDATE_BASE >::getEnergyThreshold;
+  using DamageUpdates< UPDATE_BASE >::getExtDrivingForce; 
 
   using DamageUpdates< UPDATE_BASE >::m_strainEnergyDensity;
   using DamageUpdates< UPDATE_BASE >::m_criticalStrainEnergy;
+  using DamageUpdates< UPDATE_BASE >::m_extDrivingForce; 
   using DamageUpdates< UPDATE_BASE >::m_criticalFractureEnergy;
   using DamageUpdates< UPDATE_BASE >::m_lengthScale;
 
@@ -143,6 +146,7 @@ public:
 
   using Damage< BASE >::m_damage;
   using Damage< BASE >::m_strainEnergyDensity;
+  using Damage< BASE >::m_extDrivingForce; 
   using Damage< BASE >::m_criticalFractureEnergy;
   using Damage< BASE >::m_lengthScale;
   using Damage< BASE >::m_criticalStrainEnergy;
@@ -159,6 +163,7 @@ public:
   {
     return BASE::template createDerivedKernelUpdates< KernelWrapper >( m_damage.toView(),
                                                                        m_strainEnergyDensity.toView(),
+                                                                       m_extDrivingForce.toView(), 
                                                                        m_lengthScale,
                                                                        m_criticalFractureEnergy,
                                                                        m_criticalStrainEnergy );

--- a/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEMKernels.hpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/PhaseFieldDamageFEMKernels.hpp
@@ -192,6 +192,7 @@ public:
     real64 const ell = m_constitutiveUpdate.getRegularizationLength();
     real64 const Gc = m_constitutiveUpdate.getCriticalFractureEnergy();
     real64 const threshold = m_constitutiveUpdate.getEnergyThreshold();
+    real64 const extDrivingForce = m_constitutiveUpdate.getExtDrivingForce( k, q ); 
 
     real64 D = 0;                                                                   //max between threshold and
                                                                                     // Elastic energy
@@ -215,14 +216,16 @@ public:
       if( m_localDissipationOption == 1 )
       {
         stack.localResidual[ a ] += detJ * ( -3 * N[a] / 16  -
-                                             0.375*pow( ell, 2 ) * LvArray::tensorOps::AiBi< 3 >( qp_grad_damage, dNdX[a] ) -
-                                             (0.5 * ell * D/Gc) * N[a] * m_constitutiveUpdate.getDegradationDerivative( qp_damage ));
+                                              0.375*pow( ell, 2 ) * LvArray::tensorOps::AiBi< 3 >( qp_grad_damage, dNdX[a] ) -
+                                              (0.5 * ell * D/Gc) * N[a] * m_constitutiveUpdate.getDegradationDerivative( qp_damage ) - 
+                                              (extDrivingForce / 2 / Gc * ell * N[a])); // External driving force added 
       }
       else
       {
         stack.localResidual[ a ] -= detJ * ( N[a] * qp_damage +
-                                             (pow( ell, 2 ) * LvArray::tensorOps::AiBi< 3 >( qp_grad_damage, dNdX[a] ) +
-                                              N[a] * m_constitutiveUpdate.getDegradationDerivative( qp_damage ) * (ell*strainEnergyDensity/Gc)) );
+                                              (pow( ell, 2 ) * LvArray::tensorOps::AiBi< 3 >( qp_grad_damage, dNdX[a] ) +
+                                              N[a] * m_constitutiveUpdate.getDegradationDerivative( qp_damage ) * (ell*strainEnergyDensity/Gc)) + 
+                                              (extDrivingForce / 2 / Gc * ell * N[a]) ); // External driving force added 
 
       }
       for( localIndex b = 0; b < numNodesPerElem; ++b )


### PR DESCRIPTION
Constitutive files and phase-field damage solver are updated according to a phase-field nucleation formulation derived by Kumar et al. (2020, JMPS). 
Basically, a new term called external driving force is added into the damage evolution equation. 
New member variables to account for this external driving force are added in the Damage constitutive files and function to output it is added. 
New constitutive files called DamgeExtDrivingForce.hpp and .cpp are created, in which the external driving force is nonzero and updated given the stress state. 