### PR TITLE
Fix misplaced initialization for boundary tags 

### DIFF
--- a/src/coreComponents/physicsSolvers/wavePropagation/AcousticWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/AcousticWaveEquationSEM.cpp
@@ -450,7 +450,7 @@ void AcousticWaveEquationSEM::applyFreeSurfaceBC( real64 const time, DomainParti
 
   /// array of indicators: 1 if a node is on on free surface; 0 otherwise
   arrayView1d< localIndex > const freeSurfaceNodeIndicator = nodeManager.getExtrinsicData< extrinsicMeshData::FreeSurfaceNodeIndicator >();
-  
+
   freeSurfaceFaceIndicator.zero();
   freeSurfaceNodeIndicator.zero();
 

--- a/src/coreComponents/physicsSolvers/wavePropagation/AcousticWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/AcousticWaveEquationSEM.cpp
@@ -450,6 +450,9 @@ void AcousticWaveEquationSEM::applyFreeSurfaceBC( real64 const time, DomainParti
 
   /// array of indicators: 1 if a node is on on free surface; 0 otherwise
   arrayView1d< localIndex > const freeSurfaceNodeIndicator = nodeManager.getExtrinsicData< extrinsicMeshData::FreeSurfaceNodeIndicator >();
+  
+  freeSurfaceFaceIndicator.zero();
+  freeSurfaceNodeIndicator.zero();
 
   fsManager.apply( time,
                    domain.getMeshBody( 0 ).getMeshLevel( 0 ),
@@ -466,9 +469,6 @@ void AcousticWaveEquationSEM::applyFreeSurfaceBC( real64 const time, DomainParti
     if( functionName.empty() || functionManager.getGroup< FunctionBase >( functionName ).isFunctionOfTime() == 2 )
     {
       real64 const value = bc.getScale();
-
-      freeSurfaceFaceIndicator.zero();
-      freeSurfaceNodeIndicator.zero();
 
       for( localIndex i = 0; i < targetSet.size(); ++i )
       {


### PR DESCRIPTION
This little PR fixes a misplaced intialization for two arrays (freeSurfaceFaceIndicator and freeSurfaceNodeIndicator) used when we compute Free Surface boundary condition inside the acoustic solver.

Due to this bug, we were unable to use several free surface boundary. The arrays were re-initialized each time we switch between the differents zone defined inside the Box block inside the XML.