### PR TITLE
Fixed parallel field import in VTKMeshGenerator

### DIFF
--- a/src/coreComponents/mesh/generators/VTKMeshGenerator.cpp
+++ b/src/coreComponents/mesh/generators/VTKMeshGenerator.cpp
@@ -885,9 +885,12 @@ void VTKMeshGenerator::
         GEOSX_LOG_LEVEL_RANK_0( 1, GEOSX_FMT( "Skipping import of {} -> {} on {}/{} (field not found)",
                                               vtkArray->GetName(), wrapperName, region.getName(), subRegion.getName() ) );
 
-        fieldsToBeSync.addElementFields( {wrapperName}, {region.getName()} );
         continue;
       }
+
+      // Now that we know that the subRegion has this wrapper, we can add the wrapperName to the list of fields to synchronize
+      fieldsToBeSync.addElementFields( {wrapperName}, {region.getName()} );
+
       WrapperBase & wrapper = subRegion.getWrapperBase( wrapperName );
 
       GEOSX_LOG_LEVEL_RANK_0( 1, GEOSX_FMT( "Importing field {} -> {} on {}/{}",


### PR DESCRIPTION
This PR moves a call to `addElementFields` in `VTKMeshGenerator` to make sure that the imported fields are properly synchronized. 

I don't think the error appears in `staircase_co2_wells_hybrid_3d`, but in the short term we will have more integrated tests for this capability (for instance added by https://github.com/GEOSX/GEOSX/pull/1853) which will help catching these issues, I think.

Ready for review, no rebaseline necessary.