### PR TITLE
Correct wrong `make -j` command line

### DIFF
--- a/src/docs/sphinx/buildGuide/BuildProcess.rst
+++ b/src/docs/sphinx/buildGuide/BuildProcess.rst
@@ -49,7 +49,7 @@ Build steps
   .. code-block:: console
 
      cd <buildpath>
-     make -j
+     make -j $(nproc)
 
 You may also run the CMake configure step manually instead of relying on ``config-build.py``.
 A full build typically takes between 10 and 30 minutes, depending on chosen compilers, options and number of cores.


### PR DESCRIPTION
`nproc` is part of the core utils so everyone should have it!
(However, it's better than `make -j` 😨 )