### PR TITLE
Feature/castelletto1/suppress move logging

### DIFF
--- a/src/coreComponents/common/initializeEnvironment.hpp
+++ b/src/coreComponents/common/initializeEnvironment.hpp
@@ -81,7 +81,7 @@ struct CommandLineOptions
   string timerOutput = "";
 
   /// Suppress logging of host-device data migration.
-  integer suppressMoveLogging = false;
+  integer displayMoveLogging = false;
 };
 
 /**

--- a/src/coreComponents/common/initializeEnvironment.hpp
+++ b/src/coreComponents/common/initializeEnvironment.hpp
@@ -80,8 +80,8 @@ struct CommandLineOptions
   /// The string used to initialize caliper.
   string timerOutput = "";
 
-  /// Display logging of host-device data migration.
-  integer displayMoveLogging = false;
+  /// Trace host-device data migration.
+  integer traceDataMigration = false;
 };
 
 /**

--- a/src/coreComponents/common/initializeEnvironment.hpp
+++ b/src/coreComponents/common/initializeEnvironment.hpp
@@ -80,7 +80,7 @@ struct CommandLineOptions
   /// The string used to initialize caliper.
   string timerOutput = "";
 
-  /// Suppress logging of host-device data migration.
+  /// Display logging of host-device data migration.
   integer displayMoveLogging = false;
 };
 

--- a/src/coreComponents/mainInterface/ProblemManager.cpp
+++ b/src/coreComponents/mainInterface/ProblemManager.cpp
@@ -199,7 +199,11 @@ void ProblemManager::parseCommandLineInput()
     Path::pathPrefix() = splitPath( inputFileName ).first;
   }
 
-  if( opts.suppressMoveLogging )
+  if( opts.displayMoveLogging )
+  {
+    chai::ArrayManager::getInstance()->enableCallbacks();
+  }
+  else
   {
     chai::ArrayManager::getInstance()->disableCallbacks();
   }

--- a/src/coreComponents/mainInterface/ProblemManager.cpp
+++ b/src/coreComponents/mainInterface/ProblemManager.cpp
@@ -199,7 +199,7 @@ void ProblemManager::parseCommandLineInput()
     Path::pathPrefix() = splitPath( inputFileName ).first;
   }
 
-  if( opts.displayMoveLogging )
+  if( opts.traceDataMigration )
   {
     chai::ArrayManager::getInstance()->enableCallbacks();
   }

--- a/src/coreComponents/mainInterface/initialization.cpp
+++ b/src/coreComponents/mainInterface/initialization.cpp
@@ -98,7 +98,7 @@ std::unique_ptr< CommandLineOptions > parseCommandLineOptions( int argc, char * 
     PROBLEMNAME,
     OUTPUTDIR,
     TIMERS,
-    SUPPRESS_MOVE_LOGGING,
+    DISPLAY_MOVE_LOGGING,
     PAUSE_FOR,
   };
 
@@ -117,7 +117,7 @@ std::unique_ptr< CommandLineOptions > parseCommandLineOptions( int argc, char * 
     { SUPPRESS_PINNED, 0, "s", "suppress-pinned", Arg::None, "\t-s, --suppress-pinned \t Suppress usage of pinned memory for MPI communication buffers" },
     { OUTPUTDIR, 0, "o", "output", Arg::nonEmpty, "\t-o, --output, \t Directory to put the output files" },
     { TIMERS, 0, "t", "timers", Arg::nonEmpty, "\t-t, --timers, \t String specifying the type of timer output." },
-    { SUPPRESS_MOVE_LOGGING, 0, "", "suppress-move-logging", Arg::None, "\t--suppress-move-logging \t Suppress logging of host-device data migration" },
+    { DISPLAY_MOVE_LOGGING, 0, "", "display-move-logging", Arg::None, "\t--display-move-logging \t Display logging of host-device data migration" },
     { PAUSE_FOR, 0, "", "pause-for", Arg::numeric, "\t--pause-for, \t Pause geosx for a given number of seconds before starting execution" },
     { 0, 0, nullptr, nullptr, nullptr, nullptr }
   };
@@ -215,9 +215,9 @@ std::unique_ptr< CommandLineOptions > parseCommandLineOptions( int argc, char * 
         commandLineOptions->timerOutput = opt.arg;
       }
       break;
-      case SUPPRESS_MOVE_LOGGING:
+      case DISPLAY_MOVE_LOGGING:
       {
-        commandLineOptions->suppressMoveLogging = true;
+        commandLineOptions->displayMoveLogging = true;
       }
       break;
       case PAUSE_FOR:

--- a/src/coreComponents/mainInterface/initialization.cpp
+++ b/src/coreComponents/mainInterface/initialization.cpp
@@ -98,7 +98,7 @@ std::unique_ptr< CommandLineOptions > parseCommandLineOptions( int argc, char * 
     PROBLEMNAME,
     OUTPUTDIR,
     TIMERS,
-    DISPLAY_MOVE_LOGGING,
+    TRACE_DATA_MIGRATION,
     PAUSE_FOR,
   };
 
@@ -117,7 +117,7 @@ std::unique_ptr< CommandLineOptions > parseCommandLineOptions( int argc, char * 
     { SUPPRESS_PINNED, 0, "s", "suppress-pinned", Arg::None, "\t-s, --suppress-pinned, \t Suppress usage of pinned memory for MPI communication buffers" },
     { OUTPUTDIR, 0, "o", "output", Arg::nonEmpty, "\t-o, --output, \t Directory to put the output files" },
     { TIMERS, 0, "t", "timers", Arg::nonEmpty, "\t-t, --timers, \t String specifying the type of timer output" },
-    { DISPLAY_MOVE_LOGGING, 0, "", "display-move-logging", Arg::None, "\t--display-move-logging, \t Display logging of host-device data migration" },
+    { TRACE_DATA_MIGRATION, 0, "", "trace-data-migration", Arg::None, "\t--trace-data-migration, \t Trace host-device data migration" },
     { PAUSE_FOR, 0, "", "pause-for", Arg::numeric, "\t--pause-for, \t Pause geosx for a given number of seconds before starting execution" },
     { 0, 0, nullptr, nullptr, nullptr, nullptr }
   };
@@ -215,9 +215,9 @@ std::unique_ptr< CommandLineOptions > parseCommandLineOptions( int argc, char * 
         commandLineOptions->timerOutput = opt.arg;
       }
       break;
-      case DISPLAY_MOVE_LOGGING:
+      case TRACE_DATA_MIGRATION:
       {
-        commandLineOptions->displayMoveLogging = true;
+        commandLineOptions->traceDataMigration = true;
       }
       break;
       case PAUSE_FOR:

--- a/src/coreComponents/mainInterface/initialization.cpp
+++ b/src/coreComponents/mainInterface/initialization.cpp
@@ -114,10 +114,10 @@ std::unique_ptr< CommandLineOptions > parseCommandLineOptions( int argc, char * 
     { SCHEMA, 0, "s", "schema", Arg::nonEmpty, "\t-s, --schema, \t Name of the output schema" },
     { NONBLOCKING_MPI, 0, "b", "use-nonblocking", Arg::None, "\t-b, --use-nonblocking, \t Use non-blocking MPI communication" },
     { PROBLEMNAME, 0, "n", "name", Arg::nonEmpty, "\t-n, --name, \t Name of the problem, used for output" },
-    { SUPPRESS_PINNED, 0, "s", "suppress-pinned", Arg::None, "\t-s, --suppress-pinned \t Suppress usage of pinned memory for MPI communication buffers" },
+    { SUPPRESS_PINNED, 0, "s", "suppress-pinned", Arg::None, "\t-s, --suppress-pinned, \t Suppress usage of pinned memory for MPI communication buffers" },
     { OUTPUTDIR, 0, "o", "output", Arg::nonEmpty, "\t-o, --output, \t Directory to put the output files" },
-    { TIMERS, 0, "t", "timers", Arg::nonEmpty, "\t-t, --timers, \t String specifying the type of timer output." },
-    { DISPLAY_MOVE_LOGGING, 0, "", "display-move-logging", Arg::None, "\t--display-move-logging \t Display logging of host-device data migration" },
+    { TIMERS, 0, "t", "timers", Arg::nonEmpty, "\t-t, --timers, \t String specifying the type of timer output" },
+    { DISPLAY_MOVE_LOGGING, 0, "", "display-move-logging", Arg::None, "\t--display-move-logging, \t Display logging of host-device data migration" },
     { PAUSE_FOR, 0, "", "pause-for", Arg::numeric, "\t--pause-for, \t Pause geosx for a given number of seconds before starting execution" },
     { 0, 0, nullptr, nullptr, nullptr, nullptr }
   };

--- a/src/docs/sphinx/QuickStart.rst
+++ b/src/docs/sphinx/QuickStart.rst
@@ -385,9 +385,8 @@ This should print out a brief summary of the available command line arguments:
     -s, --suppress-pinned,   Suppress usage of pinned memory for MPI communication buffers
     -o, --output,            Directory to put the output files
     -t, --timers,            String specifying the type of timer output
-    --display-move-logging,  Display logging of host-device data migration
+    --trace-data-migration,  Trace host-device data migration
     --pause-for,             Pause geosx for a given number of seconds before starting execution
-    An input xml must be specified!
 
 Obviously this doesn't do much interesting, but it will at least confirm that the executable runs.
 In typical usage, an input XML must be provided describing the problem to be run, e.g.

--- a/src/docs/sphinx/QuickStart.rst
+++ b/src/docs/sphinx/QuickStart.rst
@@ -374,17 +374,19 @@ This should print out a brief summary of the available command line arguments:
 
     Options:
     -?, --help
-    -i, --input,            Input xml filename (required)
-    -r, --restart,          Target restart filename
-    -x, --x-partitions,     Number of partitions in the x-direction
-    -y, --y-partitions,     Number of partitions in the y-direction
-    -z, --z-partitions,     Number of partitions in the z-direction
-    -s, --schema,           Name of the output schema
-    -b, --use-nonblocking,  Use non-blocking MPI communication
-    -n, --name,             Name of the problem, used for output
-    -s, --suppress-pinned   Suppress usage of pinned memory for MPI communication buffers
-    -o, --output,           Directory to put the output files
-    -t, --timers,           String specifying the type of timer output.
+    -i, --input,             Input xml filename (required)
+    -r, --restart,           Target restart filename
+    -x, --x-partitions,      Number of partitions in the x-direction
+    -y, --y-partitions,      Number of partitions in the y-direction
+    -z, --z-partitions,      Number of partitions in the z-direction
+    -s, --schema,            Name of the output schema
+    -b, --use-nonblocking,   Use non-blocking MPI communication
+    -n, --name,              Name of the problem, used for output
+    -s, --suppress-pinned,   Suppress usage of pinned memory for MPI communication buffers
+    -o, --output,            Directory to put the output files
+    -t, --timers,            String specifying the type of timer output
+    --display-move-logging,  Display logging of host-device data migration
+    --pause-for,             Pause geosx for a given number of seconds before starting execution
     An input xml must be specified!
 
 Obviously this doesn't do much interesting, but it will at least confirm that the executable runs.


### PR DESCRIPTION
This PR removes default move logging. The proposed change replaces flag `--suppress-move-logging` by `--trace-data-migration`. 

Requires updated integrated tests submodule (baselines are the same) https://github.com/GEOSX/integratedTests/pull/227