### PR TITLE
Fixed misleading behavior in source flux boundary condition 

### DIFF
--- a/src/coreComponents/fieldSpecification/FieldSpecificationBase.cpp
+++ b/src/coreComponents/fieldSpecification/FieldSpecificationBase.cpp
@@ -24,8 +24,7 @@ namespace geosx
 using namespace dataRepository;
 
 FieldSpecificationBase::FieldSpecificationBase( string const & name, Group * parent ):
-  Group( name, parent ),
-  m_normalizeBySetSize( false )
+  Group( name, parent )
 {
   setInputFlags( InputFlags::OPTIONAL_NONUNIQUE );
 

--- a/src/coreComponents/fieldSpecification/SourceFluxBoundaryCondition.cpp
+++ b/src/coreComponents/fieldSpecification/SourceFluxBoundaryCondition.cpp
@@ -25,9 +25,7 @@ using namespace dataRepository;
 
 SourceFluxBoundaryCondition::SourceFluxBoundaryCondition( string const & name, Group * const parent ):
   FieldSpecificationBase( name, parent )
-{
-  m_normalizeBySetSize = true;
-}
+{}
 
 SourceFluxBoundaryCondition::~SourceFluxBoundaryCondition()
 {

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.cpp
@@ -1288,85 +1288,129 @@ void CompositionalMultiphaseBase::applySourceFluxBC( real64 const time,
 
   string const dofKey = dofManager.getKey( viewKeyStruct::elemDofFieldString() );
 
-  fsManager.apply( time + dt,
-                   domain.getMeshBody( 0 ).getMeshLevel( 0 ),
-                   "ElementRegions",
-                   FieldSpecificationBase::viewKeyStruct::fluxBoundaryConditionString(),
-                   [&]( FieldSpecificationBase const & fs,
-                        string const & setName,
-                        SortedArrayView< localIndex const > const & targetSet,
-                        Group & subRegion,
-                        string const & )
+  // Step 1: count individual source flux boundary conditions
+
+  std::map< string, localIndex > bcNameToBcId;
+  localIndex bcCounter = 0;
+
+  fsManager.forSubGroups< SourceFluxBoundaryCondition >( [&] ( SourceFluxBoundaryCondition const & bc )
   {
-    if( fs.getLogLevel() >= 1 && m_nonlinearSolverParameters.m_numNewtonIterations == 0 )
+    // collect all the bc names to idx
+    bcNameToBcId[bc.getName()] = bcCounter;
+    bcCounter++;
+  } );
+
+  if( bcCounter == 0 )
+  {
+    return;
+  }
+
+  // Step 2: count the set size for each source flux (each source flux may have multiple target sets)
+
+  array1d< globalIndex > bcAllSetsSize( bcNameToBcId.size() );
+
+  computeSourceFluxSizeScalingFactor( time,
+                                      dt,
+                                      domain,
+                                      bcNameToBcId,
+                                      bcAllSetsSize.toView() );
+
+  // Step 3: we are ready to impose the boundary condition, normalized by the set size
+
+  forMeshTargets( domain.getMeshBodies(), [&]( string const &,
+                                               MeshLevel & mesh,
+                                               arrayView1d< string const > const & )
+  {
+    fsManager.apply( time + dt,
+                     mesh,
+                     "ElementRegions",
+                     FieldSpecificationBase::viewKeyStruct::fluxBoundaryConditionString(),
+                     [&]( FieldSpecificationBase const & fs,
+                          string const & setName,
+                          SortedArrayView< localIndex const > const & targetSet,
+                          Group & subRegion,
+                          string const & )
     {
-      globalIndex const numTargetElems = MpiWrapper::sum< globalIndex >( targetSet.size() );
-      GEOSX_LOG_RANK_0( GEOSX_FMT( geosx::internal::bcLogMessage,
-                                   getName(), time+dt, SourceFluxBoundaryCondition::catalogName(),
-                                   fs.getName(), setName, subRegion.getName(), fs.getScale(), numTargetElems ) );
-    }
+      if( fs.getLogLevel() >= 1 && m_nonlinearSolverParameters.m_numNewtonIterations == 0 )
+      {
+        globalIndex const numTargetElems = MpiWrapper::sum< globalIndex >( targetSet.size() );
+        GEOSX_LOG_RANK_0( GEOSX_FMT( geosx::internal::bcLogMessage,
+                                     getName(), time+dt, SourceFluxBoundaryCondition::catalogName(),
+                                     fs.getName(), setName, subRegion.getName(), fs.getScale(), numTargetElems ) );
+      }
 
-    arrayView1d< globalIndex const > const dofNumber = subRegion.getReference< array1d< globalIndex > >( dofKey );
-    arrayView1d< integer const > const ghostRank =
-      subRegion.getReference< array1d< integer > >( ObjectManagerBase::viewKeyStruct::ghostRankString() );
-
-    // Step 1: get the values of the source boundary condition that need to be added to the rhs
-    // We don't use FieldSpecificationBase::applyConditionToSystem here because we want to account for the row permutation used in the
-    // compositional solvers
-
-    array1d< globalIndex > dofArray( targetSet.size() );
-    array1d< real64 > rhsContributionArray( targetSet.size() );
-    arrayView1d< real64 > rhsContributionArrayView = rhsContributionArray.toView();
-    localIndex const rankOffset = dofManager.rankOffset();
-
-    // note that the dofArray will not be used after this step (simpler to use dofNumber instead)
-    fs.computeRhsContribution< FieldSpecificationAdd,
-                               parallelDevicePolicy<> >( targetSet.toViewConst(),
-                                                         time + dt,
-                                                         dt,
-                                                         subRegion,
-                                                         dofNumber,
-                                                         rankOffset,
-                                                         localMatrix,
-                                                         dofArray.toView(),
-                                                         rhsContributionArrayView,
-                                                         [] GEOSX_HOST_DEVICE ( localIndex const )
-    {
-      return 0.0;
-    } );
-
-    // Step 2: we are ready to add the right-hand side contributions, taking into account our equation layout
-
-    integer const fluidComponentId = fs.getComponent();
-    integer const numFluidComponents = m_numComponents;
-    forAll< parallelDevicePolicy<> >( targetSet.size(), [targetSet,
-                                                         rankOffset,
-                                                         ghostRank,
-                                                         fluidComponentId,
-                                                         numFluidComponents,
-                                                         dofNumber,
-                                                         rhsContributionArrayView,
-                                                         localRhs] GEOSX_HOST_DEVICE ( localIndex const a )
-    {
-      // we need to filter out ghosts here, because targetSet may contain them
-      localIndex const ei = targetSet[a];
-      if( ghostRank[ei] >= 0 )
+      if( targetSet.size() == 0 )
       {
         return;
       }
 
-      // for all "fluid components", we add the value to the total mass balance equation
-      globalIndex const totalMassBalanceRow = dofNumber[ei] - rankOffset;
-      localRhs[totalMassBalanceRow] += rhsContributionArrayView[a];
+      arrayView1d< globalIndex const > const dofNumber = subRegion.getReference< array1d< globalIndex > >( dofKey );
+      arrayView1d< integer const > const ghostRank =
+        subRegion.getReference< array1d< integer > >( ObjectManagerBase::viewKeyStruct::ghostRankString() );
 
-      // for all "fluid components" except the last one, we add the value to the component mass balance equation (shifted appropriately)
-      if( fluidComponentId < numFluidComponents - 1 )
+      // Step 3.1: get the values of the source boundary condition that need to be added to the rhs
+      // We don't use FieldSpecificationBase::applyConditionToSystem here because we want to account for the row permutation used in the
+      // compositional solvers
+
+      array1d< globalIndex > dofArray( targetSet.size() );
+      array1d< real64 > rhsContributionArray( targetSet.size() );
+      arrayView1d< real64 > rhsContributionArrayView = rhsContributionArray.toView();
+      localIndex const rankOffset = dofManager.rankOffset();
+
+      // note that the dofArray will not be used after this step (simpler to use dofNumber instead)
+      fs.computeRhsContribution< FieldSpecificationAdd,
+                                 parallelDevicePolicy<> >( targetSet.toViewConst(),
+                                                           time + dt,
+                                                           dt,
+                                                           subRegion,
+                                                           dofNumber,
+                                                           rankOffset,
+                                                           localMatrix,
+                                                           dofArray.toView(),
+                                                           rhsContributionArrayView,
+                                                           [] GEOSX_HOST_DEVICE ( localIndex const )
       {
-        globalIndex const compMassBalanceRow = totalMassBalanceRow + fluidComponentId + 1; // component mass bal equations are shifted
-        localRhs[compMassBalanceRow] += rhsContributionArrayView[a];
-      }
-    } );
+        return 0.0;
+      } );
 
+      // Step 3.2: we are ready to add the right-hand side contributions, taking into account our equation layout
+
+      // get the normalizer
+      real64 const sizeScalingFactor = bcAllSetsSize[bcNameToBcId.at( fs.getName())];
+
+      integer const fluidComponentId = fs.getComponent();
+      integer const numFluidComponents = m_numComponents;
+      forAll< parallelDevicePolicy<> >( targetSet.size(), [sizeScalingFactor,
+                                                           targetSet,
+                                                           rankOffset,
+                                                           ghostRank,
+                                                           fluidComponentId,
+                                                           numFluidComponents,
+                                                           dofNumber,
+                                                           rhsContributionArrayView,
+                                                           localRhs] GEOSX_HOST_DEVICE ( localIndex const a )
+      {
+        // we need to filter out ghosts here, because targetSet may contain them
+        localIndex const ei = targetSet[a];
+        if( ghostRank[ei] >= 0 )
+        {
+          return;
+        }
+
+        // for all "fluid components", we add the value to the total mass balance equation
+        globalIndex const totalMassBalanceRow = dofNumber[ei] - rankOffset;
+        localRhs[totalMassBalanceRow] += rhsContributionArrayView[a] / sizeScalingFactor; // scale the contribution by the sizeScalingFactor
+                                                                                          // here
+
+        // for all "fluid components" except the last one, we add the value to the component mass balance equation (shifted appropriately)
+        if( fluidComponentId < numFluidComponents - 1 )
+        {
+          globalIndex const compMassBalanceRow = totalMassBalanceRow + fluidComponentId + 1; // component mass bal equations are shifted
+          localRhs[compMassBalanceRow] += rhsContributionArrayView[a] / sizeScalingFactor; // scale the contribution by the
+                                                                                           // sizeScalingFactor here
+        }
+      } );
+    } );
   } );
 }
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBase.cpp
@@ -354,6 +354,56 @@ void FlowSolverBase::findMinMaxElevationInEquilibriumTarget( DomainPartition & d
                          MPI_COMM_GEOSX );
 }
 
+void FlowSolverBase::computeSourceFluxSizeScalingFactor( real64 const & time,
+                                                         real64 const & dt,
+                                                         DomainPartition & domain, // cannot be const...
+                                                         std::map< string, localIndex > const & bcNameToBcId,
+                                                         arrayView1d< globalIndex > const & bcAllSetsSize ) const
+{
+  FieldSpecificationManager & fsManager = FieldSpecificationManager::getInstance();
+
+  forMeshTargets( domain.getMeshBodies(), [&]( string const &,
+                                               MeshLevel & mesh,
+                                               arrayView1d< string const > const & )
+  {
+    fsManager.apply( time + dt,
+                     mesh,
+                     "ElementRegions",
+                     FieldSpecificationBase::viewKeyStruct::fluxBoundaryConditionString(),
+                     [&]( FieldSpecificationBase const & fs,
+                          string const &,
+                          SortedArrayView< localIndex const > const & targetSet,
+                          Group & subRegion,
+                          string const & )
+    {
+      arrayView1d< integer const > const ghostRank =
+        subRegion.getReference< array1d< integer > >( ObjectManagerBase::viewKeyStruct::ghostRankString() );
+
+      // loop over all the elements of this target set
+      RAJA::ReduceSum< ReducePolicy< parallelDevicePolicy<> >, localIndex > localSetSize( 0 );
+      forAll< parallelDevicePolicy<> >( targetSet.size(),
+                                        [targetSet, ghostRank, localSetSize] GEOSX_HOST_DEVICE ( localIndex const k )
+      {
+        localIndex const ei = targetSet[k];
+        if( ghostRank[ei] < 0 )
+        {
+          localSetSize += 1;
+        }
+      } );
+
+      // increment the set size for this source flux boundary conditions
+      bcAllSetsSize[bcNameToBcId.at( fs.getName())] += localSetSize.get();
+    } );
+  } );
+
+  // synchronize the set size over all the MPI ranks
+  MpiWrapper::allReduce( bcAllSetsSize.data(),
+                         bcAllSetsSize.data(),
+                         bcAllSetsSize.size(),
+                         MpiWrapper::getMpiOp( MpiWrapper::Reduction::Sum ),
+                         MPI_COMM_GEOSX );
+}
+
 void FlowSolverBase::saveAquiferConvergedState( real64 const & time,
                                                 real64 const & dt,
                                                 DomainPartition & domain )

--- a/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBase.hpp
@@ -97,6 +97,20 @@ public:
                                                arrayView1d< real64 > const & maxElevation,
                                                arrayView1d< real64 > const & minElevation ) const;
 
+  /**
+   * @brief For each source flux boundary condition, loop over all the target cells and sum the owned cells
+   * @param[in] time the time at the beginning of the time step
+   * @param[in] dt the time step size
+   * @param[in] domain the domain partition
+   * @param[in] bcNameToBcId the map from the name of the boundary condition to the boundary condition index
+   * @param[out] bcAllSetsSize the total number of owned cells for each source flux boundary condition
+   */
+  void computeSourceFluxSizeScalingFactor( real64 const & time,
+                                           real64 const & dt,
+                                           DomainPartition & domain, // cannot be const...
+                                           std::map< string, localIndex > const & bcNameToBcId,
+                                           arrayView1d< globalIndex > const & bcAllSetsSize ) const;
+
 
 protected:
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseBase.cpp
@@ -737,13 +737,42 @@ void SinglePhaseBase::applySourceFluxBC( real64 const time_n,
   GEOSX_MARK_FUNCTION;
 
   FieldSpecificationManager & fsManager = FieldSpecificationManager::getInstance();
+
   string const dofKey = dofManager.getKey( extrinsicMeshData::flow::pressure::key() );
 
-  forMeshTargets( domain.getMeshBodies(), [&] ( string const &,
-                                                MeshLevel & mesh,
-                                                arrayView1d< string const > const & )
-  {
+  // Step 1: count individual source flux boundary conditions
 
+  std::map< string, localIndex > bcNameToBcId;
+  localIndex bcCounter = 0;
+
+  fsManager.forSubGroups< SourceFluxBoundaryCondition >( [&] ( SourceFluxBoundaryCondition const & bc )
+  {
+    // collect all the bc names to idx
+    bcNameToBcId[bc.getName()] = bcCounter;
+    bcCounter++;
+  } );
+
+  if( bcCounter == 0 )
+  {
+    return;
+  }
+
+  // Step 2: count the set size for each source flux (each source flux may have multiple target sets)
+
+  array1d< globalIndex > bcAllSetsSize( bcNameToBcId.size() );
+
+  computeSourceFluxSizeScalingFactor( time_n,
+                                      dt,
+                                      domain,
+                                      bcNameToBcId,
+                                      bcAllSetsSize.toView() );
+
+  // Step 3: we are ready to impose the boundary condition, normalized by the set size
+
+  forMeshTargets( domain.getMeshBodies(), [&]( string const &,
+                                               MeshLevel & mesh,
+                                               arrayView1d< string const > const & )
+  {
     fsManager.apply( time_n + dt,
                      mesh,
                      "ElementRegions",
@@ -762,25 +791,63 @@ void SinglePhaseBase::applySourceFluxBC( real64 const time_n,
                                      fs.getName(), setName, subRegion.getName(), fs.getScale(), numTargetElems ) );
       }
 
-      arrayView1d< globalIndex const > const
-      dofNumber = subRegion.getReference< array1d< globalIndex > >( dofKey );
+      if( targetSet.size() == 0 )
+      {
+        return;
+      }
 
-      fs.applyBoundaryConditionToSystem< FieldSpecificationAdd,
-                                         parallelDevicePolicy<> >( targetSet.toViewConst(),
-                                                                   time_n + dt,
-                                                                   dt,
-                                                                   subRegion,
-                                                                   dofNumber,
-                                                                   dofManager.rankOffset(),
-                                                                   localMatrix,
-                                                                   localRhs,
-                                                                   [] GEOSX_HOST_DEVICE ( localIndex const )
+      arrayView1d< globalIndex const > const dofNumber = subRegion.getReference< array1d< globalIndex > >( dofKey );
+      arrayView1d< integer const > const ghostRank =
+        subRegion.getReference< array1d< integer > >( ObjectManagerBase::viewKeyStruct::ghostRankString() );
+
+      // Step 3.1: get the values of the source boundary condition that need to be added to the rhs
+
+      array1d< globalIndex > dofArray( targetSet.size() );
+      array1d< real64 > rhsContributionArray( targetSet.size() );
+      arrayView1d< real64 > rhsContributionArrayView = rhsContributionArray.toView();
+      localIndex const rankOffset = dofManager.rankOffset();
+
+      // note that the dofArray will not be used after this step (simpler to use dofNumber instead)
+      fs.computeRhsContribution< FieldSpecificationAdd,
+                                 parallelDevicePolicy<> >( targetSet.toViewConst(),
+                                                           time_n + dt,
+                                                           dt,
+                                                           subRegion,
+                                                           dofNumber,
+                                                           rankOffset,
+                                                           localMatrix,
+                                                           dofArray.toView(),
+                                                           rhsContributionArrayView,
+                                                           [] GEOSX_HOST_DEVICE ( localIndex const )
       {
         return 0.0;
       } );
 
-    } );
+      // Step 3.2: we are ready to add the right-hand side contributions, taking into account our equation layout
 
+      // get the normalizer
+      real64 const sizeScalingFactor = bcAllSetsSize[bcNameToBcId.at( fs.getName())];
+
+      forAll< parallelDevicePolicy<> >( targetSet.size(), [sizeScalingFactor,
+                                                           targetSet,
+                                                           rankOffset,
+                                                           ghostRank,
+                                                           dofNumber,
+                                                           rhsContributionArrayView,
+                                                           localRhs] GEOSX_HOST_DEVICE ( localIndex const a )
+      {
+        // we need to filter out ghosts here, because targetSet may contain them
+        localIndex const ei = targetSet[a];
+        if( ghostRank[ei] >= 0 )
+        {
+          return;
+        }
+
+        // add the value to the mass balance equation
+        globalIndex const rowIndex = dofNumber[ei] - rankOffset;
+        localRhs[rowIndex] += rhsContributionArrayView[a] / sizeScalingFactor; // scale the contribution by the sizeScalingFactor here!
+      } );
+    } );
   } );
 }
 


### PR DESCRIPTION
This PR fixes #1930  I moved the computation of the size scaling factor to the solvers, which makes it possible to normalize consistently the `scale` across multiple cell blocks.

The PR passes the integrated tests and is ready for review.