### PR TITLE
Remove mermaid support and use plantuml instead.

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -100,14 +100,8 @@ extensions = [
     'sphinx.ext.inheritance_diagram',
     'matplotlib.sphinxext.plot_directive',
     'sphinx.ext.napoleon',
-    'sphinxcontrib.mermaid',
     'sphinxcontrib.plantuml',
 ]
-
-mermaid_output_format = "svg"
-with open('/tmp/puppeteer-config.json', 'w') as f:
-    f.write('{ "args": [ "--no-sandbox" ] }')
-mermaid_params = ['--backgroundColor', 'transparent', '-p', '/tmp/puppeteer-config.json']
 
 plantuml = "/usr/bin/plantuml"
 plantuml_output_format = "svg_img"

--- a/src/coreComponents/mesh/docs/MeshObjectInstantiationHierarchy.plantuml
+++ b/src/coreComponents/mesh/docs/MeshObjectInstantiationHierarchy.plantuml
@@ -1,18 +1,16 @@
-classDiagram
-
 class DomainPartition {
-    +getMeshBodies() List~MeshBody~
+    +getMeshBodies(): List<MeshBody>
 }
 
 class MeshBody {
-    +getMeshLevels() List~MeshLevels~
+    +getMeshLevels(): List<MeshLevels>
 }
 
 class MeshLevel {
-    +getNodeManager() NodeManager
-    +getEdgeManager() EdgeManager
-    +getFaceManager() FaceManager
-    +getElemManager() ElementRegionManager
+    +getNodeManager(): NodeManager
+    +getEdgeManager(): EdgeManager
+    +getFaceManager(): FaceManager
+    +getElemManager():: ElementRegionManager
 }
 
 class NodeManager {

--- a/src/coreComponents/mesh/docs/meshDeveloperGuide.rst
+++ b/src/coreComponents/mesh/docs/meshDeveloperGuide.rst
@@ -12,7 +12,7 @@ how instantiations of each class relate to each other in the data hierarchy rath
 type relates to each other in an inheritance diagram.
 
 .. _diagMeshDevFig:
-.. mermaid:: /coreComponents/mesh/docs/MeshObjectInstantiationHierarchy.mmd
+.. uml:: /coreComponents/mesh/docs/MeshObjectInstantiationHierarchy.plantuml
    :caption: Object instances describing the mesh domain. Cardinalities and relationships are indicated.
 
 

--- a/src/docs/sphinx/requirements.txt
+++ b/src/docs/sphinx/requirements.txt
@@ -4,6 +4,5 @@ numpy
 h5py
 mpmath
 docutils<0.18
-# using mermaid and plantuml for diagrams
-sphinxcontrib-mermaid
+# using plantuml for diagrams
 sphinxcontrib-plantuml


### PR DESCRIPTION
Removes the support for `mermaid` because of bugs in the `sphinxcontrib` plugin.
The mesh hierarchy is now described using `plantuml` https://geosx-geosx--1946.com.readthedocs.build/en/1946/coreComponents/mesh/docs/meshDeveloperGuide.html#mesh-hierarchy

Fixes https://github.com/GEOSX/GEOSX/issues/1944