### PR TITLE
Move gcc 10 debug job back to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -176,5 +176,11 @@ jobs:
   - stage: builds
     name: Mac_OSX
     <<: *geosx_osx_build
+  - stage: builds
+    name: Ubuntu debug (20.04, gcc 10.3.0, open-mpi 4.0.3)
+    script: scripts/ci_build_and_test.sh
+    env:
+    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc10
+    - CMAKE_BUILD_TYPE=Debug
   - stage: return_status
     <<: *return_script

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,11 +89,6 @@ stages:
           DOCKER_REPOSITORY: 'geosx/ubuntu20.04-gcc9'
           CMAKE_BUILD_TYPE: 'Release'
           VM_ImageName: 'ubuntu-latest'
-        ubuntu20_gcc10_openmpi4_debug:
-          JOB_NAME: 'Ubuntu debug (20.04, gcc 10.3.0, open-mpi 4.0.3)'
-          DOCKER_REPOSITORY: 'geosx/ubuntu20.04-gcc10'
-          CMAKE_BUILD_TYPE: 'Debug'
-          VM_ImageName: 'ubuntu-latest'
         ubuntu20_gcc10_openmpi4_release:
           JOB_NAME: 'Ubuntu (20.04, gcc 10.3.0, open-mpi 4.0.3)'
           DOCKER_REPOSITORY: 'geosx/ubuntu20.04-gcc10'


### PR DESCRIPTION
The gcc 10 debug job is failing on Azure Pipelines as its hitting the [10GB space limit ](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml&viewFallbackFrom=vsts#capabilities-and-limitations) on Microsoft's hosted agents.

Moving the job back to Travis ([limit is 50 GB](https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system)).
