### PR TITLE
Improve performance of ghost map unpacking

### DIFF
--- a/src/coreComponents/dataRepository/BufferOps_inline.hpp
+++ b/src/coreComponents/dataRepository/BufferOps_inline.hpp
@@ -1469,6 +1469,16 @@ Unpack( buffer_unit_type const * & buffer,
   // local indices of known global indices
   std::vector< localIndex > mapped;
 
+  // local indices of known objects not yet present in the map
+  std::vector< localIndex > mappedNew;
+
+  // storage for new values that don't fit into existing capacity
+  array1d< localIndex > indiciesToInsert;
+  ArrayOfSets< localIndex > valuesToInsert;
+  indiciesToInsert.reserve( numIndicesUnpacked );
+  valuesToInsert.reserve( numIndicesUnpacked );
+  valuesToInsert.reserveValues( numIndicesUnpacked * 12 ); // guesstimate
+
   for( localIndex a=0; a<numIndicesUnpacked; ++a )
   {
     globalIndex gi;
@@ -1495,6 +1505,7 @@ Unpack( buffer_unit_type const * & buffer,
     sizeOfUnpackedChars += Unpack( buffer, set_length );
 
     mapped.clear();
+    mappedNew.clear();
     unmapped.clear();
 
     // again, the global indices being unpacked here are for
@@ -1519,16 +1530,68 @@ Unpack( buffer_unit_type const * & buffer,
       }
     }
 
-    // insert known local indices into the set of indices
-    //  related to the local index
-    localIndex const numUniqueMapped = LvArray::sortedArrayManipulation::makeSortedUnique( mapped.begin(), mapped.end() );
-    var.insertIntoSet( li, mapped.begin(), mapped.begin() + numUniqueMapped );
+    // insert known local indices into the set of indices related to the local index
+    mapped.resize( LvArray::sortedArrayManipulation::makeSortedUnique( mapped.begin(), mapped.end() ) );
+    std::set_difference( mapped.begin(), mapped.end(), var[li].begin(), var[li].end(), std::back_inserter( mappedNew ) );
+    localIndex const numNewValues = LvArray::integerConversion< localIndex >( mappedNew.size() );
 
-    // insert unknown global indices related to the local index
-    //  into an additional mapping to resolve externally
-    localIndex const numUniqueUnmapped = LvArray::sortedArrayManipulation::makeSortedUnique( unmapped.begin(), unmapped.end() );
-    unmappedGlobalIndices[li].insert( unmapped.begin(), unmapped.begin() + numUniqueUnmapped );
+    // check if we have enough capacity to insert new indices
+    if( numNewValues <= var.capacityOfSet( li ) - var.sizeOfSet( li ) )
+    {
+      // all good, just insert new entries
+      var.insertIntoSet( li, mappedNew.begin(), mappedNew.end() );
+    }
+    else
+    {
+      // need to stash away and rebuild the map later
+      localIndex const k = indiciesToInsert.size();
+      indiciesToInsert.emplace_back( li );
+      valuesToInsert.appendSet( numNewValues );
+      valuesToInsert.insertIntoSet( k, mappedNew.begin(), mappedNew.end() );
+    }
+
+    // insert unknown global indices related to the local index into an additional mapping to resolve externally
+    unmapped.resize( LvArray::sortedArrayManipulation::makeSortedUnique( unmapped.begin(), unmapped.end() ) );
+    unmappedGlobalIndices[li].insert( unmapped.begin(), unmapped.end() );
   }
+
+  // If there were element lists that didn't fit in the map, rebuild the whole thing
+  if( !indiciesToInsert.empty() )
+  {
+    // Copy old capacities (no way to direct copy, must kernel launch)
+    array1d< localIndex > newCapacities( var.size() );
+    forAll< parallelHostPolicy >( var.size(), [var, newCapacities = newCapacities.toView()]( localIndex const k )
+    {
+      newCapacities[k] = var.capacityOfSet( k );
+    } );
+
+    // Add new capacities where needed
+    for( localIndex i = 0; i < indiciesToInsert.size(); ++i )
+    {
+      newCapacities[indiciesToInsert[i]] += valuesToInsert.sizeOfSet( i );
+    }
+
+    // Allocate new map
+    ArrayOfSets< localIndex > newVar;
+    newVar.resizeFromCapacities< parallelHostPolicy >( var.size(), newCapacities.data() );
+
+    // Fill new map with old values
+    forAll< parallelHostPolicy >( var.size(), [var, newVar = newVar.toView()]( localIndex const k )
+    {
+      newVar.insertIntoSet( k, var[k].begin(), var[k].end() );
+    } );
+
+    // Insert new values
+    for( localIndex i = 0; i < indiciesToInsert.size(); ++i )
+    {
+      localIndex const k = indiciesToInsert[i];
+      newVar.insertIntoSet( k, valuesToInsert[i].begin(), valuesToInsert[i].end() );
+    }
+
+    // Replace the old map
+    var = std::move( newVar );
+  }
+
   return sizeOfUnpackedChars;
 }
 

--- a/src/coreComponents/mesh/BufferOps.cpp
+++ b/src/coreComponents/mesh/BufferOps.cpp
@@ -78,15 +78,22 @@ localIndex Unpack( buffer_unit_type const * & buffer,
                    ElementRegionManager const * const elementRegionManager,
                    bool const clearFlag )
 {
-  GEOSX_MARK_SCOPE( "Unpack OrderedVariableToManyElementRelation" );
-
   localIndex sizeOfUnpackedChars = 0;
 
   localIndex numIndicesUnpacked;
   sizeOfUnpackedChars += bufferOps::Unpack( buffer, numIndicesUnpacked );
   GEOSX_ERROR_IF( numIndicesUnpacked != packList.size(), "" );
 
-  std::vector< std::array< localIndex, 3 > > values;
+  using ElementID = std::array< localIndex, 3 >;
+
+  // Allocate some memory to store map entries that don't fit in existing capacity
+  array1d< localIndex > indicesToReplace;
+  ArrayOfArrays< ElementID > valuesToReplace;
+  indicesToReplace.reserve( numIndicesUnpacked );
+  valuesToReplace.reserve( numIndicesUnpacked );
+  valuesToReplace.reserveValues( numIndicesUnpacked * 12 ); // guesstimate
+
+  std::vector< ElementID > values;
   for( localIndex a=0; a<packList.size(); ++a )
   {
     values.clear();
@@ -139,16 +146,92 @@ localIndex Unpack( buffer_unit_type const * & buffer,
 
     localIndex const numUniqueValues = LvArray::sortedArrayManipulation::makeSortedUnique( values.begin(), values.end() );
 
-    var.m_toElementRegion.resizeArray( index, numUniqueValues );
-    var.m_toElementSubRegion.resizeArray( index, numUniqueValues );
-    var.m_toElementIndex.resizeArray( index, numUniqueValues );
-
-    for( localIndex b=0; b < numUniqueValues; ++b )
+    if( numUniqueValues <= var.m_toElementIndex.capacityOfArray( index ) )
     {
-      var.m_toElementRegion( index, b ) = values[ b ][ 0 ];
-      var.m_toElementSubRegion( index, b ) = values[ b ][ 1 ];
-      var.m_toElementIndex( index, b ) = values[ b ][ 2 ];
+      var.m_toElementRegion.resizeArray( index, numUniqueValues );
+      var.m_toElementSubRegion.resizeArray( index, numUniqueValues );
+      var.m_toElementIndex.resizeArray( index, numUniqueValues );
+
+      for( localIndex b = 0; b < numUniqueValues; ++b )
+      {
+        var.m_toElementRegion( index, b ) = values[b][0];
+        var.m_toElementSubRegion( index, b ) = values[b][1];
+        var.m_toElementIndex( index, b ) = values[b][2];
+      }
     }
+    else
+    {
+      localIndex const k = indicesToReplace.size();
+      indicesToReplace.emplace_back( index );
+      valuesToReplace.appendArray( numUniqueValues );
+      std::copy( values.begin(), values.end(), valuesToReplace[k].begin() );
+    }
+  }
+
+  // If there were element lists that didn't fit in the map, rebuild the whole thing
+  if( !indicesToReplace.empty() )
+  {
+    ArrayOfArraysView< localIndex const > const toRegion = var.m_toElementRegion.toViewConst();
+    ArrayOfArraysView< localIndex const > const toSubRegion = var.m_toElementSubRegion.toViewConst();
+    ArrayOfArraysView< localIndex const > const toIndex = var.m_toElementIndex.toViewConst();
+    localIndex const numEntries = toRegion.size();
+
+    // Copy old capacities (no way to direct copy, must kernel launch)
+    array1d< localIndex > newCapacities( numEntries );
+    forAll< parallelHostPolicy >( numEntries, [toRegion, newCapacities = newCapacities.toView()]( localIndex const k )
+    {
+      newCapacities[k] = toRegion.capacityOfArray( k );
+    } );
+
+    // Replace with new capacities where needed
+    for( localIndex i = 0; i < indicesToReplace.size(); ++i )
+    {
+      newCapacities[indicesToReplace[i]] = valuesToReplace.sizeOfArray( i );
+    }
+
+    // Scan to generate new offsets
+    array1d< localIndex > newOffsets( newCapacities.size() + 1 );
+    newOffsets[ 0 ] = 0;
+    RAJA::inclusive_scan< parallelHostPolicy >( RAJA::make_span( newCapacities.data(), numEntries ),
+                                                RAJA::make_span( newOffsets.data() + 1, numEntries ) );
+
+    // Allocate new maps
+    ArrayOfArrays< localIndex > toRegionNew, toSubRegionNew, toIndexNew;
+    toRegionNew.resizeFromOffsets( numEntries, newOffsets.data() );
+    toSubRegionNew.resizeFromOffsets( numEntries, newOffsets.data() );
+    toIndexNew.resizeFromOffsets( numEntries, newOffsets.data() );
+
+    // Fill new maps with old values
+    forAll< parallelHostPolicy >( numEntries, [toRegion, toSubRegion, toIndex,
+                                               toRegionNew = toRegionNew.toView(),
+                                               toSubRegionNew = toSubRegionNew.toView(),
+                                               toIndexNew = toIndexNew.toView() ]( localIndex const k )
+    {
+      toRegionNew.appendToArray( k, toRegion[k].begin(), toRegion[k].end() );
+      toSubRegionNew.appendToArray( k, toSubRegion[k].begin(), toSubRegion[k].end() );
+      toIndexNew.appendToArray( k, toIndex[k].begin(), toIndex[k].end() );
+    } );
+
+    // Replace with new values
+    for( localIndex i = 0; i < indicesToReplace.size(); ++i )
+    {
+      localIndex const k = indicesToReplace[i];
+      localIndex const numValues = valuesToReplace.sizeOfArray( i );
+      toRegionNew.resizeArray( k, numValues );
+      toSubRegionNew.resizeArray( k, numValues );
+      toIndexNew.resizeArray( k, numValues );
+      for( localIndex j = 0; j < numValues; ++j )
+      {
+        toRegionNew[k][j] = valuesToReplace[i][j][0];
+        toSubRegionNew[k][j] = valuesToReplace[i][j][1];
+        toIndexNew[k][j] = valuesToReplace[i][j][2];
+      }
+    }
+
+    // Move into place
+    var.m_toElementRegion = std::move( toRegionNew );
+    var.m_toElementSubRegion = std::move( toSubRegionNew );
+    var.m_toElementIndex = std::move( toIndexNew );
   }
 
   return sizeOfUnpackedChars;
@@ -209,8 +292,6 @@ localIndex Unpack( buffer_unit_type const * & buffer,
                    ElementRegionManager const * const elementRegionManager,
                    bool const clearFlag )
 {
-  GEOSX_MARK_SCOPE( "Unpack FixedToManyElementRelation" );
-
   localIndex sizeOfUnpackedChars = 0;
 
   localIndex numIndicesUnpacked;

--- a/src/coreComponents/mesh/EdgeManager.cpp
+++ b/src/coreComponents/mesh/EdgeManager.cpp
@@ -166,8 +166,8 @@ void EdgeManager::setIsExternal( FaceManager const & faceManager )
   }
 }
 
-void EdgeManager::extractMapFromObjectForAssignGlobalIndexNumbers( NodeManager const & nodeManager,
-                                                                   std::vector< std::vector< globalIndex > > & globalEdgeNodes )
+ArrayOfSets< globalIndex >
+EdgeManager::extractMapFromObjectForAssignGlobalIndexNumbers( ObjectManagerBase const & nodeManager )
 {
   GEOSX_MARK_FUNCTION;
 
@@ -175,25 +175,23 @@ void EdgeManager::extractMapFromObjectForAssignGlobalIndexNumbers( NodeManager c
 
   arrayView2d< localIndex const > const edgeNodes = this->nodeList();
   arrayView1d< integer const > const isDomainBoundary = this->getDomainBoundaryIndicator();
+  arrayView1d< globalIndex const > const nodeLocalToGlobal = nodeManager.localToGlobalMap();
 
-  globalEdgeNodes.resize( numEdges );
+  ArrayOfSets< globalIndex > globalEdgeNodes( numEdges, 2 );
 
-  forAll< parallelHostPolicy >( numEdges, [&]( localIndex const edgeIndex )
+  forAll< parallelHostPolicy >( numEdges, [globalEdgeNodes = globalEdgeNodes.toView(),
+                                           isDomainBoundary, edgeNodes, nodeLocalToGlobal]( localIndex const edgeIndex )
   {
-    std::vector< globalIndex > & curEdgeGlobalNodes = globalEdgeNodes[ edgeIndex ];
-
     if( isDomainBoundary( edgeIndex ) )
     {
-      curEdgeGlobalNodes.resize( 2 );
-
-      for( localIndex a = 0; a < 2; ++a )
+      for( localIndex const nodeIndex : edgeNodes[edgeIndex] )
       {
-        curEdgeGlobalNodes[ a ]= nodeManager.localToGlobalMap()( edgeNodes[ edgeIndex ][ a ] );
+        globalEdgeNodes.insertIntoSet( edgeIndex, nodeLocalToGlobal[nodeIndex] );
       }
-
-      std::sort( curEdgeGlobalNodes.begin(), curEdgeGlobalNodes.end() );
     }
   } );
+
+  return globalEdgeNodes;
 }
 
 localIndex EdgeManager::packUpDownMapsSize( arrayView1d< localIndex const > const & packList ) const
@@ -243,7 +241,7 @@ localIndex EdgeManager::unpackUpDownMaps( buffer_unit_type const * & buffer,
                                           bool const overwriteUpMaps,
                                           bool const GEOSX_UNUSED_PARAM( overwriteDownMaps ) )
 {
-  // GEOSX_MARK_FUNCTION;
+  GEOSX_MARK_FUNCTION;
 
   localIndex unPackedSize = 0;
 

--- a/src/coreComponents/mesh/EdgeManager.hpp
+++ b/src/coreComponents/mesh/EdgeManager.hpp
@@ -149,15 +149,12 @@ public:
 
 
   /**
-   * @brief Build \p globalEdgeNodes, a  vector containing all the global indices
-   * of each nodes of each edges
+   * @brief Build a vector containing all the global indices of each nodes of each edges
    * @param[in] nodeManager the nodeManager object.
-   * @param[out] globalEdgeNodes the globalEdgesNodes array to be built
-   * [ [global_index_node_0_edge_0, global_index_node1_edge_0], [global_index_node_0_edge_1, global_index_node1_edge_1] ....]
+   * @return an array of pairs of each edge's nodes globalIndices
    */
-  virtual void
-  extractMapFromObjectForAssignGlobalIndexNumbers( NodeManager const & nodeManager,
-                                                   std::vector< std::vector< globalIndex > > & globalEdgeNodes ) override;
+  virtual ArrayOfSets< globalIndex >
+  extractMapFromObjectForAssignGlobalIndexNumbers( ObjectManagerBase const & nodeManager ) override;
 
   /**
    * @brief Compute the future size of a packed list.

--- a/src/coreComponents/mesh/FaceManager.hpp
+++ b/src/coreComponents/mesh/FaceManager.hpp
@@ -250,10 +250,10 @@ public:
   /**
    * @brief Extract a face-to-nodes map with global indexed for boundary faces.
    * @param[in] nodeManager mesh nodeManager
-   * @param[out] faceToNodes face-to-node map
+   * @return face-to-node map
    */
-  virtual void extractMapFromObjectForAssignGlobalIndexNumbers( NodeManager const & nodeManager,
-                                                                std::vector< std::vector< globalIndex > > & faceToNodes ) override;
+  virtual ArrayOfSets< globalIndex >
+  extractMapFromObjectForAssignGlobalIndexNumbers( ObjectManagerBase const & nodeManager ) override;
 
   /**
    * @name viewKeyStruct/groupKeyStruct

--- a/src/coreComponents/mesh/NodeManager.cpp
+++ b/src/coreComponents/mesh/NodeManager.cpp
@@ -217,6 +217,8 @@ localIndex NodeManager::unpackUpDownMaps( buffer_unit_type const * & buffer,
                                           bool const overwriteUpMaps,
                                           bool const )
 {
+  GEOSX_MARK_FUNCTION;
+
   localIndex unPackedSize = 0;
 
   string temp;

--- a/src/coreComponents/mesh/ObjectManagerBase.cpp
+++ b/src/coreComponents/mesh/ObjectManagerBase.cpp
@@ -174,20 +174,10 @@ void ObjectManagerBase::constructSetFromSetAndMap( SortedArrayView< localIndex c
   }
 }
 
-void ObjectManagerBase::constructLocalListOfBoundaryObjects( localIndex_array & objectList ) const
+array1d< globalIndex >
+ObjectManagerBase::constructGlobalListOfBoundaryObjects() const
 {
-  arrayView1d< integer const > const & isDomainBoundary = this->getDomainBoundaryIndicator();
-  for( localIndex k=0; k<size(); ++k )
-  {
-    if( isDomainBoundary[k] == 1 )
-    {
-      objectList.emplace_back( k );
-    }
-  }
-}
-
-void ObjectManagerBase::constructGlobalListOfBoundaryObjects( globalIndex_array & objectList ) const
-{
+  array1d< globalIndex > objectList;
   arrayView1d< integer const > const & isDomainBoundary = this->getDomainBoundaryIndicator();
   for( localIndex k=0; k<size(); ++k )
   {
@@ -197,6 +187,7 @@ void ObjectManagerBase::constructGlobalListOfBoundaryObjects( globalIndex_array 
     }
   }
   std::sort( objectList.begin(), objectList.end() );
+  return objectList;
 }
 
 void ObjectManagerBase::constructGlobalToLocalMap()

--- a/src/coreComponents/mesh/ObjectManagerBase.hpp
+++ b/src/coreComponents/mesh/ObjectManagerBase.hpp
@@ -26,8 +26,6 @@
 namespace geosx
 {
 
-class NodeManager;
-
 /**
  * @brief The ObjectManagerBase is the base object of all object managers in the mesh data hierachy.
  */
@@ -343,33 +341,23 @@ public:
   void constructGlobalToLocalMap();
 
   /**
-   * @brief Computes the (local) index list that are domain boundaries.
-   * @param[in,out] objectList Container that is filled with the local indices.
-   *
-   * Note that @p objectList is not cleared and domain boundary indices are only appended.
-   */
-  void constructLocalListOfBoundaryObjects( localIndex_array & objectList ) const;
-
-  /**
    * @brief Computes the (global) index list that are domain boundaries.
-   * @param[in,out] objectList Sorted container that is filled with the global indices.
-   *
-   * Note that @p objectList is not cleared and domain boundary indices are only appended.
+   * @return Sorted container that is filled with the global indices.
    */
-  void constructGlobalListOfBoundaryObjects( globalIndex_array & objectList ) const;
+  array1d< globalIndex > constructGlobalListOfBoundaryObjects() const;
 
   /**
    * @brief Extract map from object and assign global indices.
    * @param nodeManager The node manager.
-   * @param map The map.
+   * @return The map.
    *
    * Dummy version, needs to be specialised by derived classes.
    */
-  virtual void extractMapFromObjectForAssignGlobalIndexNumbers( NodeManager const & nodeManager,
-                                                                std::vector< std::vector< globalIndex > > & map )
+  virtual ArrayOfSets< globalIndex >
+  extractMapFromObjectForAssignGlobalIndexNumbers( ObjectManagerBase const & nodeManager )
   {
     GEOSX_UNUSED_VAR( nodeManager );
-    GEOSX_UNUSED_VAR( map );
+    return {};
   }
 
   /**

--- a/src/coreComponents/mesh/generators/VTKMeshGenerator.cpp
+++ b/src/coreComponents/mesh/generators/VTKMeshGenerator.cpp
@@ -310,6 +310,17 @@ splitMeshByPartition( vtkDataSet & mesh,
 }
 
 vtkSmartPointer< vtkDataSet >
+generateGlobalIDs( vtkDataSet & mesh )
+{
+  GEOSX_MARK_FUNCTION;
+
+  vtkNew< vtkGenerateGlobalIds > generator;
+  generator->SetInputDataObject( &mesh );
+  generator->Update();
+  return vtkDataSet::SafeDownCast( generator->GetOutputDataObject( 0 ) );
+}
+
+vtkSmartPointer< vtkDataSet >
 redistributeByCellGraph( vtkDataSet & mesh,
                          VTKMeshGenerator::PartitionMethod const method,
                          MPI_Comm const comm,
@@ -444,7 +455,7 @@ redistributeMesh( vtkDataSet & loadedMesh,
     vtkNew< vtkGenerateGlobalIds > generator;
     generator->SetInputDataObject( &loadedMesh );
     generator->Update();
-    mesh = vtkDataSet::SafeDownCast( generator->GetOutputDataObject( 0 ) );
+    mesh = generateGlobalIDs( loadedMesh );
   }
 
 

--- a/src/coreComponents/mesh/mpiCommunications/CommunicationTools.hpp
+++ b/src/coreComponents/mesh/mpiCommunications/CommunicationTools.hpp
@@ -54,11 +54,11 @@ public:
                             NodeManager const & compositionObject,
                             std::vector< NeighborCommunicator > & neighbors );
 
-  void assignNewGlobalIndices( ObjectManagerBase & object,
-                               std::set< localIndex > const & indexList );
+  static void assignNewGlobalIndices( ObjectManagerBase & object,
+                                      std::set< localIndex > const & indexList );
 
-  void assignNewGlobalIndices( ElementRegionManager & elementManager,
-                               std::map< std::pair< localIndex, localIndex >, std::set< localIndex > > const & newElems );
+  static void assignNewGlobalIndices( ElementRegionManager & elementManager,
+                                      std::map< std::pair< localIndex, localIndex >, std::set< localIndex > > const & newElems );
 
   void setupGhosts( MeshLevel & meshLevel,
                     std::vector< NeighborCommunicator > & neighbors,

--- a/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
@@ -607,9 +607,9 @@ int SurfaceGenerator::separationDriver( DomainPartition & domain,
     modifiedObjects.clearNewFromModified();
 
     // 1) Assign new global indices to the new objects
-    CommunicationTools::getInstance().assignNewGlobalIndices( nodeManager, modifiedObjects.newNodes );
-    CommunicationTools::getInstance().assignNewGlobalIndices( edgeManager, modifiedObjects.newEdges );
-    CommunicationTools::getInstance().assignNewGlobalIndices( faceManager, modifiedObjects.newFaces );
+    CommunicationTools::assignNewGlobalIndices( nodeManager, modifiedObjects.newNodes );
+    CommunicationTools::assignNewGlobalIndices( edgeManager, modifiedObjects.newEdges );
+    CommunicationTools::assignNewGlobalIndices( faceManager, modifiedObjects.newFaces );
 //    CommunicationTools::getInstance().AssignNewGlobalIndices( elementManager, modifiedObjects.newElements );
 
     ModifiedObjectLists receivedObjects;


### PR DESCRIPTION
This PR resolves a performance issue I have with up/down map unpacking during initial ghost setup. 

Performance degradation is observed when running medium-large unstructured meshes (>10M elements) on multiple ranks. When unpacking node-to-face and node-to-element maps received from another rank, multiple insertions into `ArrayOfArrays` and `ArrayOfSets` data structures occur that exceed preallocated capacity in some rows, causing the data to be shifted in memory multiple times by a single thread. This can take multiple minutes (!) and leads to longer-than-necessary simulation startup times.

The solution proposed here is to only insert map values immediately if they fit into capacity. Otherwise, the values are stashed in a separately allocated memory, and at the end the full map is recreated with sufficient capacity to hold the data, and populated by merging old and stashed values. The "happy" path (when everything fits, which is typical for Cartesian grids) is preserved, and the "sad" path (when we have to rebuild the map) is still at least an order of magnitude faster than before. The code added is not particularly pretty, and is a bit repetitive between the two places it affects, but it does the job; I'm open to better suggestions though.

For example, on a tetrahedral mesh with 17.5M elements, run on 16 cluster nodes we have:
   * Before:
```
        geosx::CommunicationTools::setupGhosts                                      94.483528     94.648196     94.554713 64.855307 
          geosx::ObjectManagerBase::fixUpDownMaps                                    0.106413      0.200425      0.151398  0.103844 
          geosx::NeighborCommunicator::unpackAndRebuildSyncLists                     0.029844      0.097199      0.048903  0.033542 
          geosx::NeighborCommunicator::prepareAndSendSyncLists                       0.002321      0.018478      0.004689  0.003216 
          geosx::NeighborCommunicator::unpackGhosts                                 28.344562     88.643873     56.317344 38.628203 
            geosx::ObjectManagerBase::unpackGlobalMaps                               1.209660      2.357186      1.719698  1.179545 
          geosx::NeighborCommunicator::prepareAndSendGhosts                          3.931577      5.541717      4.625739  3.172806
```
   * With this PR:
```
        geosx::CommunicationTools::setupGhosts                                      16.104713     16.323403     16.167828 24.411996 
          geosx::ObjectManagerBase::fixUpDownMaps                                    0.087404      0.244874      0.131243  0.198166 
          geosx::NeighborCommunicator::unpackAndRebuildSyncLists                     0.018214      0.079982      0.036050  0.054433 
          geosx::NeighborCommunicator::prepareAndSendSyncLists                       0.001909      0.009524      0.003048  0.004602 
          geosx::NeighborCommunicator::unpackGhosts                                  5.413896     10.341693      7.728974 11.670070 
            geosx::ObjectManagerBase::unpackGlobalMaps                               1.034739      2.335245      1.673386  2.526665 
          geosx::NeighborCommunicator::prepareAndSendGhosts                          3.810749      5.482466      4.640694  7.007039
```