### PR TITLE
Use brew's tap to install precise version of open-mpi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: minimal
 
 env:
   global:
-  - GEOSX_TPL_TAG=192-765
+  - GEOSX_TPL_TAG=194-777
   - secure: CGs2uH6efq1Me6xJWRr0BnwtwxoujzlowC4FHXHdWbNOkPsXf7nCgdaW5vthfD3bhnOeEUQSrfxdhTRtyU/NfcKLmKgGBnZOdUG4/JJK4gDSJ2Wp8LZ/mB0QEoODKVxbh+YtoAiHe3y4M9PGCs+wkNDw/3eEU00cK12DZ6gad0RbLjI3xkhEr/ZEZDZkcYg9yHAhl5bmpqoh/6QGnIg8mxIqdAtGDw+6tT0EgUqjeqc5bG5WwsamKzJItHSXD5zx8IJAlgDk4EzEGjZe0m56YnNfb9iwqqUsmL3Cuwgs7ByVDYw78JC5Kv42YqoxA5BxMT2mFsEe37TpYNXlzofU7ma2Duw9DGXWQd4IkTCcBxlyR0I0bfo0TmgO+y7PYG9lIyHPUkENemdozsZcWamqqkqegiEdRhDVYlSRo3mu7iCwTS6ZTALliVyEYjYxYb7oAnR3cNywXjblTCI8oKfgLSY+8WijM9SRl57JruIHLkLMCjmRI+cZBfv5tS2tYQTBPkygGrigrrN77ZiC7/TGyfggSN0+y0oYtOAgqEnBcKcreiibMW7tKcV2Z1RFD9ZvIkSc1EXLUPDP8FX1oyhmqBMqVo8LksrYLDJHQ05+F3YNgl2taSt7uMjQ4e8iZ3/IjFeMnbylDw+cj/RbS520HXsFPbWFm2Pb9pceA9n6GnY=
 
 # The integrated test repository contains large data (using git lfs) and we do not use them here.
@@ -14,7 +14,7 @@ services: docker
 
 geosx_osx_build: &geosx_osx_build
   os: osx
-  osx_image: xcode12.5
+  osx_image: xcode13.2
   install:
   - TPL_METADATA_URL=https://www.googleapis.com/storage/v1/b/geosx/o/TPL%2Fosx-${GEOSX_TPL_TAG}.tar
   - TPL_BULK_URL=${TPL_METADATA_URL}?alt=media
@@ -25,12 +25,11 @@ geosx_osx_build: &geosx_osx_build
     # Then download the TPLs and uncompress where needed
   - curl -s "${TPL_BULK_URL}" | tar --strip-component=1 --directory=${GEOSX_TPL_DIR} -xf -
     # Now let's deal with Homebrew third parties
-  - BREW_HASH=$(echo -n ${METADATA} | python3 -c "import sys, json; print(json.load(sys.stdin)['metadata']['BREW_HASH'], end='')")
-  - BREW_URL=https://raw.github.com/Homebrew/homebrew-core/${BREW_HASH}
-  - wget ${BREW_URL}/Formula/open-mpi.rb
-  - brew update
-  - HOMEBREW_NO_AUTO_UPDATE=1 brew install ./open-mpi.rb
-  - for dep in `brew deps open-mpi.rb`; do brew install $dep; done
+  - BREW_OPENMPI_VERSION=$(echo -n ${METADATA} | python3 -c "import sys, json; print(json.load(sys.stdin)['metadata']['BREW_OPENMPI_VERSION'], end='')")
+  - BREW_OPENMPI_TAP=${USER}/local-open-mpi
+  - brew tap-new ${BREW_OPENMPI_TAP}
+  - brew extract --version=${BREW_OPENMPI_VERSION} open-mpi ${BREW_OPENMPI_TAP}
+  - HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_MAKE_JOBS=$(nproc) brew install ${BREW_OPENMPI_TAP}/open-mpi@${BREW_OPENMPI_VERSION}
   script:
   - git submodule update --init --recursive src/cmake/blt
   - git submodule update --init --recursive src/coreComponents/LvArray


### PR DESCRIPTION
This fixes the build failure on Mac OSX.
I've been modified the way we install `open-mpi` using `brew` and its `tap`s.
A strong difference is that from now `brew` recompiles `open-mpi`, which takes ~5 more minutes for GEOSX or TPL builds.

I also must confess that I do not know anything about `brew` and that I simply stack command lines there. 

Related to https://github.com/GEOSX/thirdPartyLibs/pull/194