### PR TITLE
Fix TPL discrepancy between travis and azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-  GEOSX_TPL_TAG: 192-765
+  GEOSX_TPL_TAG: 194-777
 
 # only build non-draft, merge target PR's to develop
 trigger: none


### PR DESCRIPTION
I forgot that we have duplicated the `GEOSX_TPL_TAG` on travis and azure.
Even if this is not a problem because there's only impact on the Mac OSX build, I prefer to keep it clean.