### PR TITLE
Re-enable object libraries build

### DIFF
--- a/scripts/build_test_helper.sh
+++ b/scripts/build_test_helper.sh
@@ -67,8 +67,9 @@ if [[ "$*" == *--test-documentation* ]]; then
 fi
 
 # "Make" target check (builds geosx executable target only if true)
+# Use one process to prevent out-of-memory error
 if [[ "$*" == *--build-exe-only* ]]; then
-  or_die make -j $(nproc) geosx VERBOSE=1
+  or_die make -j 1 geosx VERBOSE=1
 else
   or_die make -j $(nproc) VERBOSE=1
   or_die make install VERBOSE=1

--- a/src/cmake/GeosxOptions.cmake
+++ b/src/cmake/GeosxOptions.cmake
@@ -75,7 +75,7 @@ endif()
 
 ### BUILD & BLT SETUP ###
 
-option( GEOSX_BUILD_OBJ_LIBS "Builds coreComponent modules as object libraries" OFF )
+option( GEOSX_BUILD_OBJ_LIBS "Builds coreComponent modules as object libraries" ON )
 
 option( GEOSX_BUILD_SHARED_LIBS "Builds geosx_core as a shared library " OFF )
 

--- a/src/cmake/thirdparty/SetupGeosxThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupGeosxThirdParty.cmake
@@ -486,8 +486,10 @@ if(DEFINED HYPRE_DIR AND ENABLE_HYPRE)
                       DEPENDS ${HYPRE_DEPENDS})
 
 
-   # Prepend Hypre to link flags, fix for Umpire appearing before Hypre on the link line
-   blt_add_target_link_flags (TO hypre FLAGS "-Wl,--whole-archive ${HYPRE_DIR}/lib/libHYPRE.a -Wl,--no-whole-archive")
+    # Prepend Hypre to link flags, fix for Umpire appearing before Hypre on the link line
+    if (NOT CMAKE_HOST_APPLE)
+      blt_add_target_link_flags (TO hypre FLAGS "-Wl,--whole-archive ${HYPRE_DIR}/lib/libHYPRE.a -Wl,--no-whole-archive")
+    endif()
 
     # if( ENABLE_CUDA AND ( NOT ENABLE_HYPRE_CUDA ) )
     #   set(ENABLE_HYPRE OFF CACHE BOOL "" FORCE)

--- a/src/cmake/thirdparty/SetupGeosxThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupGeosxThirdParty.cmake
@@ -485,6 +485,10 @@ if(DEFINED HYPRE_DIR AND ENABLE_HYPRE)
                       EXTRA_LIBRARIES ${EXTRA_LIBS}
                       DEPENDS ${HYPRE_DEPENDS})
 
+
+   # Prepend Hypre to link flags, fix for Umpire appearing before Hypre on the link line
+   blt_add_target_link_flags (TO hypre FLAGS "-Wl,--whole-archive ${HYPRE_DIR}/lib/libHYPRE.a -Wl,--no-whole-archive")
+
     # if( ENABLE_CUDA AND ( NOT ENABLE_HYPRE_CUDA ) )
     #   set(ENABLE_HYPRE OFF CACHE BOOL "" FORCE)
     #   if( GEOSX_LA_INTERFACE STREQUAL "Hypre")


### PR DESCRIPTION
This PR:

- For object libraries, fixes the link-order undefined reference error between hypre and umpire.
- Sets object libraries build as default.
- Changes Azure Pipelines CI build for CUDA debug to use one process to prevent out of memory error.