### PR TITLE
Re-enable unit tests in OSX CI and fix catalog registration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ geosx_osx_build: &geosx_osx_build
     -DBLT_MPI_COMMAND_APPEND:STRING="--oversubscribe" -DENABLE_VTK:BOOL=OFF
   - cd build-darwin-clang-debug
   - make -j $(nproc) VERBOSE=1
-  # - ctest -V -E "testUncrustifyCheck|testDoxygenCheck|blt_mpi_smoke"
+  - ctest -V -E "testUncrustifyCheck|testDoxygenCheck|blt_mpi_smoke"
 
 geosx_totalenergies_cluster_build: &geosx_totalenergies_cluster_build
   script: scripts/ci_build_and_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ geosx_osx_build: &geosx_osx_build
   - git submodule update --init --recursive src/coreComponents/fileIO/coupling/hdf5_interface
   - python ${TRAVIS_BUILD_DIR}/scripts/config-build.py
     -hc ${TRAVIS_BUILD_DIR}/host-configs/darwin-clang.cmake
-    -DBLT_MPI_COMMAND_APPEND:STRING="--oversubscribe" -DENABLE_VTK:BOOL=OFF
+    -DBLT_MPI_COMMAND_APPEND:STRING="--oversubscribe" -DENABLE_VTK:BOOL=OFF -DGEOSX_BUILD_OBJ_LIBS:BOOL=ON
   - cd build-darwin-clang-debug
   - make -j $(nproc) VERBOSE=1
   - ctest -V -E "testUncrustifyCheck|testDoxygenCheck|blt_mpi_smoke"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ geosx_osx_build: &geosx_osx_build
   - git submodule update --init --recursive src/coreComponents/fileIO/coupling/hdf5_interface
   - python ${TRAVIS_BUILD_DIR}/scripts/config-build.py
     -hc ${TRAVIS_BUILD_DIR}/host-configs/darwin-clang.cmake
-    -DBLT_MPI_COMMAND_APPEND:STRING="--oversubscribe" -DENABLE_VTK:BOOL=OFF -DGEOSX_BUILD_OBJ_LIBS:BOOL=ON
+    -DBLT_MPI_COMMAND_APPEND:STRING="--oversubscribe" -DENABLE_VTK:BOOL=OFF
   - cd build-darwin-clang-debug
   - make -j $(nproc) VERBOSE=1
   - ctest -V -E "testUncrustifyCheck|testDoxygenCheck|blt_mpi_smoke"

--- a/host-configs/darwin-clang.cmake
+++ b/host-configs/darwin-clang.cmake
@@ -21,6 +21,8 @@ set(ENABLE_OPENMP "OFF" CACHE PATH "" FORCE)
 
 set(ENABLE_CALIPER "OFF" CACHE PATH "" FORCE )
 
+set(GEOSX_BUILD_OBJ_LIBS ON CACHE BOOL "" FORCE)
+
 set( BLAS_LIBRARIES /usr/local/opt/openblas/lib/libblas.dylib CACHE PATH "" FORCE )
 set( LAPACK_LIBRARIES /usr/local/opt/openblas/lib/liblapack.dylib CACHE PATH "" FORCE )
 


### PR DESCRIPTION
This PR re-enables unit testing in OSX CI and works around catalog registration issues by enforcing object libraries build in darwin host-config.

Resolves https://github.com/GEOSX/GEOSX/issues/2016