### PR TITLE
Skipped the shallow mesh copies in the vtk output

### DIFF
--- a/src/coreComponents/fileIO/vtk/VTKPolyDataWriterInterface.cpp
+++ b/src/coreComponents/fileIO/vtk/VTKPolyDataWriterInterface.cpp
@@ -1000,6 +1000,12 @@ void VTKPolyDataWriterInterface::writeVtmFile( integer const cycle,
   {
     meshBody.forMeshLevels( [&]( MeshLevel const & meshLevel )
     {
+
+      if( meshLevel.isShallowCopy() )
+      {
+        return;
+      }
+
       ElementRegionManager const & elemManager = meshLevel.getElemManager();
       string const meshPath = joinPath( getCycleSubFolder( cycle ), meshBody.getName(), meshLevel.getName() );
       int const mpiSize = MpiWrapper::commSize();
@@ -1088,6 +1094,12 @@ void VTKPolyDataWriterInterface::write( real64 const time,
   {
     meshBody.forMeshLevels( [&]( MeshLevel const & meshLevel )
     {
+
+      if( meshLevel.isShallowCopy() )
+      {
+        return;
+      }
+
       ElementRegionManager const & elemManager = meshLevel.getElemManager();
       NodeManager const & nodeManager = meshLevel.getNodeManager();
       EmbeddedSurfaceNodeManager const & embSurfNodeManager = meshLevel.getEmbSurfNodeManager();


### PR DESCRIPTION
I am creating a PR for this fix proposed by @klevzoff that hopefully I haven't messed up. I am not sure it was meant to be merged, but it turned out to be very useful to make sure that the VTK output is still usable for our field-scale examples.

With the current `develop`, we have large VTK files in which the information is duplicated because we output the shallow copies of the mesh to the file:
<img width="325" alt="Screen Shot 2022-09-07 at 4 38 44 PM" src="https://user-images.githubusercontent.com/20196406/188861626-f977a126-9445-4b98-aff5-7245a24c05d2.png">

After this PR, we get back to:
<img width="339" alt="Screen Shot 2022-09-07 at 9 45 28 PM" src="https://user-images.githubusercontent.com/20196406/188861787-40df965d-f5c9-4015-bd3e-3ef955b835c4.png">

The integrated tests pass, and the `testMultipleBodies.xml` test seems to produce a valid VTK output as well. But I don't mind closing the PR if someone is already working on a proper fix (I missed the discussion on this issue).
