### PR TITLE
Force GEOSX organisation in submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,19 +1,19 @@
 [submodule "src/coreComponents/LvArray"]
 	path = src/coreComponents/LvArray
-	url = ../LvArray.git
+	url = ../../GEOSX/LvArray.git
 [submodule "src/cmake/blt"]
 	path = src/cmake/blt
 	url = ../../LLNL/blt.git
 [submodule "src/coreComponents/constitutive/PVTPackage"]
 	path = src/coreComponents/constitutive/PVTPackage
-	url = ../PVTPackage.git
+	url = ../../GEOSX/PVTPackage.git
 [submodule "integratedTests"]
 	path = integratedTests
-	url = ../integratedTests.git
+	url = ../../GEOSX/integratedTests.git
 [submodule "src/coreComponents/mesh/PAMELA"]
 	path = src/coreComponents/mesh/PAMELA
-	url = ../PAMELA.git
+	url = ../../GEOSX/PAMELA.git
 	shallow = true
 [submodule "src/coreComponents/fileIO/coupling/hdf5_interface"]
 	path = src/coreComponents/fileIO/coupling/hdf5_interface
-	url = ../hdf5_interface.git
+	url = ../../GEOSX/hdf5_interface.git


### PR DESCRIPTION
This would allow easier _GEOSX forking on github_ since submodules would work without any further action.
People who also _fork_ the submodules will have to modify the `.gitmodules` file, but it should not be the default pattern I think.