### PR TITLE
Removed MPI_CXX_BOOL

### DIFF
--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -52,7 +52,6 @@ typedef int MPI_Datatype;
 #define MPI_LONG_LONG_INT  ((MPI_Datatype)0x4c000809)
 #define MPI_UNSIGNED_LONG_LONG ((MPI_Datatype)0x4c000819)
 #define MPI_LONG_LONG      MPI_LONG_LONG_INT
-#define MPI_CXX_BOOL       ((MPI_Datatype)0x0c000000)
 
 typedef int MPI_Op;
 
@@ -594,8 +593,6 @@ ADD_MPI_TYPE_MAP( long long int, MPI_LONG_LONG );
 ADD_MPI_TYPE_MAP( unsigned int, MPI_UNSIGNED );
 ADD_MPI_TYPE_MAP( unsigned long int, MPI_UNSIGNED_LONG );
 ADD_MPI_TYPE_MAP( unsigned long long int, MPI_UNSIGNED_LONG_LONG );
-
-ADD_MPI_TYPE_MAP( bool, MPI_CXX_BOOL );
 
 #undef ADD_MPI_TYPE_MAP
 

--- a/src/coreComponents/fileIO/timeHistory/HDFHistoryIO.cpp
+++ b/src/coreComponents/fileIO/timeHistory/HDFHistoryIO.cpp
@@ -240,7 +240,7 @@ void HDFHistoryIO::init( bool existsOkay )
 void HDFHistoryIO::write()
 {
   // check if the size has changed on any process in the primary comm
-  bool anyChanged = false;
+  int anyChanged = false;
   MpiWrapper::allReduce( &m_sizeChanged, &anyChanged, 1, MPI_LOR, m_comm );
   m_sizeChanged = anyChanged;
 

--- a/src/coreComponents/fileIO/timeHistory/HDFHistoryIO.hpp
+++ b/src/coreComponents/fileIO/timeHistory/HDFHistoryIO.hpp
@@ -183,7 +183,7 @@ private:
   /// growing the data size in the file)
   MPI_Comm m_subcomm;
   /// Whether the size of the collected data has changed between writes to file
-  bool m_sizeChanged;
+  int m_sizeChanged;
 };
 
 }

--- a/src/coreComponents/physicsSolvers/contact/LagrangianContactSolver.cpp
+++ b/src/coreComponents/physicsSolvers/contact/LagrangianContactSolver.cpp
@@ -1745,7 +1745,7 @@ bool LagrangianContactSolver::updateConfiguration( DomainPartition & domain )
 
   using namespace extrinsicMeshData::contact;
 
-  bool hasConfigurationConverged = true;
+  int hasConfigurationConverged = true;
 
   forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
                                                                 MeshLevel & mesh,
@@ -1840,7 +1840,7 @@ bool LagrangianContactSolver::updateConfiguration( DomainPartition & domain )
   synchronizeFractureState( domain );
 
   // Compute if globally the fracture state has changed
-  bool hasConfigurationConvergedGlobally;
+  int hasConfigurationConvergedGlobally;
   MpiWrapper::allReduce( &hasConfigurationConverged,
                          &hasConfigurationConvergedGlobally,
                          1,

--- a/src/coreComponents/physicsSolvers/contact/SolidMechanicsEmbeddedFractures.cpp
+++ b/src/coreComponents/physicsSolvers/contact/SolidMechanicsEmbeddedFractures.cpp
@@ -769,7 +769,7 @@ void SolidMechanicsEmbeddedFractures::updateState( DomainPartition & domain )
 
 bool SolidMechanicsEmbeddedFractures::updateConfiguration( DomainPartition & domain )
 {
-  bool hasConfigurationConverged = true;
+  int hasConfigurationConverged = true;
 
   using namespace extrinsicMeshData::contact;
 
@@ -816,7 +816,7 @@ bool SolidMechanicsEmbeddedFractures::updateConfiguration( DomainPartition & dom
   synchronizeFractureState( domain );
 
   // Compute if globally the fracture state has changed
-  bool hasConfigurationConvergedGlobally;
+  int hasConfigurationConvergedGlobally;
   MpiWrapper::allReduce( &hasConfigurationConverged,
                          &hasConfigurationConvergedGlobally,
                          1,


### PR DESCRIPTION
`MPI_CXX_BOOL` isn't actually part of the MPI standard, and it has led to issues on Perlmutter.