### PR TITLE
Fixed a crash in the statistics on GPU

### DIFF
--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseStatistics.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseStatistics.cpp
@@ -216,9 +216,9 @@ void CompositionalMultiphaseStatistics::computeRegionStatistics( MeshLevel & mes
     real64 subRegionMinTemp = 0.0;
     real64 subRegionMaxTemp = 0.0;
     real64 subRegionTotalUncompactedPoreVol = 0.0;
-    stackArray1d< real64, MultiFluidBase::MAX_NUM_PHASES > subRegionPhaseDynamicPoreVol( numPhases );
-    stackArray1d< real64, MultiFluidBase::MAX_NUM_PHASES > subRegionPhaseMass( numPhases );
-    stackArray2d< real64, MultiFluidBase::MAX_NUM_PHASES *MultiFluidBase::MAX_NUM_COMPONENTS > subRegionDissolvedComponentMass( numPhases, numComps );
+    array1d< real64 > subRegionPhaseDynamicPoreVol( numPhases );
+    array1d< real64 > subRegionPhaseMass( numPhases );
+    array2d< real64 > subRegionDissolvedComponentMass( numPhases, numComps );
 
     isothermalCompositionalMultiphaseBaseKernels::
       StatisticsKernel::
@@ -244,9 +244,9 @@ void CompositionalMultiphaseStatistics::computeRegionStatistics( MeshLevel & mes
                                         subRegionAvgTempNumerator,
                                         subRegionMaxTemp,
                                         subRegionTotalUncompactedPoreVol,
-                                        subRegionPhaseDynamicPoreVol.toSlice(),
-                                        subRegionPhaseMass.toSlice(),
-                                        subRegionDissolvedComponentMass.toSlice() );
+                                        subRegionPhaseDynamicPoreVol.toView(),
+                                        subRegionPhaseMass.toView(),
+                                        subRegionDissolvedComponentMass.toView() );
 
     ElementRegionBase & region = elemManager.getRegion( subRegion.getParent().getParent().getName() );
     RegionStatistics & regionStatistics = region.getReference< RegionStatistics >( viewKeyStruct::regionStatisticsString() );

--- a/src/coreComponents/physicsSolvers/fluidFlow/IsothermalCompositionalMultiphaseBaseKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/IsothermalCompositionalMultiphaseBaseKernels.hpp
@@ -1455,9 +1455,9 @@ struct StatisticsKernel
           real64 & avgTempNumerator,
           real64 & maxTemp,
           real64 & totalUncompactedPoreVol,
-          arraySlice1d< real64 > const & phaseDynamicPoreVol,
-          arraySlice1d< real64 > const & phaseMass,
-          arraySlice2d< real64 > const & dissolvedComponentMass )
+          arrayView1d< real64 > const & phaseDynamicPoreVol,
+          arrayView1d< real64 > const & phaseMass,
+          arrayView2d< real64 > const & dissolvedComponentMass )
   {
     RAJA::ReduceMin< parallelDeviceReduce, real64 > subRegionMinPres( LvArray::NumericLimits< real64 >::max );
     RAJA::ReduceSum< parallelDeviceReduce, real64 > subRegionAvgPresNumerator( 0.0 );


### PR DESCRIPTION
This PR fixed a bug that I introduced in `CompositionalMultiphaseStatistics.cpp` on GPU platforms. It was causing a crash on Pangea 3 and Pecan, but unfortunately, on Lassen the code was working, so I missed the issue. 

The PR changes the type of some arrays from `stackArray1d/arraySlice1d` to `array1d/arrayView1d` to make sure that the data is properly moved to the GPU.

No rebaseline needed.