### PR TITLE
Fix nvcc crash related to fast_float

### DIFF
--- a/src/coreComponents/codingUtilities/CMakeLists.txt
+++ b/src/coreComponents/codingUtilities/CMakeLists.txt
@@ -15,6 +15,7 @@ set( codingUtilities_headers
 # Specify all sources
 #
 set( codingUtilities_sources
+     Parsing.cpp
      StringUtilities.cpp )
 
 set( dependencyList common fast_float )
@@ -29,6 +30,9 @@ blt_add_library( NAME       codingUtilities
                  DEPENDS_ON ${dependencyList}
                  OBJECT     ${GEOSX_BUILD_OBJ_LIBS}
                )
+
+# Avoid compiling with nvcc which sometimes crashes on fast_float
+set_source_files_properties( Parsing.cpp PROPERTIES LANGUAGE CXX )
 
 target_include_directories( codingUtilities PUBLIC ${CMAKE_SOURCE_DIR}/coreComponents )
 

--- a/src/coreComponents/codingUtilities/Parsing.cpp
+++ b/src/coreComponents/codingUtilities/Parsing.cpp
@@ -1,0 +1,86 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file Parsing.hpp
+ */
+
+#include <fast_float.h>
+
+#include <cstdlib>
+
+namespace geosx
+{
+
+namespace
+{
+
+template< typename T, std::enable_if_t< std::is_floating_point< T >::value > * = nullptr >
+char const * parseValueImpl( char const * const first,
+                             char const * const last,
+                             T & value )
+{
+  using namespace fast_float;
+  from_chars_result const res = from_chars( first, last, value, chars_format::general );
+  return res.ec == std::errc() && !std::isinf( value ) ? res.ptr : first;
+}
+
+template< typename T, std::enable_if_t< std::is_integral< T >::value > * = nullptr >
+char const * parseValueImpl( char const * const first,
+                             char const * const last,
+                             T & value )
+{
+  if( first == last )
+  {
+    return first;
+  }
+
+  errno = 0;
+  char * tmp{};
+  long long const v = std::strtoll( first, &tmp, 0 ); // strtol is not const-correct
+  char const * const ptr = tmp;
+
+  // Error handling from strtol is a bit quirky
+  if( tmp == nullptr || std::distance( ptr, last ) <= 0 || ( ( v == LLONG_MIN || v == LLONG_MAX ) && errno == ERANGE ) )
+  {
+    return first;
+  }
+  value = static_cast< T >( v );
+  return ptr;
+}
+
+}
+
+template< typename T >
+char const * parseValue( char const * const first,
+                         char const * const last,
+                         T & value )
+{
+  return parseValueImpl( first, last, value );
+}
+
+#define INST_PARSEVALUE( T ) \
+  template char const * parseValue< T >( char const * const first, char const * const last, T & value )
+
+INST_PARSEVALUE( float );
+INST_PARSEVALUE( double );
+INST_PARSEVALUE( short );
+INST_PARSEVALUE( int );
+INST_PARSEVALUE( long );
+INST_PARSEVALUE( long long );
+// Add other types as needed
+
+#undef INST_PARSEVALUE
+
+} // namespace geosx

--- a/src/coreComponents/codingUtilities/Parsing.hpp
+++ b/src/coreComponents/codingUtilities/Parsing.hpp
@@ -21,68 +21,24 @@
 
 #include "common/DataTypes.hpp"
 
-#include <fast_float.h>
-
 #include <fstream>
-#include <cstdlib>
 
 namespace geosx
 {
 
 /**
- * @brief Parse a floating point value from a character sequence.
- * @tparam T type of value (float or double)
- * @param first pointer to start of the character sequence
- * @param last pointer past-the-end of the character sequence
- * @param value the parsed value, or unchanged if parsing failed
- * @return pointer to the first character following the parsed value,
- *         or @p first if parsing dit no succeed for any reason
- */
-template< typename T, std::enable_if_t< std::is_floating_point< T >::value > * = nullptr >
-char const * parseValue( char const * const first,
-                         char const * const last,
-                         T & value )
-{
-  using namespace fast_float;
-  from_chars_result const res = from_chars( first, last, value, chars_format::general );
-  return res.ec == std::errc() && !std::isinf( value ) ? res.ptr : first;
-}
-
-/**
- * @brief Parse an integral value from a character sequence.
+ * @brief Parse an numeric value from a character sequence.
  * @tparam T type of value
  * @param first pointer to start of the character sequence
  * @param last pointer past-the-end of the character sequence
  * @param value the parsed value, or unchanged if parsing failed
  * @return pointer to the first character following the parsed value,
  *         or @p first if parsing did no succeed for any reason
- * @note Only supports values between LLONG_MIN and LLONG_MAX, regardless of T
- * @note If parsed value does not fit into T, terminates the program instead of returning
- *       (due to relying on LvArray::integerConversion for casting the result)
  */
-template< typename T, std::enable_if_t< std::is_integral< T >::value > * = nullptr >
+template< typename T >
 char const * parseValue( char const * const first,
                          char const * const last,
-                         T & value )
-{
-  if( first == last )
-  {
-    return first;
-  }
-
-  errno = 0;
-  char * tmp{};
-  long long const v = std::strtoll( first, &tmp, 0 ); // strtol is not const-correct
-  char const * const ptr = tmp;
-
-  // Error handling from strtol is a bit quirky
-  if( tmp == nullptr || std::distance( ptr, last ) <= 0 || ( ( v == LLONG_MIN || v == LLONG_MAX ) && errno == ERANGE ) )
-  {
-    return first;
-  }
-  value = LvArray::integerConversion< T >( v );
-  return ptr;
-}
+                         T & value );
 
 /**
  * @brief Parse a sequence of values into a container

--- a/src/coreComponents/mesh/CMakeLists.txt
+++ b/src/coreComponents/mesh/CMakeLists.txt
@@ -157,6 +157,11 @@ blt_add_library( NAME       mesh
                
 target_include_directories( mesh PUBLIC ${CMAKE_SOURCE_DIR}/coreComponents )
 
+if( ENABLE_VTK )
+    # Avoid compiling with nvcc which sometimes segfaults in debug
+    set_source_files_properties( generators/VTKMeshGeneratorTools.cpp PROPERTIES LANGUAGE CXX )
+endif()
+
 add_subdirectory( unitTests )
 
 geosx_add_code_checks( PREFIX mesh


### PR DESCRIPTION
This PR fixes an `nvcc` crash that was happening on my machine (Ubuntu 20.04, cuda-10.1.243) but for some reason not in CI and apparently on none of the real systems either (lassen, etc.):
```
Error: Internal Compiler Error (codegen): "there was an error in verifying the lgenfe output!"
```

Figured out that it was crashing when compiling the call to `fast_float::from_chars()`. The proposed solution that seems to work for me:
  * Move all calls to `fast_float` into a separate translation unit (for consistency moved parsing of integral types there as well)
  * Force it to be compiled with host compiler