### PR TITLE
Add ubuntu 22.04 LTS Jammy to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ __geosx_osx_build: &__geosx_osx_build
   - make -j $(nproc) VERBOSE=1
   - ctest -V -E "testUncrustifyCheck|testDoxygenCheck|blt_mpi_smoke"
 
-__geosx_totalenergies_cluster_build: &__geosx_totalenergies_cluster_build
+__geosx_auto_deploy: &__geosx_auto_deploy
   <<: *__geosx_linux_build
   # We use the most recent ubuntu distribution available in travis-ci to ensure maximum support of google cloud's sdk.
   dist: focal
@@ -220,7 +220,7 @@ jobs:
     - BUILD_AND_TEST_ARGS="--disable-unit-tests --reduce-install-logs"
   - stage: builds
     name: Pecan GPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5, cuda 10.2.89p2)
-    <<: *__geosx_totalenergies_cluster_build
+    <<: *__geosx_auto_deploy
     env:
     - DOCKER_REPOSITORY=geosx/pecan-gpu-gcc8.2.0-openmpi4.0.1-mkl2019.5-cuda10.2.89p2
     - CMAKE_BUILD_TYPE=Release
@@ -229,7 +229,7 @@ jobs:
     - GCP_BUCKET=geosx/Pecan-GPU
   - stage: builds
     name: Pecan CPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5)
-    <<: *__geosx_totalenergies_cluster_build
+    <<: *__geosx_auto_deploy
     env:
     - DOCKER_REPOSITORY=geosx/pecan-cpu-gcc8.2.0-openmpi4.0.1-mkl2019.5
     - CMAKE_BUILD_TYPE=Release
@@ -237,7 +237,7 @@ jobs:
     - GCP_BUCKET=geosx/Pecan-CPU
   - stage: builds
     name: Pangea 2 (centos 7.6, gcc 8.3.0, open-mpi 2.1.5, mkl 2019.3)
-    <<: *__geosx_totalenergies_cluster_build
+    <<: *__geosx_auto_deploy
     env:
     - DOCKER_REPOSITORY=geosx/pangea2-gcc8.3.0-openmpi2.1.5-mkl2019.3
     - CMAKE_BUILD_TYPE=Release
@@ -267,7 +267,7 @@ jobs:
     - CMAKE_BUILD_TYPE=Release
   - stage: builds
     name: Ubuntu (22.04, gcc 11.2.0, open-mpi 4.1.2)
-    <<: *__geosx_totalenergies_cluster_build
+    <<: *__geosx_auto_deploy
     env:
     - DOCKER_REPOSITORY=geosx/ubuntu22.04-gcc11
     - CMAKE_BUILD_TYPE=RelWithDebInfo

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ vm:
 
 env:
   global:
-  - GEOSX_TPL_TAG=false-807
+  - GEOSX_TPL_TAG=false-810
   - secure: CGs2uH6efq1Me6xJWRr0BnwtwxoujzlowC4FHXHdWbNOkPsXf7nCgdaW5vthfD3bhnOeEUQSrfxdhTRtyU/NfcKLmKgGBnZOdUG4/JJK4gDSJ2Wp8LZ/mB0QEoODKVxbh+YtoAiHe3y4M9PGCs+wkNDw/3eEU00cK12DZ6gad0RbLjI3xkhEr/ZEZDZkcYg9yHAhl5bmpqoh/6QGnIg8mxIqdAtGDw+6tT0EgUqjeqc5bG5WwsamKzJItHSXD5zx8IJAlgDk4EzEGjZe0m56YnNfb9iwqqUsmL3Cuwgs7ByVDYw78JC5Kv42YqoxA5BxMT2mFsEe37TpYNXlzofU7ma2Duw9DGXWQd4IkTCcBxlyR0I0bfo0TmgO+y7PYG9lIyHPUkENemdozsZcWamqqkqegiEdRhDVYlSRo3mu7iCwTS6ZTALliVyEYjYxYb7oAnR3cNywXjblTCI8oKfgLSY+8WijM9SRl57JruIHLkLMCjmRI+cZBfv5tS2tYQTBPkygGrigrrN77ZiC7/TGyfggSN0+y0oYtOAgqEnBcKcreiibMW7tKcV2Z1RFD9ZvIkSc1EXLUPDP8FX1oyhmqBMqVo8LksrYLDJHQ05+F3YNgl2taSt7uMjQ4e8iZ3/IjFeMnbylDw+cj/RbS520HXsFPbWFm2Pb9pceA9n6GnY=
 
 # The integrated test repository contains large data (using git lfs) and we do not use them here.
@@ -190,87 +190,87 @@ jobs:
   - stage: checks
     name: check_pr_is_assigned
     <<: *__geosx_assigned_script
-  # - stage: builds
-  #   name: Ubuntu CUDA debug (18.04, clang 8.0.0 + gcc 8.3.1, open-mpi 2.1.1, cuda-10.1.243)
-  #   <<: *__geosx_linux_build
-  #   # Builds only the geosx executable (timeout when building tests)
-  #   env:
-  #   - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
-  #   - CMAKE_BUILD_TYPE=Debug
-  #   - BUILD_AND_TEST_ARGS="--disable-unit-tests --build-exe-only"
-  #   - ENABLE_HYPRE=ON
-  #   - ENABLE_HYPRE_CUDA=ON
-  #   - ENABLE_TRILINOS=OFF
-  # - stage: builds
-  #   name: Ubuntu CUDA (18.04, clang 8.0.0 + gcc 8.3.1, open-mpi 2.1.1, cuda-10.1.243)
-  #   <<: *__geosx_linux_build
-  #   env:
-  #   - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
-  #   - CMAKE_BUILD_TYPE=Release
-  #   - BUILD_AND_TEST_ARGS="--disable-unit-tests --reduce-install-logs"
-  #   - ENABLE_HYPRE=ON
-  #   - ENABLE_HYPRE_CUDA=ON
-  #   - ENABLE_TRILINOS=OFF
-  # - stage: builds
-  #   name: Centos (7.6, gcc 8.3.1, open-mpi 1.10.7, cuda 10.1.243)
-  #   <<: *__geosx_linux_build
-  #   env:
-  #   - DOCKER_REPOSITORY=geosx/centos7.6.1810-gcc8.3.1-cuda10.1.243
-  #   - CMAKE_BUILD_TYPE=Release
-  #   - BUILD_AND_TEST_ARGS="--disable-unit-tests --reduce-install-logs"
-  # - stage: builds
-  #   name: Pecan GPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5, cuda 10.2.89p2)
-  #   <<: *__geosx_totalenergies_cluster_build
-  #   env:
-  #   - DOCKER_REPOSITORY=geosx/pecan-gpu-gcc8.2.0-openmpi4.0.1-mkl2019.5-cuda10.2.89p2
-  #   - CMAKE_BUILD_TYPE=Release
-  #   - BUILD_AND_TEST_ARGS=--disable-unit-tests
-  #   - HOST_CONFIG=host-configs/TOTAL/pecan-GPU.cmake
-  #   - GCP_BUCKET=geosx/Pecan-GPU
-  # - stage: builds
-  #   name: Pecan CPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5)
-  #   <<: *__geosx_totalenergies_cluster_build
-  #   env:
-  #   - DOCKER_REPOSITORY=geosx/pecan-cpu-gcc8.2.0-openmpi4.0.1-mkl2019.5
-  #   - CMAKE_BUILD_TYPE=Release
-  #   - HOST_CONFIG=host-configs/TOTAL/pecan-CPU.cmake
-  #   - GCP_BUCKET=geosx/Pecan-CPU
-  # - stage: builds
-  #   name: Pangea 2 (centos 7.6, gcc 8.3.0, open-mpi 2.1.5, mkl 2019.3)
-  #   <<: *__geosx_totalenergies_cluster_build
-  #   env:
-  #   - DOCKER_REPOSITORY=geosx/pangea2-gcc8.3.0-openmpi2.1.5-mkl2019.3
-  #   - CMAKE_BUILD_TYPE=Release
-  #   - GCP_BUCKET=geosx/Pangea2
-  #   - ENABLE_HYPRE=ON
-  #   - ENABLE_TRILINOS=OFF
-  # - stage: builds
-  #   name: Mac_OSX
-  #   <<: *__geosx_osx_build
-  # - stage: builds
-  #   name: Centos (7.7, clang 9.0.0 + gcc 4.9.3, open-mpi 1.10.7)
-  #   <<: *__geosx_linux_build
-  #   env:
-  #   - DOCKER_REPOSITORY=geosx/centos7.7.1908-clang9.0.0
-  #   - CMAKE_BUILD_TYPE=Release
-  # - stage: builds
-  #   name: Ubuntu (20.04, gcc 9.3.0, open-mpi 4.0.3)
-  #   <<: *__geosx_linux_build
-  #   env:
-  #   - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc9
-  #   - CMAKE_BUILD_TYPE=Release
-  # - stage: builds
-  #   name: Ubuntu debug (20.04, gcc 10.3.0, open-mpi 4.0.3)
-  #   <<: *__geosx_linux_build
-  #   env:
-  #   - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc10
-  #   - CMAKE_BUILD_TYPE=Debug
-  # - stage: builds
-  #   name: Ubuntu (20.04, gcc 10.3.0, open-mpi 4.0.3)
-  #   <<: *__geosx_linux_build
-  #   env:
-  #   - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc10
-  #   - CMAKE_BUILD_TYPE=Release
+  - stage: builds
+    name: Ubuntu CUDA debug (18.04, clang 8.0.0 + gcc 8.3.1, open-mpi 2.1.1, cuda-10.1.243)
+    <<: *__geosx_linux_build
+    # Builds only the geosx executable (timeout when building tests)
+    env:
+    - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
+    - CMAKE_BUILD_TYPE=Debug
+    - BUILD_AND_TEST_ARGS="--disable-unit-tests --build-exe-only"
+    - ENABLE_HYPRE=ON
+    - ENABLE_HYPRE_CUDA=ON
+    - ENABLE_TRILINOS=OFF
+  - stage: builds
+    name: Ubuntu CUDA (18.04, clang 8.0.0 + gcc 8.3.1, open-mpi 2.1.1, cuda-10.1.243)
+    <<: *__geosx_linux_build
+    env:
+    - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
+    - CMAKE_BUILD_TYPE=Release
+    - BUILD_AND_TEST_ARGS="--disable-unit-tests --reduce-install-logs"
+    - ENABLE_HYPRE=ON
+    - ENABLE_HYPRE_CUDA=ON
+    - ENABLE_TRILINOS=OFF
+  - stage: builds
+    name: Centos (7.6, gcc 8.3.1, open-mpi 1.10.7, cuda 10.1.243)
+    <<: *__geosx_linux_build
+    env:
+    - DOCKER_REPOSITORY=geosx/centos7.6.1810-gcc8.3.1-cuda10.1.243
+    - CMAKE_BUILD_TYPE=Release
+    - BUILD_AND_TEST_ARGS="--disable-unit-tests --reduce-install-logs"
+  - stage: builds
+    name: Pecan GPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5, cuda 10.2.89p2)
+    <<: *__geosx_totalenergies_cluster_build
+    env:
+    - DOCKER_REPOSITORY=geosx/pecan-gpu-gcc8.2.0-openmpi4.0.1-mkl2019.5-cuda10.2.89p2
+    - CMAKE_BUILD_TYPE=Release
+    - BUILD_AND_TEST_ARGS=--disable-unit-tests
+    - HOST_CONFIG=host-configs/TOTAL/pecan-GPU.cmake
+    - GCP_BUCKET=geosx/Pecan-GPU
+  - stage: builds
+    name: Pecan CPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5)
+    <<: *__geosx_totalenergies_cluster_build
+    env:
+    - DOCKER_REPOSITORY=geosx/pecan-cpu-gcc8.2.0-openmpi4.0.1-mkl2019.5
+    - CMAKE_BUILD_TYPE=Release
+    - HOST_CONFIG=host-configs/TOTAL/pecan-CPU.cmake
+    - GCP_BUCKET=geosx/Pecan-CPU
+  - stage: builds
+    name: Pangea 2 (centos 7.6, gcc 8.3.0, open-mpi 2.1.5, mkl 2019.3)
+    <<: *__geosx_totalenergies_cluster_build
+    env:
+    - DOCKER_REPOSITORY=geosx/pangea2-gcc8.3.0-openmpi2.1.5-mkl2019.3
+    - CMAKE_BUILD_TYPE=Release
+    - GCP_BUCKET=geosx/Pangea2
+    - ENABLE_HYPRE=ON
+    - ENABLE_TRILINOS=OFF
+  - stage: builds
+    name: Mac_OSX
+    <<: *__geosx_osx_build
+  - stage: builds
+    name: Centos (7.7, clang 9.0.0 + gcc 4.9.3, open-mpi 1.10.7)
+    <<: *__geosx_linux_build
+    env:
+    - DOCKER_REPOSITORY=geosx/centos7.7.1908-clang9.0.0
+    - CMAKE_BUILD_TYPE=Release
+  - stage: builds
+    name: Ubuntu (20.04, gcc 9.3.0, open-mpi 4.0.3)
+    <<: *__geosx_linux_build
+    env:
+    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc9
+    - CMAKE_BUILD_TYPE=Release
+  - stage: builds
+    name: Ubuntu debug (20.04, gcc 10.3.0, open-mpi 4.0.3)
+    <<: *__geosx_linux_build
+    env:
+    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc10
+    - CMAKE_BUILD_TYPE=Debug
+  - stage: builds
+    name: Ubuntu (20.04, gcc 10.3.0, open-mpi 4.0.3)
+    <<: *__geosx_linux_build
+    env:
+    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc10
+    - CMAKE_BUILD_TYPE=Release
   - stage: builds
     name: Ubuntu (22.04, gcc 11.2.0, open-mpi 4.1.2)
     <<: *__geosx_totalenergies_cluster_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ vm:
 
 env:
   global:
-  - GEOSX_TPL_TAG=false-810
+  - GEOSX_TPL_TAG=200-813
   - secure: CGs2uH6efq1Me6xJWRr0BnwtwxoujzlowC4FHXHdWbNOkPsXf7nCgdaW5vthfD3bhnOeEUQSrfxdhTRtyU/NfcKLmKgGBnZOdUG4/JJK4gDSJ2Wp8LZ/mB0QEoODKVxbh+YtoAiHe3y4M9PGCs+wkNDw/3eEU00cK12DZ6gad0RbLjI3xkhEr/ZEZDZkcYg9yHAhl5bmpqoh/6QGnIg8mxIqdAtGDw+6tT0EgUqjeqc5bG5WwsamKzJItHSXD5zx8IJAlgDk4EzEGjZe0m56YnNfb9iwqqUsmL3Cuwgs7ByVDYw78JC5Kv42YqoxA5BxMT2mFsEe37TpYNXlzofU7ma2Duw9DGXWQd4IkTCcBxlyR0I0bfo0TmgO+y7PYG9lIyHPUkENemdozsZcWamqqkqegiEdRhDVYlSRo3mu7iCwTS6ZTALliVyEYjYxYb7oAnR3cNywXjblTCI8oKfgLSY+8WijM9SRl57JruIHLkLMCjmRI+cZBfv5tS2tYQTBPkygGrigrrN77ZiC7/TGyfggSN0+y0oYtOAgqEnBcKcreiibMW7tKcV2Z1RFD9ZvIkSc1EXLUPDP8FX1oyhmqBMqVo8LksrYLDJHQ05+F3YNgl2taSt7uMjQ4e8iZ3/IjFeMnbylDw+cj/RbS520HXsFPbWFm2Pb9pceA9n6GnY=
 
 # The integrated test repository contains large data (using git lfs) and we do not use them here.
@@ -247,12 +247,6 @@ jobs:
   - stage: builds
     name: Mac_OSX
     <<: *__geosx_osx_build
-  - stage: builds
-    name: Centos (7.7, clang 9.0.0 + gcc 4.9.3, open-mpi 1.10.7)
-    <<: *__geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/centos7.7.1908-clang9.0.0
-    - CMAKE_BUILD_TYPE=Release
   - stage: builds
     name: Ubuntu (20.04, gcc 9.3.0, open-mpi 4.0.3)
     <<: *__geosx_linux_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ vm:
 
 env:
   global:
-  - GEOSX_TPL_TAG=197-790
+  - GEOSX_TPL_TAG=false-807
   - secure: CGs2uH6efq1Me6xJWRr0BnwtwxoujzlowC4FHXHdWbNOkPsXf7nCgdaW5vthfD3bhnOeEUQSrfxdhTRtyU/NfcKLmKgGBnZOdUG4/JJK4gDSJ2Wp8LZ/mB0QEoODKVxbh+YtoAiHe3y4M9PGCs+wkNDw/3eEU00cK12DZ6gad0RbLjI3xkhEr/ZEZDZkcYg9yHAhl5bmpqoh/6QGnIg8mxIqdAtGDw+6tT0EgUqjeqc5bG5WwsamKzJItHSXD5zx8IJAlgDk4EzEGjZe0m56YnNfb9iwqqUsmL3Cuwgs7ByVDYw78JC5Kv42YqoxA5BxMT2mFsEe37TpYNXlzofU7ma2Duw9DGXWQd4IkTCcBxlyR0I0bfo0TmgO+y7PYG9lIyHPUkENemdozsZcWamqqkqegiEdRhDVYlSRo3mu7iCwTS6ZTALliVyEYjYxYb7oAnR3cNywXjblTCI8oKfgLSY+8WijM9SRl57JruIHLkLMCjmRI+cZBfv5tS2tYQTBPkygGrigrrN77ZiC7/TGyfggSN0+y0oYtOAgqEnBcKcreiibMW7tKcV2Z1RFD9ZvIkSc1EXLUPDP8FX1oyhmqBMqVo8LksrYLDJHQ05+F3YNgl2taSt7uMjQ4e8iZ3/IjFeMnbylDw+cj/RbS520HXsFPbWFm2Pb9pceA9n6GnY=
 
 # The integrated test repository contains large data (using git lfs) and we do not use them here.
@@ -190,86 +190,93 @@ jobs:
   - stage: checks
     name: check_pr_is_assigned
     <<: *__geosx_assigned_script
+  # - stage: builds
+  #   name: Ubuntu CUDA debug (18.04, clang 8.0.0 + gcc 8.3.1, open-mpi 2.1.1, cuda-10.1.243)
+  #   <<: *__geosx_linux_build
+  #   # Builds only the geosx executable (timeout when building tests)
+  #   env:
+  #   - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
+  #   - CMAKE_BUILD_TYPE=Debug
+  #   - BUILD_AND_TEST_ARGS="--disable-unit-tests --build-exe-only"
+  #   - ENABLE_HYPRE=ON
+  #   - ENABLE_HYPRE_CUDA=ON
+  #   - ENABLE_TRILINOS=OFF
+  # - stage: builds
+  #   name: Ubuntu CUDA (18.04, clang 8.0.0 + gcc 8.3.1, open-mpi 2.1.1, cuda-10.1.243)
+  #   <<: *__geosx_linux_build
+  #   env:
+  #   - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
+  #   - CMAKE_BUILD_TYPE=Release
+  #   - BUILD_AND_TEST_ARGS="--disable-unit-tests --reduce-install-logs"
+  #   - ENABLE_HYPRE=ON
+  #   - ENABLE_HYPRE_CUDA=ON
+  #   - ENABLE_TRILINOS=OFF
+  # - stage: builds
+  #   name: Centos (7.6, gcc 8.3.1, open-mpi 1.10.7, cuda 10.1.243)
+  #   <<: *__geosx_linux_build
+  #   env:
+  #   - DOCKER_REPOSITORY=geosx/centos7.6.1810-gcc8.3.1-cuda10.1.243
+  #   - CMAKE_BUILD_TYPE=Release
+  #   - BUILD_AND_TEST_ARGS="--disable-unit-tests --reduce-install-logs"
+  # - stage: builds
+  #   name: Pecan GPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5, cuda 10.2.89p2)
+  #   <<: *__geosx_totalenergies_cluster_build
+  #   env:
+  #   - DOCKER_REPOSITORY=geosx/pecan-gpu-gcc8.2.0-openmpi4.0.1-mkl2019.5-cuda10.2.89p2
+  #   - CMAKE_BUILD_TYPE=Release
+  #   - BUILD_AND_TEST_ARGS=--disable-unit-tests
+  #   - HOST_CONFIG=host-configs/TOTAL/pecan-GPU.cmake
+  #   - GCP_BUCKET=geosx/Pecan-GPU
+  # - stage: builds
+  #   name: Pecan CPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5)
+  #   <<: *__geosx_totalenergies_cluster_build
+  #   env:
+  #   - DOCKER_REPOSITORY=geosx/pecan-cpu-gcc8.2.0-openmpi4.0.1-mkl2019.5
+  #   - CMAKE_BUILD_TYPE=Release
+  #   - HOST_CONFIG=host-configs/TOTAL/pecan-CPU.cmake
+  #   - GCP_BUCKET=geosx/Pecan-CPU
+  # - stage: builds
+  #   name: Pangea 2 (centos 7.6, gcc 8.3.0, open-mpi 2.1.5, mkl 2019.3)
+  #   <<: *__geosx_totalenergies_cluster_build
+  #   env:
+  #   - DOCKER_REPOSITORY=geosx/pangea2-gcc8.3.0-openmpi2.1.5-mkl2019.3
+  #   - CMAKE_BUILD_TYPE=Release
+  #   - GCP_BUCKET=geosx/Pangea2
+  #   - ENABLE_HYPRE=ON
+  #   - ENABLE_TRILINOS=OFF
+  # - stage: builds
+  #   name: Mac_OSX
+  #   <<: *__geosx_osx_build
+  # - stage: builds
+  #   name: Centos (7.7, clang 9.0.0 + gcc 4.9.3, open-mpi 1.10.7)
+  #   <<: *__geosx_linux_build
+  #   env:
+  #   - DOCKER_REPOSITORY=geosx/centos7.7.1908-clang9.0.0
+  #   - CMAKE_BUILD_TYPE=Release
+  # - stage: builds
+  #   name: Ubuntu (20.04, gcc 9.3.0, open-mpi 4.0.3)
+  #   <<: *__geosx_linux_build
+  #   env:
+  #   - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc9
+  #   - CMAKE_BUILD_TYPE=Release
+  # - stage: builds
+  #   name: Ubuntu debug (20.04, gcc 10.3.0, open-mpi 4.0.3)
+  #   <<: *__geosx_linux_build
+  #   env:
+  #   - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc10
+  #   - CMAKE_BUILD_TYPE=Debug
+  # - stage: builds
+  #   name: Ubuntu (20.04, gcc 10.3.0, open-mpi 4.0.3)
+  #   <<: *__geosx_linux_build
+  #   env:
+  #   - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc10
+  #   - CMAKE_BUILD_TYPE=Release
   - stage: builds
-    name: Ubuntu CUDA debug (18.04, clang 8.0.0 + gcc 8.3.1, open-mpi 2.1.1, cuda-10.1.243)
-    <<: *__geosx_linux_build
-    # Builds only the geosx executable (timeout when building tests)
-    env:
-    - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
-    - CMAKE_BUILD_TYPE=Debug
-    - BUILD_AND_TEST_ARGS="--disable-unit-tests --build-exe-only"
-    - ENABLE_HYPRE=ON
-    - ENABLE_HYPRE_CUDA=ON
-    - ENABLE_TRILINOS=OFF
-  - stage: builds
-    name: Ubuntu CUDA (18.04, clang 8.0.0 + gcc 8.3.1, open-mpi 2.1.1, cuda-10.1.243)
-    <<: *__geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
-    - CMAKE_BUILD_TYPE=Release
-    - BUILD_AND_TEST_ARGS="--disable-unit-tests --reduce-install-logs"
-    - ENABLE_HYPRE=ON
-    - ENABLE_HYPRE_CUDA=ON
-    - ENABLE_TRILINOS=OFF
-  - stage: builds
-    name: Centos (7.6, gcc 8.3.1, open-mpi 1.10.7, cuda 10.1.243)
-    <<: *__geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/centos7.6.1810-gcc8.3.1-cuda10.1.243
-    - CMAKE_BUILD_TYPE=Release
-    - BUILD_AND_TEST_ARGS="--disable-unit-tests --reduce-install-logs"
-  - stage: builds
-    name: Pecan GPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5, cuda 10.2.89p2)
+    name: Ubuntu (22.04, gcc 11.2.0, open-mpi 4.1.2)
     <<: *__geosx_totalenergies_cluster_build
     env:
-    - DOCKER_REPOSITORY=geosx/pecan-gpu-gcc8.2.0-openmpi4.0.1-mkl2019.5-cuda10.2.89p2
-    - CMAKE_BUILD_TYPE=Release
-    - BUILD_AND_TEST_ARGS=--disable-unit-tests
-    - HOST_CONFIG=host-configs/TOTAL/pecan-GPU.cmake
-    - GCP_BUCKET=geosx/Pecan-GPU
-  - stage: builds
-    name: Pecan CPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5)
-    <<: *__geosx_totalenergies_cluster_build
-    env:
-    - DOCKER_REPOSITORY=geosx/pecan-cpu-gcc8.2.0-openmpi4.0.1-mkl2019.5
-    - CMAKE_BUILD_TYPE=Release
-    - HOST_CONFIG=host-configs/TOTAL/pecan-CPU.cmake
-    - GCP_BUCKET=geosx/Pecan-CPU
-  - stage: builds
-    name: Pangea 2 (centos 7.6, gcc 8.3.0, open-mpi 2.1.5, mkl 2019.3)
-    <<: *__geosx_totalenergies_cluster_build
-    env:
-    - DOCKER_REPOSITORY=geosx/pangea2-gcc8.3.0-openmpi2.1.5-mkl2019.3
-    - CMAKE_BUILD_TYPE=Release
-    - GCP_BUCKET=geosx/Pangea2
-    - ENABLE_HYPRE=ON
-    - ENABLE_TRILINOS=OFF
-  - stage: builds
-    name: Mac_OSX
-    <<: *__geosx_osx_build
-  - stage: builds
-    name: Centos (7.7, clang 9.0.0 + gcc 4.9.3, open-mpi 1.10.7)
-    <<: *__geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/centos7.7.1908-clang9.0.0
-    - CMAKE_BUILD_TYPE=Release
-  - stage: builds
-    name: Ubuntu (20.04, gcc 9.3.0, open-mpi 4.0.3)
-    <<: *__geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc9
-    - CMAKE_BUILD_TYPE=Release
-  - stage: builds
-    name: Ubuntu debug (20.04, gcc 10.3.0, open-mpi 4.0.3)
-    <<: *__geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc10
-    - CMAKE_BUILD_TYPE=Debug
-  - stage: builds
-    name: Ubuntu (20.04, gcc 10.3.0, open-mpi 4.0.3)
-    <<: *__geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc10
-    - CMAKE_BUILD_TYPE=Release
+    - DOCKER_REPOSITORY=geosx/ubuntu22.04-gcc11
+    - CMAKE_BUILD_TYPE=RelWithDebInfo
+    - GCP_BUCKET=geosx/ubuntu22.04-gcc11
   - stage: return_status
     <<: *__geosx_return_script

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ __geosx_osx_build: &__geosx_osx_build
 __geosx_totalenergies_cluster_build: &__geosx_totalenergies_cluster_build
   <<: *__geosx_linux_build
   # We use the most recent ubuntu distribution available in travis-ci to ensure maximum support of google cloud's sdk.
-  dist: bionic
+  dist: focal
   addons:
     apt:
       sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: shell
 os: linux
-dist: xenial
+dist: focal
 
 vm:
   size: large

--- a/scripts/travis_build_and_test.sh
+++ b/scripts/travis_build_and_test.sh
@@ -51,12 +51,12 @@ fi
 # This will tells OpenMPI to discover the number of hardware threads on the node,
 # and use that as the number of slots available. (There is a distinction between threads and cores).
 GEOSX_BUILD_DIR=/tmp/build
-or_die python scripts/config-build.py \
-              -hc ${HOST_CONFIG} \
-              -bt ${CMAKE_BUILD_TYPE} \
-              -bp ${GEOSX_BUILD_DIR} \
-              -ip ${GEOSX_DIR} \
-              -DBLT_MPI_COMMAND_APPEND='"--allow-run-as-root;--oversubscribe"'
+or_die python3 scripts/config-build.py \
+               -hc ${HOST_CONFIG} \
+               -bt ${CMAKE_BUILD_TYPE} \
+               -bp ${GEOSX_BUILD_DIR} \
+               -ip ${GEOSX_DIR} \
+               -DBLT_MPI_COMMAND_APPEND='"--allow-run-as-root;--oversubscribe"'
 
 or_die cd ${GEOSX_BUILD_DIR}
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,7 +144,7 @@ if( ENABLE_XML_UPDATES AND ENABLE_MPI AND UNIX AND NOT CMAKE_HOST_APPLE AND NOT 
 
   add_custom_target( geosx_update_rst_tables
                      ALL
-                     COMMAND python ${SCRIPT_DIR}/SchemaToRSTDocumentation.py ${SCHEMA_DIR} >update_rst_tables.log 2>&1 || (cat update_rst_tables.log && exit 1)
+                     COMMAND python3 ${SCRIPT_DIR}/SchemaToRSTDocumentation.py ${SCHEMA_DIR} >update_rst_tables.log 2>&1 || (cat update_rst_tables.log && exit 1)
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
                      DEPENDS geosx_generate_schema
                      COMMENT "Generating schema-dependent RST files"

--- a/src/docs/sphinx/buildGuide/Prerequisites.rst
+++ b/src/docs/sphinx/buildGuide/Prerequisites.rst
@@ -10,7 +10,7 @@ List of prerequisites
 
 Minimal requirements:
 
-- `CMake <https://cmake.org/>`_ build system generator (3.13+).
+- `CMake <https://cmake.org/>`_ build system generator (3.17+).
 - build tools (`GNU make <https://www.gnu.org/software/make/>`_ or `ninja <https://ninja-build.org/>`_ on Linux, XCode on MacOS).
 - a C++ compiler with full c++14 standard support (`gcc <https://gcc.gnu.org/>`_ 8.3+ or `clang <https://clang.llvm.org/>`_ 8.0+ are recommended).
 - `python <https://www.python.org/>`_ (2.7+ or 3.6+).


### PR DESCRIPTION
Target `ubuntu 22.04 LTS Jammy` is added to travis.
Target `Centos (7.6, clang 9.0.0 + gcc 4.9.3, open-mpi 1.10.7)` is removed.

Auto deployment is done for `ubuntu 22.04`.

Related to TPL PR https://github.com/GEOSX/thirdPartyLibs/pull/200
Resolves https://github.com/GEOSX/GEOSX/issues/1889