### PR TITLE
Added extrinsic mesh data for solid mechanics

### DIFF
--- a/inputFiles/efemFractureMechanics/EmbFrac_Compression_CoulombFriction_base.xml
+++ b/inputFiles/efemFractureMechanics/EmbFrac_Compression_CoulombFriction_base.xml
@@ -102,7 +102,7 @@
     <FieldSpecification
       name="xnegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ bottomPoint, topPoint }"/>
@@ -110,7 +110,7 @@
     <FieldSpecification
       name="yposconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ leftPoint, rightPoint }"/>
@@ -118,7 +118,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>   

--- a/inputFiles/efemFractureMechanics/EmbFrac_Compression_Frictionless_base.xml
+++ b/inputFiles/efemFractureMechanics/EmbFrac_Compression_Frictionless_base.xml
@@ -99,7 +99,7 @@
     <FieldSpecification
       name="xnegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ bottomPoint, topPoint }"/>
@@ -107,7 +107,7 @@
     <FieldSpecification
       name="yposconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ leftPoint, rightPoint }"/>
@@ -115,7 +115,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>   

--- a/inputFiles/efemFractureMechanics/SneddonRotated_base.xml
+++ b/inputFiles/efemFractureMechanics/SneddonRotated_base.xml
@@ -77,7 +77,7 @@
     <FieldSpecification
       name="xnegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
@@ -85,7 +85,7 @@
     <FieldSpecification
       name="yposconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ ypos }"/>
@@ -93,7 +93,7 @@
     <FieldSpecification
       name="ynegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="-0.0"
       setNames="{ yneg }"/>
@@ -101,7 +101,7 @@
     <FieldSpecification
       name="zposconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zpos }"/>
@@ -109,7 +109,7 @@
     <FieldSpecification
       name="znegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="-0.0"
       setNames="{ zneg }"/>
@@ -117,7 +117,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/efemFractureMechanics/Sneddon_embeddedFrac_base.xml
+++ b/inputFiles/efemFractureMechanics/Sneddon_embeddedFrac_base.xml
@@ -104,7 +104,7 @@
     <FieldSpecification
       name="xnegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
@@ -112,7 +112,7 @@
     <FieldSpecification
       name="yposconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -120,7 +120,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/efemFractureMechanics/Sneddon_staticCondensation_base.xml
+++ b/inputFiles/efemFractureMechanics/Sneddon_staticCondensation_base.xml
@@ -76,7 +76,7 @@
     <FieldSpecification
       name="xnegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
@@ -84,7 +84,7 @@
     <FieldSpecification
       name="yposconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ ypos }"/>
@@ -92,7 +92,7 @@
     <FieldSpecification
       name="ynegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="-0.0"
       setNames="{ yneg }"/>
@@ -100,7 +100,7 @@
     <FieldSpecification
       name="zposconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zpos }"/>
@@ -108,7 +108,7 @@
     <FieldSpecification
       name="znegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="-0.0"
       setNames="{ zneg }"/>
@@ -116,7 +116,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/hydraulicFracturing/Sneddon_hydroFrac_base.xml
+++ b/inputFiles/hydraulicFracturing/Sneddon_hydroFrac_base.xml
@@ -169,7 +169,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -177,7 +177,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ all }"/>
@@ -185,7 +185,7 @@
     <FieldSpecification
       name="xConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>

--- a/inputFiles/hydraulicFracturing/heterogeneousInSitu_base.xml
+++ b/inputFiles/hydraulicFracturing/heterogeneousInSitu_base.xml
@@ -291,7 +291,7 @@
     <FieldSpecification
       name="x_constraint"
       component="0"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       objectPath="nodeManager"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
@@ -299,7 +299,7 @@
     <FieldSpecification
       name="y_constraint"
       component="1"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       objectPath="nodeManager"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -307,7 +307,7 @@
     <FieldSpecification
       name="z_constraint"
       component="2"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       objectPath="nodeManager"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/hydraulicFracturing/heterogeneousInSitu_smoke.xml
+++ b/inputFiles/hydraulicFracturing/heterogeneousInSitu_smoke.xml
@@ -323,7 +323,7 @@
     <FieldSpecification
       name="x_constraint"
       component="0"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       objectPath="nodeManager"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
@@ -331,7 +331,7 @@
     <FieldSpecification
       name="y_constraint"
       component="1"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       objectPath="nodeManager"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -339,7 +339,7 @@
     <FieldSpecification
       name="z_constraint"
       component="2"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       objectPath="nodeManager"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/hydraulicFracturing/hydrofractureSinglePhase2d.xml
+++ b/inputFiles/hydraulicFracturing/hydrofractureSinglePhase2d.xml
@@ -184,7 +184,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ all }"/>
@@ -192,7 +192,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ all }"/>
@@ -200,7 +200,7 @@
     <FieldSpecification
       name="left"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -208,7 +208,7 @@
     <FieldSpecification
       name="right"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="-0.0"
       setNames="{ xpos }"/>

--- a/inputFiles/hydraulicFracturing/kgdBase_C3D6_base.xml
+++ b/inputFiles/hydraulicFracturing/kgdBase_C3D6_base.xml
@@ -96,7 +96,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ all }"/>
@@ -104,7 +104,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ all }"/>
@@ -112,7 +112,7 @@
     <FieldSpecification
       name="left"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -120,7 +120,7 @@
     <FieldSpecification
       name="right"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="-0.0"
       setNames="{ xpos }"/>

--- a/inputFiles/hydraulicFracturing/kgdToughnessDominated_base.xml
+++ b/inputFiles/hydraulicFracturing/kgdToughnessDominated_base.xml
@@ -162,7 +162,7 @@
     <FieldSpecification
       name="xConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
@@ -170,7 +170,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -178,7 +178,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/hydraulicFracturing/kgdValidation_base.xml
+++ b/inputFiles/hydraulicFracturing/kgdValidation_base.xml
@@ -159,7 +159,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>
@@ -167,7 +167,7 @@
     <FieldSpecification
       name="xConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg }"/>

--- a/inputFiles/hydraulicFracturing/kgdViscosityDominated_base.xml
+++ b/inputFiles/hydraulicFracturing/kgdViscosityDominated_base.xml
@@ -154,7 +154,7 @@
     <FieldSpecification
       name="xConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
@@ -162,7 +162,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -170,7 +170,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/hydraulicFracturing/oldFiles/Hydrofracture_KGD_EdgeBased_C3D6.xml
+++ b/inputFiles/hydraulicFracturing/oldFiles/Hydrofracture_KGD_EdgeBased_C3D6.xml
@@ -212,7 +212,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ all }"/>
@@ -220,7 +220,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ all }"/>
@@ -228,7 +228,7 @@
     <FieldSpecification
       name="left"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -236,7 +236,7 @@
     <FieldSpecification
       name="right"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="-0.0"
       setNames="{ xpos }"/>

--- a/inputFiles/hydraulicFracturing/oldFiles/Hydrofracture_KGD_NodeBased_C3D6.xml
+++ b/inputFiles/hydraulicFracturing/oldFiles/Hydrofracture_KGD_NodeBased_C3D6.xml
@@ -204,7 +204,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ all }"/>
@@ -212,7 +212,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ all }"/>
@@ -220,7 +220,7 @@
     <FieldSpecification
       name="left"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -228,7 +228,7 @@
     <FieldSpecification
       name="right"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="-0.0"
       setNames="{ xpos }"/>

--- a/inputFiles/hydraulicFracturing/oldFiles/Hydrofracture_SinglePhase_2d.xml
+++ b/inputFiles/hydraulicFracturing/oldFiles/Hydrofracture_SinglePhase_2d.xml
@@ -184,7 +184,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ all }"/>
@@ -192,7 +192,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ all }"/>
@@ -200,7 +200,7 @@
     <FieldSpecification
       name="left"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -208,7 +208,7 @@
     <FieldSpecification
       name="right"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="-0.0"
       setNames="{ xpos }"/>

--- a/inputFiles/hydraulicFracturing/oldFiles/KGD/KGD.xml
+++ b/inputFiles/hydraulicFracturing/oldFiles/KGD/KGD.xml
@@ -223,7 +223,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -231,7 +231,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ all }"/>
@@ -239,7 +239,7 @@
     <FieldSpecification
       name="left"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -247,7 +247,7 @@
     <FieldSpecification
       name="right"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="-0.0"
       setNames="{ xpos }"/>

--- a/inputFiles/hydraulicFracturing/oldFiles/KGD/KGDBase.xml
+++ b/inputFiles/hydraulicFracturing/oldFiles/KGD/KGDBase.xml
@@ -159,7 +159,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -167,7 +167,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ all }"/>
@@ -175,7 +175,7 @@
     <FieldSpecification
       name="xConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>

--- a/inputFiles/hydraulicFracturing/oldFiles/KGD/KGD_nodesNumber.xml
+++ b/inputFiles/hydraulicFracturing/oldFiles/KGD/KGD_nodesNumber.xml
@@ -215,7 +215,7 @@
     <FieldSpecification
       name="ypos"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.1"
       setNames="{ ypos }"/>
@@ -223,7 +223,7 @@
     <FieldSpecification
       name="yneg"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="-0.1"
       setNames="{ yneg }"/>
@@ -231,7 +231,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ all }"/>
@@ -239,7 +239,7 @@
     <FieldSpecification
       name="left"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -247,7 +247,7 @@
     <FieldSpecification
       name="right"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="-0.0"
       setNames="{ xpos }"/>

--- a/inputFiles/hydraulicFracturing/oldFiles/KGD/KGD_rotated.xml
+++ b/inputFiles/hydraulicFracturing/oldFiles/KGD/KGD_rotated.xml
@@ -214,7 +214,7 @@
     <FieldSpecification
       name="ypos"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ ypos, yneg }"/>
@@ -222,7 +222,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ all }"/>
@@ -230,7 +230,7 @@
     <FieldSpecification
       name="left"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -238,7 +238,7 @@
     <FieldSpecification
       name="right"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="-0.0"
       setNames="{ xpos }"/>

--- a/inputFiles/hydraulicFracturing/oldFiles/KGD/KGD_testing.xml
+++ b/inputFiles/hydraulicFracturing/oldFiles/KGD/KGD_testing.xml
@@ -256,7 +256,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -264,7 +264,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ all }"/>
@@ -272,7 +272,7 @@
     <FieldSpecification
       name="left"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -280,7 +280,7 @@
     <FieldSpecification
       name="right"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="-0.0"
       setNames="{ xpos }"/>

--- a/inputFiles/hydraulicFracturing/oldFiles/KGDBase.xml
+++ b/inputFiles/hydraulicFracturing/oldFiles/KGDBase.xml
@@ -158,7 +158,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -166,7 +166,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ all }"/>
@@ -174,7 +174,7 @@
     <FieldSpecification
       name="xConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>

--- a/inputFiles/hydraulicFracturing/oldFiles/KGDTest_GEOSX.xml
+++ b/inputFiles/hydraulicFracturing/oldFiles/KGDTest_GEOSX.xml
@@ -206,7 +206,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ all }"/>
@@ -214,7 +214,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ all }"/>
@@ -222,7 +222,7 @@
     <FieldSpecification
       name="left"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -230,7 +230,7 @@
     <FieldSpecification
       name="right"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="-0.0"
       setNames="{ xpos }"/>

--- a/inputFiles/hydraulicFracturing/oldFiles/PKNBase.xml
+++ b/inputFiles/hydraulicFracturing/oldFiles/PKNBase.xml
@@ -224,7 +224,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -232,7 +232,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>
@@ -240,7 +240,7 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>

--- a/inputFiles/hydraulicFracturing/oldFiles/pennyShapedBase.xml
+++ b/inputFiles/hydraulicFracturing/oldFiles/pennyShapedBase.xml
@@ -231,7 +231,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -239,7 +239,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>
@@ -247,7 +247,7 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>

--- a/inputFiles/hydraulicFracturing/oldFiles/walsh.xml
+++ b/inputFiles/hydraulicFracturing/oldFiles/walsh.xml
@@ -264,42 +264,42 @@
 
     <FieldSpecification name="yconstraint"
                objectPath="nodeManager"
-               fieldName="TotalDisplacement"
+               fieldName="totalDisplacement"
                component="1"
                scale="0.0"
                setNames="{yneg, ypos}"/>
 
     <FieldSpecification name="zconstraint"
                objectPath="nodeManager"
-               fieldName="TotalDisplacement"
+               fieldName="totalDisplacement"
                component="2"
                scale="0.0"
                setNames="{zneg, zpos}"/>
 
     <FieldSpecification name="xconstraint"
                objectPath="nodeManager"
-               fieldName="TotalDisplacement"
+               fieldName="totalDisplacement"
                component="0"
                scale="0.0"
                setNames="{xneg, xpos}"/>
 
     <FieldSpecification name="coreLine0"
                         objectPath="nodeManager"
-                        fieldName="TotalDisplacement"
+                        fieldName="totalDisplacement"
                         component="0"
                         scale="0.0"
                         setNames="{coreline}"/>
 
     <FieldSpecification name="coreLine1"
                         objectPath="nodeManager"
-                        fieldName="TotalDisplacement"
+                        fieldName="totalDisplacement"
                         component="1"
                         scale="0.0"
                         setNames="{coreline}"/>
 
     <FieldSpecification name="coreLine2"
                         objectPath="nodeManager"
-                        fieldName="TotalDisplacement"
+                        fieldName="totalDisplacement"
                         component="2"
                         scale="0.0"
                         setNames="{coreline}"/>

--- a/inputFiles/hydraulicFracturing/pennyShapedToughnessDominated_base.xml
+++ b/inputFiles/hydraulicFracturing/pennyShapedToughnessDominated_base.xml
@@ -102,7 +102,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -110,7 +110,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>
@@ -118,7 +118,7 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>

--- a/inputFiles/hydraulicFracturing/pennyShapedViscosityDominated_base.xml
+++ b/inputFiles/hydraulicFracturing/pennyShapedViscosityDominated_base.xml
@@ -103,7 +103,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -111,7 +111,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>
@@ -119,7 +119,7 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>

--- a/inputFiles/hydraulicFracturing/pknViscosityDominated_base.xml
+++ b/inputFiles/hydraulicFracturing/pknViscosityDominated_base.xml
@@ -103,7 +103,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -111,7 +111,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>
@@ -119,7 +119,7 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>

--- a/inputFiles/hydraulicFracturing/walshQuarterNoChombo_base.xml
+++ b/inputFiles/hydraulicFracturing/walshQuarterNoChombo_base.xml
@@ -121,42 +121,42 @@
 
     <FieldSpecification name="yconstraint"
                objectPath="nodeManager"
-               fieldName="TotalDisplacement"
+               fieldName="totalDisplacement"
                component="1"
                scale="0.0"
                setNames="{yneg, ypos}"/>
 
     <FieldSpecification name="zconstraint"
                objectPath="nodeManager"
-               fieldName="TotalDisplacement"
+               fieldName="totalDisplacement"
                component="2"
                scale="0.0"
                setNames="{zneg, zpos}"/>
 
     <FieldSpecification name="xconstraint"
                objectPath="nodeManager"
-               fieldName="TotalDisplacement"
+               fieldName="totalDisplacement"
                component="0"
                scale="0.0"
                setNames="{xneg, xpos}"/>
 
     <FieldSpecification name="coreLine0"
                         objectPath="nodeManager"
-                        fieldName="TotalDisplacement"
+                        fieldName="totalDisplacement"
                         component="0"
                         scale="0.0"
                         setNames="{coreline}"/>
 
     <FieldSpecification name="coreLine1"
                         objectPath="nodeManager"
-                        fieldName="TotalDisplacement"
+                        fieldName="totalDisplacement"
                         component="1"
                         scale="0.0"
                         setNames="{coreline}"/>
 
     <FieldSpecification name="coreLine2"
                         objectPath="nodeManager"
-                        fieldName="TotalDisplacement"
+                        fieldName="totalDisplacement"
                         component="2"
                         scale="0.0"
                         setNames="{coreline}"/>

--- a/inputFiles/lagrangianContactMechanics/ContactMechanics_PassingCrack_base.xml
+++ b/inputFiles/lagrangianContactMechanics/ContactMechanics_PassingCrack_base.xml
@@ -101,7 +101,7 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ bottomRightCorner }"/>
@@ -109,7 +109,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ bottom }"/>
@@ -117,7 +117,7 @@
     <FieldSpecification
       name="ydisplacement"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="-0.1"
       setNames="{ top }"/>
@@ -125,7 +125,7 @@
     <FieldSpecification
       name="zconstraintFront"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ front }"/>
@@ -133,7 +133,7 @@
     <FieldSpecification
       name="zconstraintRear"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ rear }"/>

--- a/inputFiles/lagrangianContactMechanics/ContactMechanics_SimpleCubes_base.xml
+++ b/inputFiles/lagrangianContactMechanics/ContactMechanics_SimpleCubes_base.xml
@@ -100,7 +100,7 @@
     <FieldSpecification
       name="xconstraintBack"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ back }"/>
@@ -108,7 +108,7 @@
     <FieldSpecification
       name="yconstraintBack"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ back }"/>
@@ -116,7 +116,7 @@
     <FieldSpecification
       name="zconstraintBack"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ back }"/>
@@ -124,7 +124,7 @@
     <FieldSpecification
       name="xconstraintBottom"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ bottom }"/>
@@ -132,7 +132,7 @@
     <FieldSpecification
       name="yconstraintBottom"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ bottom }"/>
@@ -140,7 +140,7 @@
     <FieldSpecification
       name="zconstraintBottom"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ bottom }"/>

--- a/inputFiles/lagrangianContactMechanics/ContactMechanics_SingleFracCompression_base.xml
+++ b/inputFiles/lagrangianContactMechanics/ContactMechanics_SingleFracCompression_base.xml
@@ -122,7 +122,7 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ leftPoint, rightPoint }"/>
@@ -130,7 +130,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ bottomPoint, topPoint }"/>
@@ -138,7 +138,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ front, rear }"/>

--- a/inputFiles/lagrangianContactMechanics/ContactMechanics_TFrac_base.xml
+++ b/inputFiles/lagrangianContactMechanics/ContactMechanics_TFrac_base.xml
@@ -150,7 +150,7 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xpos, xneg }"/>
@@ -158,7 +158,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ ypos, yneg }"/>
@@ -166,7 +166,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zpos, zneg }"/>

--- a/inputFiles/lagrangianContactMechanics/ContactMechanics_UnstructuredCrack_base.xml
+++ b/inputFiles/lagrangianContactMechanics/ContactMechanics_UnstructuredCrack_base.xml
@@ -100,7 +100,7 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ bottomPoint, topPoint }"/>
@@ -108,7 +108,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ leftPoint, rightPoint }"/>
@@ -116,7 +116,7 @@
     <FieldSpecification
       name="zconstraintFront"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ front }"/>
@@ -124,7 +124,7 @@
     <FieldSpecification
       name="zconstraintRear"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ rear }"/>

--- a/inputFiles/lagrangianContactMechanics/Sneddon_contactMechanics_base.xml
+++ b/inputFiles/lagrangianContactMechanics/Sneddon_contactMechanics_base.xml
@@ -137,7 +137,7 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xpos, xneg }"/>
@@ -145,7 +145,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ ypos, yneg }"/>
@@ -153,7 +153,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zpos, zneg }"/>

--- a/inputFiles/meshGeneration/multiBodyMeshGen_base.xml
+++ b/inputFiles/meshGeneration/multiBodyMeshGen_base.xml
@@ -61,7 +61,7 @@
     <FieldSpecification
       name="xnegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -69,7 +69,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -77,7 +77,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/meshGeneration/multiBodyMeshGen_smoke.xml
+++ b/inputFiles/meshGeneration/multiBodyMeshGen_smoke.xml
@@ -107,7 +107,7 @@
     <FieldSpecification
       name="xnegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -115,7 +115,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -123,7 +123,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/multipleMeshBodies/testMultipleBodies.xml
+++ b/inputFiles/multipleMeshBodies/testMultipleBodies.xml
@@ -118,7 +118,7 @@
     <FieldSpecification
       name="ypos"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="1.0e-7"
       functionName="f_b"
@@ -127,7 +127,7 @@
     <FieldSpecification
       name="yneg"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="-1.0e-7"
       functionName="f_b"
@@ -136,14 +136,14 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       setNames="{ xpos }"/>
 
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       setNames="{ all }"/>
 

--- a/inputFiles/phaseField/PhaseFieldFracture_CohesiveModel.xml
+++ b/inputFiles/phaseField/PhaseFieldFracture_CohesiveModel.xml
@@ -127,7 +127,7 @@
     <FieldSpecification
       name="xpos"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="1.0e-7"
       functionName="f_b"
@@ -136,7 +136,7 @@
     <FieldSpecification
       name="xneg"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="-1.0e-7"
       functionName="f_b"
@@ -144,7 +144,7 @@
 
     <!-- <FieldSpecification name="xconstraint1"
                objectPath="nodeManager"
-               fieldName="TotalDisplacement"
+               fieldName="totalDisplacement"
                component="0"
                scale="0.0000010"
                functionName="f_b"
@@ -152,14 +152,14 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       setNames="{ all }"/>
 
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       setNames="{ all }"/>
 

--- a/inputFiles/phaseField/PhaseFieldFracture_DamageAndLoad.xml
+++ b/inputFiles/phaseField/PhaseFieldFracture_DamageAndLoad.xml
@@ -122,7 +122,7 @@
   <FieldSpecifications>
     <FieldSpecification
       name="xtraction"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       objectPath="nodeManager"
       scale="1e-4"
@@ -131,21 +131,21 @@
 
     <FieldSpecification
       name="xfix"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       objectPath="nodeManager"
       setNames="{ xneg }"/>
 
     <FieldSpecification
       name="yfix"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       objectPath="nodeManager"
       setNames="{ all }"/>
 
     <FieldSpecification
       name="zfix"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       objectPath="nodeManager"
       setNames="{ all }"/>

--- a/inputFiles/phaseField/PhaseFieldFracture_DamageOnly.xml
+++ b/inputFiles/phaseField/PhaseFieldFracture_DamageOnly.xml
@@ -124,21 +124,21 @@
   <FieldSpecifications>
     <FieldSpecification
       name="xboundary"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       objectPath="nodeManager"
       setNames="{ all }"/>
 
     <FieldSpecification
       name="yboundary"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       objectPath="nodeManager"
       setNames="{ all }"/>
 
     <FieldSpecification
       name="zboundary"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       objectPath="nodeManager"
       setNames="{ all }"/>

--- a/inputFiles/phaseField/PhaseFieldFracture_SpectralSplit.xml
+++ b/inputFiles/phaseField/PhaseFieldFracture_SpectralSplit.xml
@@ -135,7 +135,7 @@
   <FieldSpecifications>
     <FieldSpecification
       name="shearLoad"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       objectPath="nodeManager"
       scale="1.00e-3"
@@ -144,21 +144,21 @@
 
     <FieldSpecification
       name="fixedY"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       objectPath="nodeManager"
       setNames="{ top, bottom, left, right }"/>
 
     <FieldSpecification
       name="fixedX"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       objectPath="nodeManager"
       setNames="{ bottom }"/>
 
     <FieldSpecification
       name="fixedZ"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       objectPath="nodeManager"
       setNames="{ top, bottom, left, right }"/>

--- a/inputFiles/phaseField/PhaseFieldFracture_VolDevSplit.xml
+++ b/inputFiles/phaseField/PhaseFieldFracture_VolDevSplit.xml
@@ -135,7 +135,7 @@
   <FieldSpecifications>
     <FieldSpecification
       name="shearLoad"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       objectPath="nodeManager"
       scale="1.00e-3"
@@ -144,21 +144,21 @@
 
     <FieldSpecification
       name="fixedY"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       objectPath="nodeManager"
       setNames="{ top, bottom, left, right }"/>
 
     <FieldSpecification
       name="fixedX"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       objectPath="nodeManager"
       setNames="{ bottom }"/>
 
     <FieldSpecification
       name="fixedZ"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       objectPath="nodeManager"
       setNames="{ top, bottom, left, right }"/>

--- a/inputFiles/poromechanics/PoroDelftEggWellbore_base.xml
+++ b/inputFiles/poromechanics/PoroDelftEggWellbore_base.xml
@@ -100,7 +100,7 @@
   <FieldSpecification 
     name="xconstraint"    
     objectPath="nodeManager" 
-    fieldName="TotalDisplacement" 
+    fieldName="totalDisplacement" 
     component="0" 
     scale="0.0" 
     setNames="{xneg, xpos}"
@@ -109,7 +109,7 @@
   <FieldSpecification 
     name="yconstraint"    
     objectPath="nodeManager" 
-    fieldName="TotalDisplacement" 
+    fieldName="totalDisplacement" 
     component="1" 
     scale="0.0" 
     setNames="{tneg, tpos, ypos}"
@@ -118,7 +118,7 @@
   <FieldSpecification 
     name="zconstraint" 
     objectPath="nodeManager" 
-    fieldName="TotalDisplacement" 
+    fieldName="totalDisplacement" 
     component="2" 
     scale="0.0" 
     setNames="{zneg, zpos}"

--- a/inputFiles/poromechanics/PoroDruckerPragerWellbore_base.xml
+++ b/inputFiles/poromechanics/PoroDruckerPragerWellbore_base.xml
@@ -105,7 +105,7 @@
   <FieldSpecification 
     name="xconstraint"    
     objectPath="nodeManager" 
-    fieldName="TotalDisplacement" 
+    fieldName="totalDisplacement" 
     component="0" 
     scale="0.0" 
     setNames="{xneg, xpos}"
@@ -114,7 +114,7 @@
   <FieldSpecification 
     name="yconstraint"    
     objectPath="nodeManager" 
-    fieldName="TotalDisplacement" 
+    fieldName="totalDisplacement" 
     component="1" 
     scale="0.0" 
     setNames="{tneg, tpos, ypos}"
@@ -123,7 +123,7 @@
   <FieldSpecification 
     name="zconstraint" 
     objectPath="nodeManager" 
-    fieldName="TotalDisplacement" 
+    fieldName="totalDisplacement" 
     component="2" 
     scale="0.0" 
     setNames="{zneg, zpos}"

--- a/inputFiles/poromechanics/PoroElasticWellbore_base.xml
+++ b/inputFiles/poromechanics/PoroElasticWellbore_base.xml
@@ -100,7 +100,7 @@
   <FieldSpecification 
     name="xconstraint"    
     objectPath="nodeManager" 
-    fieldName="TotalDisplacement" 
+    fieldName="totalDisplacement" 
     component="0" 
     scale="0.0" 
     setNames="{xneg, xpos}"
@@ -109,7 +109,7 @@
   <FieldSpecification 
     name="yconstraint"    
     objectPath="nodeManager" 
-    fieldName="TotalDisplacement" 
+    fieldName="totalDisplacement" 
     component="1" 
     scale="0.0" 
     setNames="{tneg, tpos, ypos}"
@@ -118,7 +118,7 @@
   <FieldSpecification 
     name="zconstraint" 
     objectPath="nodeManager" 
-    fieldName="TotalDisplacement" 
+    fieldName="totalDisplacement" 
     component="2" 
     scale="0.0" 
     setNames="{zneg, zpos}"

--- a/inputFiles/poromechanics/PoroElastic_Mandel_base.xml
+++ b/inputFiles/poromechanics/PoroElastic_Mandel_base.xml
@@ -112,7 +112,7 @@
       initialCondition="1"
       setNames="{ all }"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="1.0"
       functionName="initialUxFunc"/>
@@ -122,7 +122,7 @@
       initialCondition="1"
       setNames="{ all }"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"/>
 
@@ -131,7 +131,7 @@
       initialCondition="1"
       setNames="{ all }"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="1.0"
       functionName="initialUzFunc"/>
@@ -139,7 +139,7 @@
     <FieldSpecification
       name="xnegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -147,7 +147,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -155,7 +155,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg }"/>
@@ -163,7 +163,7 @@
     <FieldSpecification
       name="NormalDisplacement"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="-1.0e-5"
       setNames="{ zpos }"
@@ -210,7 +210,7 @@
     <PackCollection
       name="displacementCollection"
       objectPath="nodeManager" 
-      fieldName="TotalDisplacement"/>  
+      fieldName="totalDisplacement"/>  
   </Tasks>
   <!-- SPHINX_TASKS_END -->
 

--- a/inputFiles/poromechanics/PoroElastic_Terzaghi_base_direct.xml
+++ b/inputFiles/poromechanics/PoroElastic_Terzaghi_base_direct.xml
@@ -101,7 +101,7 @@
       initialCondition="1"
       setNames="{ all }"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"/>
 
@@ -110,7 +110,7 @@
       initialCondition="1"
       setNames="{ all }"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"/>
 
@@ -119,14 +119,14 @@
       initialCondition="1"
       setNames="{ all }"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"/>
 
     <FieldSpecification
       name="xnegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xpos }"/>
@@ -134,7 +134,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -142,7 +142,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/poromechanics/PoroElastic_Terzaghi_base_iterative.xml
+++ b/inputFiles/poromechanics/PoroElastic_Terzaghi_base_iterative.xml
@@ -102,7 +102,7 @@
       initialCondition="1"
       setNames="{ all }"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"/>
 
@@ -111,7 +111,7 @@
       initialCondition="1"
       setNames="{ all }"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"/>
 
@@ -120,14 +120,14 @@
       initialCondition="1"
       setNames="{ all }"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"/>
 
     <FieldSpecification
       name="xnegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xpos }"/>
@@ -135,7 +135,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -143,7 +143,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/poromechanics/PoroElastic_deadoil_3ph_baker_2d.xml
+++ b/inputFiles/poromechanics/PoroElastic_deadoil_3ph_baker_2d.xml
@@ -263,7 +263,7 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
@@ -271,7 +271,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -279,7 +279,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg }"/>
@@ -302,12 +302,12 @@
 
     <Silo
       name="siloOutput"
-      fieldNames="{ TotalDisplacement, pressure, skeleton_stress, deltaPressure }"/>
+      fieldNames="{ totalDisplacement, pressure, skeleton_stress, deltaPressure }"/>
 
     <VTK
       name="vtkOutput"
       onlyPlotSpecifiedFieldNames="1"
-      fieldNames="{ TotalDisplacement, pressure, skeleton_stress, skeleton_density }"/>
+      fieldNames="{ totalDisplacement, pressure, skeleton_stress, skeleton_density }"/>
 
     <Restart
       name="restartOutput"/>

--- a/inputFiles/poromechanics/PoroElastic_embFractures.xml
+++ b/inputFiles/poromechanics/PoroElastic_embFractures.xml
@@ -199,7 +199,7 @@
     <FieldSpecification
       name="xnegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
@@ -207,7 +207,7 @@
     <FieldSpecification
       name="yposconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ ypos, yneg }"/>
@@ -215,7 +215,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/poromechanics/PoroElastic_staircase_co2_3d.xml
+++ b/inputFiles/poromechanics/PoroElastic_staircase_co2_3d.xml
@@ -244,21 +244,21 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg }"/>

--- a/inputFiles/poromechanics/PoroElastic_staircase_singlephase_3d.xml
+++ b/inputFiles/poromechanics/PoroElastic_staircase_singlephase_3d.xml
@@ -227,21 +227,21 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg }"/>

--- a/inputFiles/poromechanics/PoroModifiedCamClayWellbore_base.xml
+++ b/inputFiles/poromechanics/PoroModifiedCamClayWellbore_base.xml
@@ -100,7 +100,7 @@
   <FieldSpecification 
     name="xconstraint"    
     objectPath="nodeManager" 
-    fieldName="TotalDisplacement" 
+    fieldName="totalDisplacement" 
     component="0" 
     scale="0.0" 
     setNames="{xneg, xpos}"
@@ -109,7 +109,7 @@
   <FieldSpecification 
     name="yconstraint"    
     objectPath="nodeManager" 
-    fieldName="TotalDisplacement" 
+    fieldName="totalDisplacement" 
     component="1" 
     scale="0.0" 
     setNames="{tneg, tpos, ypos}"
@@ -118,7 +118,7 @@
   <FieldSpecification 
     name="zconstraint" 
     objectPath="nodeManager" 
-    fieldName="TotalDisplacement" 
+    fieldName="totalDisplacement" 
     component="2" 
     scale="0.0" 
     setNames="{zneg, zpos}"

--- a/inputFiles/poromechanics/SlipPermeability_embeddedFrac.xml
+++ b/inputFiles/poromechanics/SlipPermeability_embeddedFrac.xml
@@ -284,7 +284,7 @@
     <FieldSpecification
       name="xnegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ bottomPoint, topPoint }"/>
@@ -292,7 +292,7 @@
     <FieldSpecification
       name="yposconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ leftPoint, rightPoint }"/>
@@ -300,7 +300,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/poromechanics/SlipPermeability_pEDFM_base.xml
+++ b/inputFiles/poromechanics/SlipPermeability_pEDFM_base.xml
@@ -168,7 +168,7 @@
     <FieldSpecification
       name="xnegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ bottomPoint, topPoint }"/>
@@ -176,7 +176,7 @@
     <FieldSpecification
       name="yposconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ leftPoint, rightPoint }"/>
@@ -184,7 +184,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>
@@ -244,7 +244,7 @@
     <PackCollection
       name="totalDisplacementCollection"
       objectPath="nodeManager" 
-      fieldName="TotalDisplacement"/> 
+      fieldName="totalDisplacement"/> 
            
   </Tasks>
 

--- a/inputFiles/poromechanics/faultPoroelastic_base.xml
+++ b/inputFiles/poromechanics/faultPoroelastic_base.xml
@@ -110,7 +110,7 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ 89, 88 }"/>
@@ -118,7 +118,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ 90 }"/>
@@ -126,7 +126,7 @@
     <FieldSpecification
       name="zconstraintFront"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ 92, 93 }"/>

--- a/inputFiles/solidMechanics/ExtendedDruckerPragerWellbore_base.xml
+++ b/inputFiles/solidMechanics/ExtendedDruckerPragerWellbore_base.xml
@@ -75,7 +75,7 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
@@ -83,7 +83,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ tneg, tpos, ypos }"/>
@@ -91,7 +91,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/solidMechanics/KirschProblem_base.xml
+++ b/inputFiles/solidMechanics/KirschProblem_base.xml
@@ -65,7 +65,7 @@
     <FieldSpecification 
       name="xconstraint"    
       objectPath="nodeManager" 
-      fieldName="TotalDisplacement" 
+      fieldName="totalDisplacement" 
       component="0" 
       scale="0.0" 
       setNames="{xneg, xpos}"
@@ -74,7 +74,7 @@
     <FieldSpecification 
       name="yconstraint"    
       objectPath="nodeManager" 
-      fieldName="TotalDisplacement" 
+      fieldName="totalDisplacement" 
       component="1" 
       scale="0.0" 
       setNames="{tneg, tpos, ypos}"
@@ -83,7 +83,7 @@
     <FieldSpecification 
       name="zconstraint" 
       objectPath="nodeManager" 
-      fieldName="TotalDisplacement" 
+      fieldName="totalDisplacement" 
       component="2" 
       scale="0.0" 
       setNames="{zneg, zpos}"
@@ -101,7 +101,7 @@
     <PackCollection
       name="displacementCollection"
       objectPath="nodeManager" 
-      fieldName="TotalDisplacement"/>      
+      fieldName="totalDisplacement"/>      
   </Tasks>
 <!-- SPHINX_TASKS_END -->
 

--- a/inputFiles/solidMechanics/ModifiedCamClayWellbore_base.xml
+++ b/inputFiles/solidMechanics/ModifiedCamClayWellbore_base.xml
@@ -76,7 +76,7 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
@@ -84,7 +84,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ tneg, tpos, ypos }"/>
@@ -92,7 +92,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>   

--- a/inputFiles/solidMechanics/OpenWellbore.xml
+++ b/inputFiles/solidMechanics/OpenWellbore.xml
@@ -99,7 +99,7 @@
     <FieldSpecification
       name="xConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ rpos }"/>
@@ -107,7 +107,7 @@
     <FieldSpecification
       name="yConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ rpos }"/>
@@ -115,7 +115,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/solidMechanics/beamBending_base.xml
+++ b/inputFiles/solidMechanics/beamBending_base.xml
@@ -62,7 +62,7 @@
     <FieldSpecification
       name="xnegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -70,7 +70,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -78,7 +78,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/solidMechanics/benchmarks/SSLE-QS-small.xml
+++ b/inputFiles/solidMechanics/benchmarks/SSLE-QS-small.xml
@@ -67,7 +67,7 @@
     <FieldSpecification
       name="xnegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -75,7 +75,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -83,7 +83,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/solidMechanics/benchmarks/SSLE-io.xml
+++ b/inputFiles/solidMechanics/benchmarks/SSLE-io.xml
@@ -152,7 +152,7 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="Velocity"
+      fieldName="velocity"
       component="0"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -160,7 +160,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="Velocity"
+      fieldName="velocity"
       component="1"
       scale="0.0"
       setNames="{ yneg }"/>
@@ -168,7 +168,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="Velocity"
+      fieldName="velocity"
       component="2"
       scale="0.0"
       setNames="{ zneg }"/>

--- a/inputFiles/solidMechanics/benchmarks/VerticalElasticWellbore.xml
+++ b/inputFiles/solidMechanics/benchmarks/VerticalElasticWellbore.xml
@@ -99,7 +99,7 @@
     <FieldSpecification
       name="xConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ tpos, xpos }"/>
@@ -107,7 +107,7 @@
     <FieldSpecification
       name="yConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ tneg, ypos }"/>
@@ -115,7 +115,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/solidMechanics/casedWellbore.xml
+++ b/inputFiles/solidMechanics/casedWellbore.xml
@@ -123,7 +123,7 @@
     <FieldSpecification
       name="xConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
@@ -131,7 +131,7 @@
     <FieldSpecification
       name="yConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -139,7 +139,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/solidMechanics/elasticHollowCylinder.xml
+++ b/inputFiles/solidMechanics/elasticHollowCylinder.xml
@@ -108,7 +108,7 @@
     <FieldSpecification
       name="xnegConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xConstraint }"/>
@@ -116,7 +116,7 @@
     <FieldSpecification
       name="ynegConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yConstraint }"/>
@@ -124,7 +124,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/solidMechanics/gravity.xml
+++ b/inputFiles/solidMechanics/gravity.xml
@@ -99,7 +99,7 @@
     <FieldSpecification
       name="x_constraint"
       component="0"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       objectPath="nodeManager"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
@@ -107,7 +107,7 @@
     <FieldSpecification
       name="y_constraint"
       component="1"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       objectPath="nodeManager"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -115,7 +115,7 @@
     <FieldSpecification
       name="z_constraint"
       component="2"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       objectPath="nodeManager"
       scale="0.0"
       setNames="{ zneg }"/>

--- a/inputFiles/solidMechanics/mechanicsWithHeterogeneousMaterials.xml
+++ b/inputFiles/solidMechanics/mechanicsWithHeterogeneousMaterials.xml
@@ -169,7 +169,7 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="Velocity"
+      fieldName="velocity"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
@@ -177,7 +177,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="Velocity"
+      fieldName="velocity"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -185,7 +185,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="Velocity"
+      fieldName="velocity"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/solidMechanics/plasticCubeReset.xml
+++ b/inputFiles/solidMechanics/plasticCubeReset.xml
@@ -114,7 +114,7 @@
     <FieldSpecification
       name="xConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ zneg }"/>
@@ -122,7 +122,7 @@
     <FieldSpecification
       name="yConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ zneg }"/>
@@ -130,7 +130,7 @@
     <FieldSpecification
       name="zConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg }"/>

--- a/inputFiles/solidMechanics/sedov_base.xml
+++ b/inputFiles/solidMechanics/sedov_base.xml
@@ -67,7 +67,7 @@
     <FieldSpecification
       name="xconstraint"
       objectPath="nodeManager"
-      fieldName="Velocity"
+      fieldName="velocity"
       component="0"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -75,7 +75,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="Velocity"
+      fieldName="velocity"
       component="1"
       scale="0.0"
       setNames="{ yneg }"/>
@@ -83,7 +83,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="Velocity"
+      fieldName="velocity"
       component="2"
       scale="0.0"
       setNames="{ zneg }"/>
@@ -112,7 +112,7 @@
       name="velocityCollection"
       objectPath="nodeManager"
       setNames="{ source }"
-      fieldName="Velocity"/>
+      fieldName="velocity"/>
   </Tasks>
 
   <Geometry>

--- a/inputFiles/solidMechanics/solidMechBlock.xml
+++ b/inputFiles/solidMechanics/solidMechBlock.xml
@@ -89,7 +89,7 @@
     <FieldSpecification
       name="xnegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
@@ -97,7 +97,7 @@
     <FieldSpecification
       name="yconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ ypos }"/>
@@ -105,7 +105,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/surfaceGeneration/DryFrac_StaticPenny_PrismElem.xml
+++ b/inputFiles/surfaceGeneration/DryFrac_StaticPenny_PrismElem.xml
@@ -121,7 +121,7 @@
       name="x"
       component="0"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
 
@@ -129,7 +129,7 @@
       name="y"
       component="1"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
 
@@ -150,7 +150,7 @@
       name="znegconstraint"
       component="2"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       scale="0.0"
       setNames="{ zneg }"/>
   </FieldSpecifications>

--- a/inputFiles/surfaceGeneration/DryFrac_ThreeNodesPinched_HorizontalFrac.xml
+++ b/inputFiles/surfaceGeneration/DryFrac_ThreeNodesPinched_HorizontalFrac.xml
@@ -119,7 +119,7 @@
       name="x"
       component="0"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
 
@@ -127,7 +127,7 @@
       name="y"
       component="1"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
 
@@ -135,7 +135,7 @@
       name="zposconstraint"
       component="2"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       scale="0.001"
       setNames="{ zpos }"/>
 
@@ -143,7 +143,7 @@
       name="znegconstraint"
       component="2"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       setNames="{ zneg }"/>
   </FieldSpecifications>
 

--- a/inputFiles/surfaceGeneration/DryFrac_ThreeNodesPinched_SlantFrac.xml
+++ b/inputFiles/surfaceGeneration/DryFrac_ThreeNodesPinched_SlantFrac.xml
@@ -121,7 +121,7 @@
       name="x"
       component="0"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
 
@@ -129,7 +129,7 @@
       name="z"
       component="2"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       scale="0.0"
       setNames="{ zneg, zpos }"/>
 
@@ -137,14 +137,14 @@
       name="yposConstraint"
       component="1"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       scale="0.001"
       setNames="{ ypos }"/>
 
     <FieldSpecification
       name="ynegconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       setNames="{ yneg }"/>
   </FieldSpecifications>

--- a/inputFiles/surfaceGeneration/SurfaceGenerator.xml
+++ b/inputFiles/surfaceGeneration/SurfaceGenerator.xml
@@ -127,7 +127,7 @@
       name="xneg"
       component="0"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       scale="-0.1"
       setNames="{ xneg }"/>
 
@@ -135,7 +135,7 @@
       name="xpos"
       component="0"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       scale="0.1"
       setNames="{ xpos }"/>
 
@@ -143,7 +143,7 @@
       name="zneg"
       component="2"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       scale="-0.1"
       setNames="{ zneg }"/>
 
@@ -151,7 +151,7 @@
       name="zpos"
       component="2"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       scale="0.1"
       setNames="{ zpos }"/>
 
@@ -159,7 +159,7 @@
       name="bot"
       component="1"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       scale="-0.1"
       setNames="{ yneg }"/>
 
@@ -167,7 +167,7 @@
       name="top"
       component="1"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       scale="0.1"
       setNames="{ ypos }"/>
   </FieldSpecifications>

--- a/inputFiles/wellbore/CasedElasticWellbore_base.xml
+++ b/inputFiles/wellbore/CasedElasticWellbore_base.xml
@@ -86,7 +86,7 @@
     <FieldSpecification
       name="xConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
@@ -94,7 +94,7 @@
     <FieldSpecification
       name="yConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ yneg, ypos }"/>
@@ -102,7 +102,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/wellbore/DeviatedElasticWellbore_base.xml
+++ b/inputFiles/wellbore/DeviatedElasticWellbore_base.xml
@@ -64,7 +64,7 @@
     <FieldSpecification
       name="xConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg }"/>
@@ -72,7 +72,7 @@
     <FieldSpecification
       name="yConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ tneg, tpos }"/>
@@ -80,7 +80,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg }"/>

--- a/inputFiles/wellbore/DeviatedPoroElasticWellbore_Drilling_base.xml
+++ b/inputFiles/wellbore/DeviatedPoroElasticWellbore_Drilling_base.xml
@@ -142,7 +142,7 @@
     <FieldSpecification
       name="xConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
@@ -150,7 +150,7 @@
     <FieldSpecification
       name="yConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ tneg, tpos, ypos }"/>
@@ -158,7 +158,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/inputFiles/wellbore/DeviatedPoroElasticWellbore_Injection_base.xml
+++ b/inputFiles/wellbore/DeviatedPoroElasticWellbore_Injection_base.xml
@@ -102,7 +102,7 @@
     <FieldSpecification
       name="xConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="0"
       scale="0.0"
       setNames="{ xneg, xpos }"/>
@@ -110,7 +110,7 @@
     <FieldSpecification
       name="yConstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="1"
       scale="0.0"
       setNames="{ tneg, tpos, ypos }"/>
@@ -118,7 +118,7 @@
     <FieldSpecification
       name="zconstraint"
       objectPath="nodeManager"
-      fieldName="TotalDisplacement"
+      fieldName="totalDisplacement"
       component="2"
       scale="0.0"
       setNames="{ zneg, zpos }"/>

--- a/src/coreComponents/dataRepository/KeyNames.hpp
+++ b/src/coreComponents/dataRepository/KeyNames.hpp
@@ -30,41 +30,11 @@ namespace keys
 
 /// @cond DO_NOT_DOCUMENT
 
-//static constexpr auto ReferencePosition = "ReferencePosition";
-static constexpr auto referencePositionString = "ReferencePosition";
-
-static constexpr auto TotalDisplacement = "TotalDisplacement";
-static constexpr auto IncrementalDisplacement = "IncrementalDisplacement";
-static constexpr auto Velocity = "Velocity";
-static constexpr auto Acceleration = "Acceleration";
-static constexpr auto Mass = "Mass";
-static constexpr auto Force = "Force";
-static constexpr auto Strain = "Strain";
-static constexpr auto Name = "name";
-static constexpr auto Size = "size";
 static constexpr auto ProblemManager = "Problem";
 static constexpr auto ConstitutiveManager = "Constitutive";
-static constexpr auto ConstitutiveBase = "ConstitutiveBase";
-static constexpr auto solverNames = "solverNames";
-
 static constexpr auto schema = "schema";
-
-static constexpr auto time = "time";
-static constexpr auto cycle = "cycle";
-static constexpr auto beginTime = "beginTime";
-static constexpr auto endTime = "endTime";
-static constexpr auto dt = "dt";
-
 static constexpr auto domain  = "domain";
-static constexpr auto solvers = "solvers";
-static constexpr auto simulationParameterMap = "simulationParameterMap";
-static constexpr auto FE_Space    = "FE_Space";
-//static constexpr auto FEM_Nodes    = "FEM_Nodes";
-//static constexpr auto FEM_Edges    = "FEM_Edges";
-//static constexpr auto FEM_Faces    = "FEM_Faces";
-//static constexpr auto FEM_Elements = "FEM_Elements";
 static constexpr auto cellManager = "cellManager";
-static constexpr auto functionManager = "FunctionManager";
 
 /// @endcond
 

--- a/src/coreComponents/fileIO/silo/SiloFile.cpp
+++ b/src/coreComponents/fileIO/silo/SiloFile.cpp
@@ -35,6 +35,7 @@
 #include "fileIO/Outputs/OutputUtilities.hpp"
 #include "mesh/DomainPartition.hpp"
 #include "mesh/MeshBody.hpp"
+#include "physicsSolvers/solidMechanics/SolidMechanicsExtrinsicData.hpp"
 
 #include <iostream>
 
@@ -1625,7 +1626,7 @@ void SiloFile::writeMeshLevel( MeshLevel const & meshLevel,
     }
   }
 
-  if( nodeManager.hasWrapper( keys::TotalDisplacement ) )
+  if( nodeManager.hasWrapper( extrinsicMeshData::solidMechanics::totalDisplacement::key() ) )
   {
     arrayView2d< real64 const, nodes::TOTAL_DISPLACEMENT_USD > const & totalDisplacement = nodeManager.totalDisplacement();
     for( localIndex a = 0; a < numNodes; ++a )

--- a/src/coreComponents/mesh/NodeManager.hpp
+++ b/src/coreComponents/mesh/NodeManager.hpp
@@ -22,6 +22,7 @@
 #include "mesh/generators/CellBlockManagerABC.hpp"
 #include "mesh/ObjectManagerBase.hpp"
 #include "mesh/simpleGeometricObjects/GeometricObjectManager.hpp"
+#include "physicsSolvers/solidMechanics/SolidMechanicsExtrinsicData.hpp"
 #include "ToElementRelation.hpp"
 
 namespace geosx
@@ -247,12 +248,6 @@ public:
     /// @return String to access the location of the nodes
     static constexpr char const * EmbSurfNodesPositionString() { return "EmbSurfNodesPosition"; }
 
-    /// @return String to access the displacement
-    static constexpr char const * totalDisplacementString() { return "TotalDisplacement"; }
-
-    /// @return String to access the incremental displacement
-    static constexpr char const * incrementalDisplacementString() { return "IncrementalDisplacement"; }
-
     /// @return String to access the edge map
     static constexpr char const * edgeListString() { return "edgeList"; }
 
@@ -271,12 +266,6 @@ public:
     /// Accessor to reference position
     dataRepository::ViewKey referencePosition       = { referencePositionString() };
 
-    /// Accessor to displacement
-    dataRepository::ViewKey totalDisplacement       = { totalDisplacementString() };
-
-    /// Accessor to incremental displacement
-    dataRepository::ViewKey incrementalDisplacement = { incrementalDisplacementString() };
-
     /// Accessor to edge map
     dataRepository::ViewKey edgeList                = { edgeListString() };
 
@@ -292,11 +281,6 @@ public:
     /// Accessor to element map
     dataRepository::ViewKey elementList             = { elementListString() };
 
-    /// Accessor to velocity
-    dataRepository::ViewKey velocity                = { dataRepository::keys::Velocity };
-
-    /// Accessor to acceleration
-    dataRepository::ViewKey acceleration            = { dataRepository::keys::Acceleration };
   }
   /// viewKeys
   viewKeys;
@@ -424,7 +408,7 @@ public:
    * @note An error is thrown if the total displacement does not exist
    */
   array2d< real64, nodes::TOTAL_DISPLACEMENT_PERM > & totalDisplacement()
-  { return getReference< array2d< real64, nodes::TOTAL_DISPLACEMENT_PERM > >( viewKeys.totalDisplacement ); }
+  { return getExtrinsicData< extrinsicMeshData::solidMechanics::totalDisplacement >(); }
 
   /**
    * @brief Provide an immutable arrayView to the total displacement array.
@@ -432,7 +416,7 @@ public:
    * @note An error is thrown if the total displacement does not exist
    */
   arrayView2d< real64 const, nodes::TOTAL_DISPLACEMENT_USD > totalDisplacement() const
-  {return getReference< array2d< real64, nodes::TOTAL_DISPLACEMENT_PERM > >( viewKeys.totalDisplacement ); }
+  { return getExtrinsicData< extrinsicMeshData::solidMechanics::totalDisplacement >(); }
 
   /**
    * @brief Get a mutable incremental displacement array.
@@ -440,7 +424,7 @@ public:
    * @note An error is thrown if the incremental displacement does not exist
    */
   array2d< real64, nodes::INCR_DISPLACEMENT_PERM > & incrementalDisplacement()
-  { return getReference< array2d< real64, nodes::INCR_DISPLACEMENT_PERM > >( viewKeys.incrementalDisplacement ); }
+  { return getExtrinsicData< extrinsicMeshData::solidMechanics::incrementalDisplacement >(); }
 
   /**
    * @brief Provide an immutable arrayView to the incremental displacement array.
@@ -448,7 +432,7 @@ public:
    * @note An error is thrown if the total incremental does not exist
    */
   arrayView2d< real64 const, nodes::INCR_DISPLACEMENT_USD > incrementalDisplacement() const
-  { return getReference< array2d< real64, nodes::INCR_DISPLACEMENT_PERM > >( viewKeys.incrementalDisplacement ); }
+  { return getExtrinsicData< extrinsicMeshData::solidMechanics::incrementalDisplacement >(); }
 
   /**
    * @brief Get a mutable velocity array.
@@ -456,7 +440,7 @@ public:
    * @note An error is thrown if the velocity array does not exist
    */
   array2d< real64, nodes::VELOCITY_PERM > & velocity()
-  { return getReference< array2d< real64, nodes::VELOCITY_PERM > >( viewKeys.velocity ); }
+  { return getExtrinsicData< extrinsicMeshData::solidMechanics::velocity >(); }
 
   /**
    * @brief Provide an immutable arrayView to the velocity array.
@@ -464,7 +448,7 @@ public:
    * @note An error is thrown if the velocity array does not exist
    */
   arrayView2d< real64 const, nodes::VELOCITY_USD > velocity() const
-  { return getReference< array2d< real64, nodes::VELOCITY_PERM > >( viewKeys.velocity ); }
+  { return getExtrinsicData< extrinsicMeshData::solidMechanics::velocity >(); }
 
   /**
    * @brief Get a mutable acceleration array.
@@ -472,7 +456,7 @@ public:
    * @note An error is thrown if the acceleration array does not exist
    */
   array2d< real64, nodes::ACCELERATION_PERM > & acceleration()
-  { return getReference< array2d< real64, nodes::ACCELERATION_PERM > >( viewKeys.acceleration ); }
+  { return getExtrinsicData< extrinsicMeshData::solidMechanics::acceleration >(); }
 
   /**
    * @brief Provide an immutable arrayView to the acceleration array.
@@ -480,7 +464,7 @@ public:
    * @note An error is thrown if the acceleration array does not exist
    */
   arrayView2d< real64 const, nodes::ACCELERATION_USD > acceleration() const
-  { return getReference< array2d< real64, nodes::ACCELERATION_PERM > >( viewKeys.acceleration ); }
+  { return getExtrinsicData< extrinsicMeshData::solidMechanics::acceleration >(); }
 
   ///@}
 

--- a/src/coreComponents/physicsSolvers/CMakeLists.txt
+++ b/src/coreComponents/physicsSolvers/CMakeLists.txt
@@ -79,6 +79,7 @@ set( physicsSolvers_headers
      simplePDE/LaplaceFEMKernels.hpp
      simplePDE/PhaseFieldDamageFEM.hpp
      simplePDE/PhaseFieldDamageFEMKernels.hpp
+     solidMechanics/SolidMechanicsExtrinsicData.hpp	
      solidMechanics/SolidMechanicsFiniteStrainExplicitNewmarkKernel.hpp
      solidMechanics/SolidMechanicsLagrangianFEM.hpp
      solidMechanics/SolidMechanicsLagrangianFEMKernels.hpp

--- a/src/coreComponents/physicsSolvers/contact/LagrangianContactSolver.cpp
+++ b/src/coreComponents/physicsSolvers/contact/LagrangianContactSolver.cpp
@@ -65,7 +65,7 @@ LagrangianContactSolver::LagrangianContactSolver( const string & name,
 
   m_linearSolverParameters.get().mgr.strategy = LinearSolverParameters::MGR::StrategyType::lagrangianContactMechanics;
   m_linearSolverParameters.get().mgr.separateComponents = true;
-  m_linearSolverParameters.get().mgr.displacementFieldName = keys::TotalDisplacement;
+  m_linearSolverParameters.get().mgr.displacementFieldName = extrinsicMeshData::solidMechanics::totalDisplacement::key();
   m_linearSolverParameters.get().dofsPerNode = 3;
 }
 
@@ -540,7 +540,7 @@ void LagrangianContactSolver::setupDofs( DomainPartition const & domain,
                           extrinsicMeshData::contact::traction::key(),
                           DofManager::Connector::Face,
                           meshTargets );
-  dofManager.addCoupling( keys::TotalDisplacement,
+  dofManager.addCoupling( extrinsicMeshData::solidMechanics::totalDisplacement::key(),
                           extrinsicMeshData::contact::traction::key(),
                           DofManager::Connector::Elem,
                           meshTargets );
@@ -584,7 +584,7 @@ real64 LagrangianContactSolver::calculateResidualNorm( DomainPartition const & d
   {
     NodeManager const & nodeManager = mesh.getNodeManager();
     arrayView1d< globalIndex const > const & dispDofNumber =
-      nodeManager.getReference< array1d< globalIndex > >( dofManager.getKey( keys::TotalDisplacement ) );
+      nodeManager.getReference< array1d< globalIndex > >( dofManager.getKey( extrinsicMeshData::solidMechanics::totalDisplacement::key() ) );
 
     string const & dofKey = dofManager.getKey( extrinsicMeshData::contact::traction::key() );
     globalIndex const rankOffset = dofManager.rankOffset();
@@ -735,7 +735,7 @@ void LagrangianContactSolver::createPreconditioner( DomainPartition const & doma
         MeshLevel const & mesh = domain.getMeshBody( 0 ).getBaseDiscretization();
         LAIHelperFunctions::computeRigidBodyModes( mesh,
                                                    m_dofManager,
-                                                   { keys::TotalDisplacement },
+                                                   { extrinsicMeshData::solidMechanics::totalDisplacement::key() },
                                                    m_solidSolver->getRigidBodyModes() );
       }
     }
@@ -743,7 +743,7 @@ void LagrangianContactSolver::createPreconditioner( DomainPartition const & doma
     // Preconditioner for the Schur complement: mechPrecond
     std::unique_ptr< PreconditionerBase< LAInterface > > mechPrecond = LAInterface::createPreconditioner( mechParams, m_solidSolver->getRigidBodyModes() );
     precond->setupBlock( 1,
-                         { { keys::TotalDisplacement, { 3, true } } },
+                         { { extrinsicMeshData::solidMechanics::totalDisplacement::key(), { 3, true } } },
                          std::move( mechPrecond ) );
 
     m_precond = std::move( precond );
@@ -880,7 +880,7 @@ void LagrangianContactSolver::
     ArrayOfArraysView< localIndex const > const faceToNodeMap = faceManager.nodeList().toViewConst();
 
     string const & tracDofKey = dofManager.getKey( extrinsicMeshData::contact::traction::key() );
-    string const & dispDofKey = dofManager.getKey( keys::TotalDisplacement );
+    string const & dispDofKey = dofManager.getKey( extrinsicMeshData::solidMechanics::totalDisplacement::key() );
 
     arrayView1d< globalIndex const > const & dispDofNumber = nodeManager.getReference< globalIndex_array >( dispDofKey );
     globalIndex const rankOffset = dofManager.rankOffset();
@@ -1016,7 +1016,7 @@ void LagrangianContactSolver::
     ArrayOfArraysView< localIndex const > const faceToNodeMap = faceManager.nodeList().toViewConst();
 
     string const & tracDofKey = dofManager.getKey( extrinsicMeshData::contact::traction::key() );
-    string const & dispDofKey = dofManager.getKey( keys::TotalDisplacement );
+    string const & dispDofKey = dofManager.getKey( extrinsicMeshData::solidMechanics::totalDisplacement::key() );
 
     arrayView1d< globalIndex const > const & dispDofNumber = nodeManager.getReference< globalIndex_array >( dispDofKey );
     globalIndex const rankOffset = dofManager.rankOffset();

--- a/src/coreComponents/physicsSolvers/contact/SolidMechanicsEmbeddedFractures.cpp
+++ b/src/coreComponents/physicsSolvers/contact/SolidMechanicsEmbeddedFractures.cpp
@@ -29,6 +29,7 @@
 #include "fieldSpecification/FieldSpecificationManager.hpp"
 #include "mesh/NodeManager.hpp"
 #include "mesh/SurfaceElementRegion.hpp"
+#include "physicsSolvers/solidMechanics/SolidMechanicsExtrinsicData.hpp"
 #include "physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.hpp"
 #include "common/GEOS_RAJA_Interface.hpp"
 #include "physicsSolvers/contact/SolidMechanicsEFEMKernels.hpp"
@@ -77,7 +78,7 @@ void SolidMechanicsEmbeddedFractures::postProcessInput()
   {
     linParams.mgr.strategy = LinearSolverParameters::MGR::StrategyType::solidMechanicsEmbeddedFractures;
     linParams.mgr.separateComponents = true;
-    linParams.mgr.displacementFieldName = keys::TotalDisplacement;
+    linParams.mgr.displacementFieldName = extrinsicMeshData::solidMechanics::totalDisplacement::key();
   }
 }
 
@@ -301,7 +302,7 @@ void SolidMechanicsEmbeddedFractures::assembleSystem( real64 const time,
     SurfaceElementRegion & region = elemManager.getRegion< SurfaceElementRegion >( m_fractureRegionName );
     EmbeddedSurfaceSubRegion & subRegion = region.getSubRegion< EmbeddedSurfaceSubRegion >( 0 );
 
-    string const dispDofKey = dofManager.getKey( dataRepository::keys::TotalDisplacement );
+    string const dispDofKey = dofManager.getKey( extrinsicMeshData::solidMechanics::totalDisplacement::key() );
 
     arrayView1d< globalIndex const > const dispDofNumber = nodeManager.getReference< globalIndex_array >( dispDofKey );
 
@@ -371,7 +372,7 @@ void SolidMechanicsEmbeddedFractures::addCouplingNumNonzeros( DomainPartition & 
     ElementRegionManager const & elemManager = mesh.getElemManager();
 
     string const jumpDofKey = dofManager.getKey( extrinsicMeshData::contact::dispJump::key() );
-    string const dispDofKey = dofManager.getKey( keys::TotalDisplacement );
+    string const dispDofKey = dofManager.getKey( extrinsicMeshData::solidMechanics::totalDisplacement::key() );
 
     arrayView1d< globalIndex const > const &
     dispDofNumber =  nodeManager.getReference< globalIndex_array >( dispDofKey );
@@ -439,7 +440,7 @@ void SolidMechanicsEmbeddedFractures::addCouplingSparsityPattern( DomainPartitio
     ElementRegionManager const & elemManager = mesh.getElemManager();
 
     string const jumpDofKey = dofManager.getKey( extrinsicMeshData::contact::dispJump::key() );
-    string const dispDofKey = dofManager.getKey( keys::TotalDisplacement );
+    string const dispDofKey = dofManager.getKey( extrinsicMeshData::solidMechanics::totalDisplacement::key() );
 
     arrayView1d< globalIndex const > const &
     dispDofNumber =  nodeManager.getReference< globalIndex_array >( dispDofKey );
@@ -693,7 +694,7 @@ void SolidMechanicsEmbeddedFractures::updateJump( DofManager const & dofManager,
     SurfaceElementRegion & region = elemManager.getRegion< SurfaceElementRegion >( m_fractureRegionName );
     EmbeddedSurfaceSubRegion & subRegion = region.getSubRegion< EmbeddedSurfaceSubRegion >( 0 );
 
-    string const dispDofKey = dofManager.getKey( dataRepository::keys::TotalDisplacement );
+    string const dispDofKey = dofManager.getKey( extrinsicMeshData::solidMechanics::totalDisplacement::key() );
 
     arrayView1d< globalIndex const > const dispDofNumber = nodeManager.getReference< globalIndex_array >( dispDofKey );
 

--- a/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoromechanicsSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoromechanicsSolver.cpp
@@ -22,6 +22,7 @@
 #include "constitutive/solid/PorousSolid.hpp"
 #include "physicsSolvers/fluidFlow/CompositionalMultiphaseBase.hpp"
 #include "physicsSolvers/multiphysics/MultiphasePoromechanicsKernel.hpp"
+#include "physicsSolvers/solidMechanics/SolidMechanicsExtrinsicData.hpp"
 #include "physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.hpp"
 
 namespace geosx
@@ -36,7 +37,7 @@ MultiphasePoromechanicsSolver::MultiphasePoromechanicsSolver( const string & nam
 {
   m_linearSolverParameters.get().mgr.strategy = LinearSolverParameters::MGR::StrategyType::multiphasePoromechanics;
   m_linearSolverParameters.get().mgr.separateComponents = true;
-  m_linearSolverParameters.get().mgr.displacementFieldName = keys::TotalDisplacement;
+  m_linearSolverParameters.get().mgr.displacementFieldName = extrinsicMeshData::solidMechanics::totalDisplacement::key();
   m_linearSolverParameters.get().dofsPerNode = 3;
 }
 
@@ -65,7 +66,7 @@ void MultiphasePoromechanicsSolver::registerDataOnMesh( Group & meshBodies )
 void MultiphasePoromechanicsSolver::setupCoupling( DomainPartition const & GEOSX_UNUSED_PARAM( domain ),
                                                    DofManager & dofManager ) const
 {
-  dofManager.addCoupling( keys::TotalDisplacement,
+  dofManager.addCoupling( extrinsicMeshData::solidMechanics::totalDisplacement::key(),
                           CompositionalMultiphaseBase::viewKeyStruct::elemDofFieldString(),
                           DofManager::Connector::Elem );
 }
@@ -85,7 +86,7 @@ void MultiphasePoromechanicsSolver::assembleSystem( real64 const GEOSX_UNUSED_PA
   {
     NodeManager const & nodeManager = mesh.getNodeManager();
 
-    string const displacementDofKey = dofManager.getKey( dataRepository::keys::TotalDisplacement );
+    string const displacementDofKey = dofManager.getKey( extrinsicMeshData::solidMechanics::totalDisplacement::key() );
     arrayView1d< globalIndex const > const & displacementDofNumber = nodeManager.getReference< globalIndex_array >( displacementDofKey );
 
     string const flowDofKey = dofManager.getKey( CompositionalMultiphaseBase::viewKeyStruct::elemDofFieldString() );

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolverEmbeddedFractures.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolverEmbeddedFractures.cpp
@@ -88,7 +88,7 @@ void SinglePhasePoromechanicsSolverEmbeddedFractures::setupDofs( DomainPartition
   flowSolver()->setupDofs( domain, dofManager );
 
   // Add coupling between displacement and cell pressures
-  dofManager.addCoupling( keys::TotalDisplacement,
+  dofManager.addCoupling( extrinsicMeshData::solidMechanics::totalDisplacement::key(),
                           SinglePhaseBase::viewKeyStruct::elemDofFieldString(),
                           DofManager::Connector::Elem );
 
@@ -404,7 +404,7 @@ void SinglePhasePoromechanicsSolverEmbeddedFractures::assembleSystem( real64 con
     SurfaceElementRegion const & region = elemManager.getRegion< SurfaceElementRegion >( m_fracturesSolver->getFractureRegionName() );
     EmbeddedSurfaceSubRegion const & subRegion = region.getSubRegion< EmbeddedSurfaceSubRegion >( 0 );
 
-    string const dofKey = dofManager.getKey( dataRepository::keys::TotalDisplacement );
+    string const dofKey = dofManager.getKey( extrinsicMeshData::solidMechanics::totalDisplacement::key() );
     string const jumpDofKey = dofManager.getKey( extrinsicMeshData::contact::dispJump::key() );
 
     arrayView1d< globalIndex const > const & dispDofNumber = nodeManager.getReference< globalIndex_array >( dofKey );

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsExtrinsicData.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsExtrinsicData.hpp
@@ -1,0 +1,121 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file FlowSolverBaseExtrinsicData.hpp
+ */
+
+#ifndef GEOSX_PHYSICSSOLVERS_SOLIDMECHANICS_SOLIDMECHANICSEXTRINSICDATA_HPP_
+#define GEOSX_PHYSICSSOLVERS_SOLIDMECHANICS_SOLIDMECHANICSEXTRINSICDATA_HPP_
+
+#include "common/DataLayouts.hpp"
+#include "mesh/ExtrinsicMeshData.hpp"
+
+namespace geosx
+{
+/**
+ * A scope for extrinsic mesh data traits.
+ */
+namespace extrinsicMeshData
+{
+
+namespace solidMechanics
+{
+
+using array2dLayoutTotalDisplacement = array2d< real64, nodes::TOTAL_DISPLACEMENT_PERM >;
+using array2dLayoutIncrementalDisplacement = array2d< real64, nodes::INCR_DISPLACEMENT_PERM >;
+using array2dLayoutVelocity = array2d< real64, nodes::VELOCITY_PERM >;
+using array2dLayoutAcceleration = array2d< real64, nodes::ACCELERATION_PERM >;
+
+EXTRINSIC_MESH_DATA_TRAIT( totalDisplacement,
+                           "totalDisplacement",
+                           array2dLayoutTotalDisplacement,
+                           0,
+                           LEVEL_0,
+                           WRITE_AND_READ,
+                           "Total displacements at the nodes" );
+
+EXTRINSIC_MESH_DATA_TRAIT( incrementalDisplacement,
+                           "incrementalDisplacement",
+                           array2dLayoutIncrementalDisplacement,
+                           0,
+                           LEVEL_3,
+                           WRITE_AND_READ,
+                           "Incremental displacements for the current time step on the nodes" );
+
+EXTRINSIC_MESH_DATA_TRAIT( velocity,
+                           "velocity",
+                           array2dLayoutVelocity,
+                           0,
+                           LEVEL_0,
+                           WRITE_AND_READ,
+                           "Current velocity on the nodes" );
+
+EXTRINSIC_MESH_DATA_TRAIT( acceleration,
+                           "acceleration",
+                           array2dLayoutAcceleration,
+                           0,
+                           LEVEL_1,
+                           WRITE_AND_READ,
+                           "Current acceleration on the nodes. This array also is used "
+                           "to hold the summation of nodal forces resulting from the governing equations" );
+
+EXTRINSIC_MESH_DATA_TRAIT( externalForce,
+                           "externalForce",
+                           array2d< real64 >,
+                           0,
+                           LEVEL_0,
+                           WRITE_AND_READ,
+                           "External forces on the nodes. This includes any boundary"
+                           " conditions as well as coupling forces such as hydraulic forces" );
+
+EXTRINSIC_MESH_DATA_TRAIT( mass,
+                           "mass",
+                           array1d< real64 >,
+                           0,
+                           LEVEL_0,
+                           WRITE_AND_READ,
+                           "Mass on the nodes" );
+
+EXTRINSIC_MESH_DATA_TRAIT( velocityTilde,
+                           "velocityTilde",
+                           array2d< real64 >,
+                           0,
+                           NOPLOT,
+                           WRITE_AND_READ,
+                           "Velocity predictors on the nodes" );
+
+EXTRINSIC_MESH_DATA_TRAIT( uhatTilde,
+                           "uhatTilde",
+                           array2d< real64 >,
+                           0,
+                           NOPLOT,
+                           WRITE_AND_READ,
+                           "Incremental displacement predictors on the nodes" );
+
+EXTRINSIC_MESH_DATA_TRAIT( contactForce,
+                           "contactForce",
+                           array2d< real64 >,
+                           0,
+                           NOPLOT,
+                           WRITE_AND_READ,
+                           "Contact force" );
+
+}
+
+}
+
+}
+
+#endif // GEOSX_PHYSICSSOLVERS_SOLIDMECHANICS_SOLIDMECHANICSEXTRINSICDATA_HPP_

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
@@ -23,23 +23,18 @@
 #include "SolidMechanicsFiniteStrainExplicitNewmarkKernel.hpp"
 
 #include "codingUtilities/Utilities.hpp"
-#include "common/TimingMacros.hpp"
 #include "constitutive/ConstitutiveManager.hpp"
 #include "constitutive/contact/ContactBase.hpp"
-#include "finiteElement/FiniteElementDiscretizationManager.hpp"
-#include "finiteElement/Kinematics.h"
-#include "LvArray/src/output.hpp"
-#include "mesh/DomainPartition.hpp"
-#include "mainInterface/ProblemManager.hpp"
+#include "common/GEOS_RAJA_Interface.hpp"
 #include "discretizationMethods/NumericalMethodsManager.hpp"
 #include "fieldSpecification/FieldSpecificationManager.hpp"
 #include "fieldSpecification/TractionBoundaryCondition.hpp"
+#include "finiteElement/FiniteElementDiscretizationManager.hpp"
+#include "LvArray/src/output.hpp"
+#include "mainInterface/ProblemManager.hpp"
+#include "mesh/DomainPartition.hpp"
 #include "mesh/FaceElementSubRegion.hpp"
-#include "mesh/utilities/ComputationalGeometry.hpp"
-#include "mesh/mpiCommunications/CommunicationTools.hpp"
 #include "mesh/mpiCommunications/NeighborCommunicator.hpp"
-#include "common/GEOS_RAJA_Interface.hpp"
-
 
 namespace geosx
 {
@@ -148,59 +143,30 @@ void SolidMechanicsLagrangianFEM::registerDataOnMesh( Group & meshBodies )
   {
     NodeManager & nodes = meshLevel.getNodeManager();
 
-    nodes.registerWrapper< array2d< real64, nodes::TOTAL_DISPLACEMENT_PERM > >( keys::TotalDisplacement ).
-      setPlotLevel( PlotLevel::LEVEL_0 ).
-      setRegisteringObjects( this->getName()).
-      setDescription( "An array that holds the total displacements on the nodes." ).
+    nodes.registerExtrinsicData< extrinsicMeshData::solidMechanics::totalDisplacement >( getName() ).
       reference().resizeDimension< 1 >( 3 );
 
-    nodes.registerWrapper< array2d< real64, nodes::INCR_DISPLACEMENT_PERM > >( keys::IncrementalDisplacement ).
-      setPlotLevel( PlotLevel::LEVEL_3 ).
-      setRegisteringObjects( this->getName()).
-      setDescription( "An array that holds the incremental displacements for the current time step on the nodes." ).
+    nodes.registerExtrinsicData< extrinsicMeshData::solidMechanics::incrementalDisplacement >( getName() ).
       reference().resizeDimension< 1 >( 3 );
 
-    nodes.registerWrapper< array2d< real64, nodes::VELOCITY_PERM > >( keys::Velocity ).
-      setPlotLevel( PlotLevel::LEVEL_0 ).
-      setRegisteringObjects( this->getName()).
-      setDescription( "An array that holds the current velocity on the nodes." ).
+    nodes.registerExtrinsicData< extrinsicMeshData::solidMechanics::velocity >( getName() ).
       reference().resizeDimension< 1 >( 3 );
 
-    nodes.registerWrapper< array2d< real64, nodes::ACCELERATION_PERM > >( keys::Acceleration ).
-      setPlotLevel( PlotLevel::LEVEL_1 ).
-      setRegisteringObjects( this->getName()).
-      setDescription( "An array that holds the current acceleration on the nodes. This array also is used "
-                      "to hold the summation of nodal forces resulting from the governing equations." ).
+    nodes.registerExtrinsicData< extrinsicMeshData::solidMechanics::acceleration >( getName() ).
       reference().resizeDimension< 1 >( 3 );
 
-    nodes.registerWrapper< array2d< real64 > >( viewKeyStruct::forceExternalString() ).
-      setPlotLevel( PlotLevel::LEVEL_0 ).
-      setRegisteringObjects( this->getName()).
-      setDescription( "An array that holds the external forces on the nodes. This includes any boundary"
-                      " conditions as well as coupling forces such as hydraulic forces." ).
+    nodes.registerExtrinsicData< extrinsicMeshData::solidMechanics::externalForce >( getName() ).
       reference().resizeDimension< 1 >( 3 );
 
-    nodes.registerWrapper< array1d< real64 > >( keys::Mass ).
-      setPlotLevel( PlotLevel::LEVEL_0 ).
-      setRegisteringObjects( this->getName()).
-      setDescription( "An array that holds the mass on the nodes." );
+    nodes.registerExtrinsicData< extrinsicMeshData::solidMechanics::mass >( getName() );
 
-    nodes.registerWrapper< array2d< real64 > >( viewKeyStruct::vTildeString() ).
-      setPlotLevel( PlotLevel::NOPLOT ).
-      setRegisteringObjects( this->getName()).
-      setDescription( "An array that holds the velocity predictors on the nodes." ).
+    nodes.registerExtrinsicData< extrinsicMeshData::solidMechanics::velocityTilde >( getName() ).
       reference().resizeDimension< 1 >( 3 );
 
-    nodes.registerWrapper< array2d< real64 > >( viewKeyStruct::uhatTildeString() ).
-      setPlotLevel( PlotLevel::NOPLOT ).
-      setRegisteringObjects( this->getName()).
-      setDescription( "An array that holds the incremental displacement predictors on the nodes." ).
+    nodes.registerExtrinsicData< extrinsicMeshData::solidMechanics::uhatTilde >( getName() ).
       reference().resizeDimension< 1 >( 3 );
 
-    nodes.registerWrapper< array2d< real64 > >( viewKeyStruct::contactForceString() ).
-      setPlotLevel( PlotLevel::LEVEL_0 ).
-      setRegisteringObjects( this->getName()).
-      setDescription( "An array that holds the contact force." ).
+    nodes.registerExtrinsicData< extrinsicMeshData::solidMechanics::contactForce >( getName() ).
       reference().resizeDimension< 1 >( 3 );
 
     Group & nodeSets = nodes.sets();
@@ -344,7 +310,7 @@ void SolidMechanicsLagrangianFEM::initializePostInitialConditionsPreSubGroups()
 
     ElementRegionManager & elementRegionManager = mesh.getElemManager();
 
-    arrayView1d< real64 > & mass = nodes.getReference< array1d< real64 > >( keys::Mass );
+    arrayView1d< real64 > & mass = nodes.getExtrinsicData< extrinsicMeshData::solidMechanics::mass >();
 
     arrayView1d< integer const > const & nodeGhostRank = nodes.ghostRank();
 
@@ -553,7 +519,7 @@ real64 SolidMechanicsLagrangianFEM::explicitStep( real64 const & time_n,
 
     FieldSpecificationManager & fsManager = FieldSpecificationManager::getInstance();
 
-    arrayView1d< real64 const > const & mass = nodes.getReference< array1d< real64 > >( keys::Mass );
+    arrayView1d< real64 const > const & mass = nodes.getExtrinsicData< extrinsicMeshData::solidMechanics::mass >();
     arrayView2d< real64, nodes::VELOCITY_USD > const & vel = nodes.velocity();
 
     arrayView2d< real64, nodes::TOTAL_DISPLACEMENT_USD > const & u = nodes.totalDisplacement();
@@ -561,23 +527,25 @@ real64 SolidMechanicsLagrangianFEM::explicitStep( real64 const & time_n,
     arrayView2d< real64, nodes::ACCELERATION_USD > const & acc = nodes.acceleration();
 
     FieldIdentifiers fieldsToBeSync;
-    fieldsToBeSync.addFields( FieldLocation::Node, { keys::Velocity, keys::Acceleration } );
+    fieldsToBeSync.addFields( FieldLocation::Node,
+                              { extrinsicMeshData::solidMechanics::velocity::key(),
+                                extrinsicMeshData::solidMechanics::acceleration::key() } );
     m_iComm.resize( domain.getNeighbors().size() );
     CommunicationTools::getInstance().synchronizePackSendRecvSizes( fieldsToBeSync, mesh, domain.getNeighbors(), m_iComm, true );
 
-    fsManager.applyFieldValue< parallelDevicePolicy< 1024 > >( time_n, mesh, keys::Acceleration );
+    fsManager.applyFieldValue< parallelDevicePolicy< 1024 > >( time_n, mesh, extrinsicMeshData::solidMechanics::acceleration::key() );
 
     //3: v^{n+1/2} = v^{n} + a^{n} dt/2
     solidMechanicsLagrangianFEMKernels::velocityUpdate( acc, vel, dt / 2 );
 
-    fsManager.applyFieldValue< parallelDevicePolicy< 1024 > >( time_n, mesh, keys::Velocity );
+    fsManager.applyFieldValue< parallelDevicePolicy< 1024 > >( time_n, mesh, extrinsicMeshData::solidMechanics::velocity::key() );
 
     //4. x^{n+1} = x^{n} + v^{n+{1}/{2}} dt (x is displacement)
     solidMechanicsLagrangianFEMKernels::displacementUpdate( vel, uhat, u, dt );
 
     fsManager.applyFieldValue( time_n + dt,
                                mesh,
-                               NodeManager::viewKeyStruct::totalDisplacementString(),
+                               extrinsicMeshData::solidMechanics::totalDisplacement::key(),
                                [&]( FieldSpecificationBase const & bc,
                                     SortedArrayView< localIndex const > const & targetSet )
     {
@@ -617,7 +585,7 @@ real64 SolidMechanicsLagrangianFEM::explicitStep( real64 const & time_n,
     // apply this over a set
     solidMechanicsLagrangianFEMKernels::velocityUpdate( acc, mass, vel, dt / 2, m_sendOrReceiveNodes.toViewConst() );
 
-    fsManager.applyFieldValue< parallelDevicePolicy< 1024 > >( time_n, mesh, keys::Velocity );
+    fsManager.applyFieldValue< parallelDevicePolicy< 1024 > >( time_n, mesh, extrinsicMeshData::solidMechanics::velocity::key() );
 
     parallelDeviceEvents packEvents;
     CommunicationTools::getInstance().asyncPack( fieldsToBeSync, mesh, domain.getNeighbors(), m_iComm, true, packEvents );
@@ -634,7 +602,7 @@ real64 SolidMechanicsLagrangianFEM::explicitStep( real64 const & time_n,
 
     // apply this over a set
     solidMechanicsLagrangianFEMKernels::velocityUpdate( acc, mass, vel, dt / 2, m_nonSendOrReceiveNodes.toViewConst() );
-    fsManager.applyFieldValue< parallelDevicePolicy< 1024 > >( time_n, mesh, keys::Velocity );
+    fsManager.applyFieldValue< parallelDevicePolicy< 1024 > >( time_n, mesh, extrinsicMeshData::solidMechanics::velocity::key() );
 
     // this includes  a device sync after launching all the unpacking kernels
     parallelDeviceEvents unpackEvents;
@@ -654,7 +622,7 @@ void SolidMechanicsLagrangianFEM::applyDisplacementBCImplicit( real64 const time
                                                                arrayView1d< real64 > const & localRhs )
 {
   GEOSX_MARK_FUNCTION;
-  string const dofKey = dofManager.getKey( keys::TotalDisplacement );
+  string const dofKey = dofManager.getKey( extrinsicMeshData::solidMechanics::totalDisplacement::key() );
 
   FieldSpecificationManager const & fsManager = FieldSpecificationManager::getInstance();
 
@@ -665,7 +633,7 @@ void SolidMechanicsLagrangianFEM::applyDisplacementBCImplicit( real64 const time
 
     fsManager.apply< NodeManager >( time,
                                     mesh,
-                                    keys::TotalDisplacement,
+                                    extrinsicMeshData::solidMechanics::totalDisplacement::key(),
                                     [&]( FieldSpecificationBase const & bc,
                                          string const &,
                                          SortedArrayView< localIndex const > const & targetSet,
@@ -700,7 +668,7 @@ void SolidMechanicsLagrangianFEM::applyTractionBC( real64 const time,
     FaceManager const & faceManager = mesh.getFaceManager();
     NodeManager const & nodeManager = mesh.getNodeManager();
 
-    string const dofKey = dofManager.getKey( keys::TotalDisplacement );
+    string const dofKey = dofManager.getKey( extrinsicMeshData::solidMechanics::totalDisplacement::key() );
 
     arrayView1d< globalIndex const > const blockLocalDofNumber = nodeManager.getReference< globalIndex_array >( dofKey );
     globalIndex const dofRankOffset = dofManager.rankOffset();
@@ -741,7 +709,7 @@ void SolidMechanicsLagrangianFEM::applyChomboPressure( DofManager const & dofMan
     arrayView2d< real64 const > const faceNormal  = faceManager.faceNormal();
     ArrayOfArraysView< localIndex const > const faceToNodeMap = faceManager.nodeList().toViewConst();
 
-    string const dofKey = dofManager.getKey( keys::TotalDisplacement );
+    string const dofKey = dofManager.getKey( extrinsicMeshData::solidMechanics::totalDisplacement::key() );
 
     arrayView1d< globalIndex const > const dofNumber = nodeManager.getReference< globalIndex_array >( dofKey );
     arrayView1d< real64 const > const facePressure = faceManager.getReference< array1d< real64 > >( "ChomboPressure" );
@@ -789,8 +757,8 @@ SolidMechanicsLagrangianFEM::
     if( this->m_timeIntegrationOption == TimeIntegrationOption::ImplicitDynamic )
     {
       arrayView2d< real64 const, nodes::ACCELERATION_USD > const a_n = nodeManager.acceleration();
-      arrayView2d< real64 > const vtilde = nodeManager.getReference< array2d< real64 > >( solidMechanicsViewKeys.vTilde );
-      arrayView2d< real64 > const uhatTilde = nodeManager.getReference< array2d< real64 > >( solidMechanicsViewKeys.uhatTilde );
+      arrayView2d< real64 > const vtilde = nodeManager.getExtrinsicData< extrinsicMeshData::solidMechanics::velocityTilde >();
+      arrayView2d< real64 > const uhatTilde = nodeManager.getExtrinsicData< extrinsicMeshData::solidMechanics::uhatTilde >();
 
       real64 const newmarkGamma = this->getReference< real64 >( solidMechanicsViewKeys.newmarkGamma );
       real64 const newmarkBeta = this->getReference< real64 >( solidMechanicsViewKeys.newmarkBeta );
@@ -866,8 +834,8 @@ void SolidMechanicsLagrangianFEM::implicitStepComplete( real64 const & GEOSX_UNU
     if( this->m_timeIntegrationOption == TimeIntegrationOption::ImplicitDynamic )
     {
       arrayView2d< real64, nodes::ACCELERATION_USD > const a_n = nodeManager.acceleration();
-      arrayView2d< real64 const > const vtilde    = nodeManager.getReference< array2d< real64 > >( solidMechanicsViewKeys.vTilde );
-      arrayView2d< real64 const > const uhatTilde = nodeManager.getReference< array2d< real64 > >( solidMechanicsViewKeys.uhatTilde );
+      arrayView2d< real64 const > const vtilde    = nodeManager.getExtrinsicData< extrinsicMeshData::solidMechanics::velocityTilde >();
+      arrayView2d< real64 const > const uhatTilde = nodeManager.getExtrinsicData< extrinsicMeshData::solidMechanics::uhatTilde >();
       real64 const newmarkGamma = this->getReference< real64 >( solidMechanicsViewKeys.newmarkGamma );
       real64 const newmarkBeta = this->getReference< real64 >( solidMechanicsViewKeys.newmarkBeta );
 
@@ -910,13 +878,13 @@ void SolidMechanicsLagrangianFEM::setupDofs( DomainPartition const & GEOSX_UNUSE
                                              DofManager & dofManager ) const
 {
   GEOSX_MARK_FUNCTION;
-  dofManager.addField( keys::TotalDisplacement,
+  dofManager.addField( extrinsicMeshData::solidMechanics::totalDisplacement::key(),
                        FieldLocation::Node,
                        3,
                        getMeshTargets() );
 
-  dofManager.addCoupling( keys::TotalDisplacement,
-                          keys::TotalDisplacement,
+  dofManager.addCoupling( extrinsicMeshData::solidMechanics::totalDisplacement::key(),
+                          extrinsicMeshData::solidMechanics::totalDisplacement::key(),
                           DofManager::Connector::Elem );
 }
 
@@ -942,7 +910,7 @@ void SolidMechanicsLagrangianFEM::setupSystem( DomainPartition & domain,
 
     NodeManager const & nodeManager = mesh.getNodeManager();
     arrayView1d< globalIndex const > const
-    dofNumber = nodeManager.getReference< globalIndex_array >( dofManager.getKey( keys::TotalDisplacement ) );
+    dofNumber = nodeManager.getReference< globalIndex_array >( dofManager.getKey( extrinsicMeshData::solidMechanics::totalDisplacement::key() ) );
 
 
     if( m_contactRelationName != viewKeyStruct::noContactRelationNameString() )
@@ -1034,11 +1002,11 @@ SolidMechanicsLagrangianFEM::
                                                                 MeshLevel & mesh,
                                                                 arrayView1d< string const > const & )
   {
-    string const dofKey = dofManager.getKey( keys::TotalDisplacement );
+    string const dofKey = dofManager.getKey( extrinsicMeshData::solidMechanics::totalDisplacement::key() );
 
     fsManager.apply< NodeManager >( time_n + dt,
                                     mesh,
-                                    keys::Force,
+                                    viewKeyStruct::forceString(),
                                     [&]( FieldSpecificationBase const & bc,
                                          string const &,
                                          SortedArrayView< localIndex const > const & targetSet,
@@ -1049,7 +1017,10 @@ SolidMechanicsLagrangianFEM::
                                          parallelDevicePolicy< 32 > >( targetSet,
                                                                        time_n + dt,
                                                                        targetGroup,
-                                                                       keys::TotalDisplacement, // TODO fix use of
+                                                                       extrinsicMeshData::solidMechanics::totalDisplacement::key(), // TODO
+                                                                                                                                    // fix
+                                                                                                                                    // use
+                                                                                                                                    // of
                                                                        // dummy
                                                                        // name
                                                                        dofKey,
@@ -1090,7 +1061,7 @@ SolidMechanicsLagrangianFEM::
     NodeManager const & nodeManager = mesh.getNodeManager();
 
     arrayView1d< globalIndex const > const
-    dofNumber = nodeManager.getReference< array1d< globalIndex > >( dofManager.getKey( keys::TotalDisplacement ) );
+    dofNumber = nodeManager.getReference< array1d< globalIndex > >( dofManager.getKey( extrinsicMeshData::solidMechanics::totalDisplacement::key() ) );
     globalIndex const rankOffset = dofManager.rankOffset();
 
     arrayView1d< integer const > const ghostRank = nodeManager.ghostRank();
@@ -1168,13 +1139,13 @@ SolidMechanicsLagrangianFEM::applySystemSolution( DofManager const & dofManager,
 {
   GEOSX_MARK_FUNCTION;
   dofManager.addVectorToField( localSolution,
-                               keys::TotalDisplacement,
-                               keys::IncrementalDisplacement,
+                               extrinsicMeshData::solidMechanics::totalDisplacement::key(),
+                               extrinsicMeshData::solidMechanics::incrementalDisplacement::key(),
                                scalingFactor );
 
   dofManager.addVectorToField( localSolution,
-                               keys::TotalDisplacement,
-                               keys::TotalDisplacement,
+                               extrinsicMeshData::solidMechanics::totalDisplacement::key(),
+                               extrinsicMeshData::solidMechanics::totalDisplacement::key(),
                                scalingFactor );
 
   forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
@@ -1184,7 +1155,9 @@ SolidMechanicsLagrangianFEM::applySystemSolution( DofManager const & dofManager,
   {
     FieldIdentifiers fieldsToBeSync;
 
-    fieldsToBeSync.addFields( FieldLocation::Node, { keys::IncrementalDisplacement, keys::TotalDisplacement } );
+    fieldsToBeSync.addFields( FieldLocation::Node,
+                              { extrinsicMeshData::solidMechanics::incrementalDisplacement::key(),
+                                extrinsicMeshData::solidMechanics::totalDisplacement::key() } );
 
     CommunicationTools::getInstance().synchronizeFields( fieldsToBeSync,
                                                          mesh,
@@ -1236,13 +1209,13 @@ void SolidMechanicsLagrangianFEM::applyContactConstraint( DofManager const & dof
       ElementRegionManager & elemManager = mesh.getElemManager();
 
       arrayView2d< real64 const, nodes::TOTAL_DISPLACEMENT_USD > const u = nodeManager.totalDisplacement();
-      arrayView2d< real64 > const fc = nodeManager.getReference< array2d< real64 > >( viewKeyStruct::contactForceString() );
+      arrayView2d< real64 > const fc = nodeManager.getExtrinsicData< extrinsicMeshData::solidMechanics::contactForce >();
       fc.zero();
 
       arrayView2d< real64 const > const faceNormal = faceManager.faceNormal();
       ArrayOfArraysView< localIndex const > const facesToNodes = faceManager.nodeList().toViewConst();
 
-      string const dofKey = dofManager.getKey( keys::TotalDisplacement );
+      string const dofKey = dofManager.getKey( extrinsicMeshData::solidMechanics::totalDisplacement::key() );
       arrayView1d< globalIndex > const nodeDofNumber = nodeManager.getReference< globalIndex_array >( dofKey );
       globalIndex const rankOffset = dofManager.rankOffset();
 

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.hpp
@@ -25,8 +25,8 @@
 #include "mesh/mpiCommunications/CommunicationTools.hpp"
 #include "mesh/mpiCommunications/MPI_iCommData.hpp"
 #include "physicsSolvers/SolverBase.hpp"
-
-#include "SolidMechanicsLagrangianFEMKernels.hpp"
+#include "physicsSolvers/solidMechanics/SolidMechanicsExtrinsicData.hpp"
+#include "physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEMKernels.hpp"
 
 namespace geosx
 {
@@ -217,8 +217,6 @@ public:
 
   struct viewKeyStruct : SolverBase::viewKeyStruct
   {
-    static constexpr char const * vTildeString() { return "velocityTilde"; }
-    static constexpr char const * uhatTildeString() { return "uhatTilde"; }
     static constexpr char const * cflFactorString() { return "cflFactor"; }
     static constexpr char const * newmarkGammaString() { return "newmarkGamma"; }
     static constexpr char const * newmarkBetaString() { return "newmarkBeta"; }
@@ -229,21 +227,16 @@ public:
     static constexpr char const * maxNumResolvesString() { return "maxNumResolves"; }
     static constexpr char const * strainTheoryString() { return "strainTheory"; }
     static constexpr char const * solidMaterialNamesString() { return "solidMaterialNames"; }
-    static constexpr char const * forceExternalString() { return "externalForce"; }
     static constexpr char const * contactRelationNameString() { return "contactRelationName"; }
     static constexpr char const * noContactRelationNameString() { return "NOCONTACT"; }
-    static constexpr char const * contactForceString() { return "contactForce"; }
     static constexpr char const * maxForceString() { return "maxForce"; }
     static constexpr char const * elemsAttachedToSendOrReceiveNodesString() { return "elemsAttachedToSendOrReceiveNodes"; }
     static constexpr char const * elemsNotAttachedToSendOrReceiveNodesString() { return "elemsNotAttachedToSendOrReceiveNodes"; }
-
     static constexpr char const * sendOrReceiveNodesString() { return "sendOrReceiveNodes";}
     static constexpr char const * nonSendOrReceiveNodesString() { return "nonSendOrReceiveNodes";}
     static constexpr char const * targetNodesString() { return "targetNodes";}
+    static constexpr char const * forceString() { return "Force";}
 
-
-    dataRepository::ViewKey vTilde = { vTildeString() };
-    dataRepository::ViewKey uhatTilde = { uhatTildeString() };
     dataRepository::ViewKey newmarkGamma = { newmarkGammaString() };
     dataRepository::ViewKey newmarkBeta = { newmarkBetaString() };
     dataRepository::ViewKey massDamping = { massDampingString() };
@@ -251,7 +244,6 @@ public:
     dataRepository::ViewKey useVelocityEstimateForQS = { useVelocityEstimateForQSString() };
     dataRepository::ViewKey timeIntegrationOption = { timeIntegrationOptionString() };
   } solidMechanicsViewKeys;
-
 
   SortedArray< localIndex > & getElemsAttachedToSendOrReceiveNodes( ElementSubRegionBase & subRegion )
   {
@@ -329,7 +321,7 @@ void SolidMechanicsLagrangianFEM::assemblyLaunch( DomainPartition & domain,
   {
     NodeManager const & nodeManager = mesh.getNodeManager();
 
-    string const dofKey = dofManager.getKey( dataRepository::keys::TotalDisplacement );
+    string const dofKey = dofManager.getKey( extrinsicMeshData::solidMechanics::totalDisplacement::key() );
     arrayView1d< globalIndex const > const & dofNumber = nodeManager.getReference< globalIndex_array >( dofKey );
 
     real64 const gravityVectorData[3] = LVARRAY_TENSOROPS_INIT_LOCAL_3( gravityVector() );

--- a/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
@@ -29,6 +29,7 @@
 #include "mesh/SurfaceElementRegion.hpp"
 #include "mesh/ExtrinsicMeshData.hpp"
 #include "mesh/utilities/ComputationalGeometry.hpp"
+#include "physicsSolvers/solidMechanics/SolidMechanicsExtrinsicData.hpp"
 #include "physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEMKernels.hpp"
 #include "physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.hpp"
 
@@ -522,9 +523,9 @@ int SurfaceGenerator::separationDriver( DomainPartition & domain,
   FieldIdentifiers fieldsToBeSync;
 
   fieldsToBeSync.addFields( FieldLocation::Face, { extrinsicMeshData::RuptureState::key() } );
-  if( nodeManager.hasWrapper( SolidMechanicsLagrangianFEM::viewKeyStruct::forceExternalString() ) )
+  if( nodeManager.hasWrapper( extrinsicMeshData::solidMechanics::externalForce::key() ) )
   {
-    fieldsToBeSync.addFields( FieldLocation::Node, { SolidMechanicsLagrangianFEM::viewKeyStruct::forceExternalString() } );
+    fieldsToBeSync.addFields( FieldLocation::Node, { extrinsicMeshData::solidMechanics::externalForce::key() } );
   }
 
   CommunicationTools::getInstance().synchronizeFields( fieldsToBeSync, mesh, domain.getNeighbors(), false );
@@ -2789,7 +2790,7 @@ void SurfaceGenerator::calculateNodeAndFaceSif( DomainPartition const & domain,
   SIFNode.zero();
   SIFonFace.zero();
 
-  arrayView2d< real64 const > const & fext = nodeManager.getReference< array2d< real64 > >( SolidMechanicsLagrangianFEM::viewKeyStruct::forceExternalString() );
+  arrayView2d< real64 const > const & fext = nodeManager.getExtrinsicData< extrinsicMeshData::solidMechanics::externalForce >();
   arrayView2d< real64 const, nodes::TOTAL_DISPLACEMENT_USD > const & displacement = nodeManager.totalDisplacement();
   ArrayOfArraysView< localIndex const > const & nodeToRegionMap = nodeManager.elementRegionList().toViewConst();
   ArrayOfArraysView< localIndex const > const & nodeToSubRegionMap = nodeManager.elementSubRegionList().toViewConst();


### PR DESCRIPTION
This PR adds extrinsic mesh data registration in the solid mechanics solvers.

In passing, the PR enforces camel case for the fields registered by the solid mechanics solvers to be consistent with the rest of the code: 
- `TotalDisplacement` -> `totalDisplacement`
- `Velocity` -> `velocity`
etc

Resolves https://github.com/GEOSX/GEOSX/issues/1215

Ready for review, no rebaseline necessary