### PR TITLE
Output and postprocess HDF5 files for HF examples

### DIFF
--- a/inputFiles/hydraulicFracturing/kgdToughnessDominated_base.xml
+++ b/inputFiles/hydraulicFracturing/kgdToughnessDominated_base.xml
@@ -3,7 +3,7 @@
 <Problem>
   <Solvers
     gravityVector="{ 0.0, 0.0, -0.0 }">
-	<!-- Sphinx_Solvers_Hydrofracture -->
+    <!-- Sphinx_Solvers_Hydrofracture -->
     <Hydrofracture
       name="hydrofracture"
       solidSolverName="lagsolve"
@@ -14,7 +14,7 @@
       targetRegions="{ Fracture }"
       contactRelationName="fractureContact"
       maxNumResolves="2">
-	  <!-- Sphinx_Solvers_Hydrofracture_End -->
+    <!-- Sphinx_Solvers_Hydrofracture_End -->
 
       <NonlinearSolverParameters
         newtonTol="1.0e-5"
@@ -24,14 +24,14 @@
         directParallel="0"/>
     </Hydrofracture>
 
-	<!-- Sphinx_Solvers_SolidMechanicsLagrangianSSLE -->
+    <!-- Sphinx_Solvers_SolidMechanicsLagrangianSSLE -->
     <SolidMechanicsLagrangianSSLE
       name="lagsolve"
       timeIntegrationOption="QuasiStatic"
       discretization="FE1"
       targetRegions="{ Domain, Fracture }"
       contactRelationName="fractureContact"/>
-	<!-- Sphinx_Solvers_SolidMechanicsLagrangianSSLE_End -->
+    <!-- Sphinx_Solvers_SolidMechanicsLagrangianSSLE_End -->
 
     <!-- Sphinx_Solvers_SinglePhaseFVM -->
     <SinglePhaseFVM
@@ -63,7 +63,6 @@
     </FiniteVolume>
   </NumericalMethods>
 
-
   <ElementRegions>
     <CellElementRegion
       name="Domain"
@@ -77,7 +76,7 @@
   </ElementRegions>
 
   <Constitutive>
-	<!-- Sphinx_Constitutive_CompressibleSinglePhaseFluid -->
+    <!-- Sphinx_Constitutive_CompressibleSinglePhaseFluid -->
     <CompressibleSinglePhaseFluid
       name="water"
       defaultDensity="1000"
@@ -86,15 +85,15 @@
       compressibility="5e-10"
       referenceViscosity="1.0e-6"
       viscosibility="0.0"/>
-	<!-- Sphinx_Constitutive_CompressibleSinglePhaseFluid_End -->
+    <!-- Sphinx_Constitutive_CompressibleSinglePhaseFluid_End -->
 
-	<!-- Sphinx_Constitutive_ElasticIsotropic -->
+    <!-- Sphinx_Constitutive_ElasticIsotropic -->
     <ElasticIsotropic
       name="rock"
       defaultDensity="2700"
       defaultYoungModulus="30.0e9"
       defaultPoissonRatio="0.25"/>
-	<!-- Sphinx_Constitutive_ElasticIsotropic_End -->
+    <!-- Sphinx_Constitutive_ElasticIsotropic_End -->
 
     <CompressibleSolidParallelPlatesPermeability
       name="fractureFilling"
@@ -122,15 +121,6 @@
   </Constitutive>
 
   <FieldSpecifications>
-    <!-- FieldSpecification 
-      name="initialMeanStress"
-      initialCondition="1"
-      setNames="{all}"
-      objectPath="ElementRegions"
-      fieldName="rock_stress"
-      component="0"
-      scale="-60e6"/-->
-
     <FieldSpecification
       name="waterDensity"
       initialCondition="1"
@@ -139,7 +129,7 @@
       fieldName="water_density"
       scale="1000"/>
 
-	<!-- Sphinx_FieldSpecifications_FracturePlane -->
+    <!-- Sphinx_FieldSpecifications_FracturePlane -->
     <FieldSpecification
       name="separableFace"
       initialCondition="1"
@@ -147,9 +137,9 @@
       objectPath="faceManager"
       fieldName="isFaceSeparable"
       scale="1"/>
-	<!-- Sphinx_FieldSpecifications_FracturePlane_End -->
+    <!-- Sphinx_FieldSpecifications_FracturePlane_End -->
 
-	<!-- Sphinx_FieldSpecifications_InitFracture -->
+    <!-- Sphinx_FieldSpecifications_InitFracture -->
     <FieldSpecification
       name="frac"
       initialCondition="1"
@@ -157,7 +147,7 @@
       objectPath="faceManager"
       fieldName="ruptureState"
       scale="1"/>
-	<!-- Sphinx_FieldSpecifications_InitFracture_End -->
+    <!-- Sphinx_FieldSpecifications_InitFracture_End -->
 
     <FieldSpecification
       name="xConstraint"
@@ -183,13 +173,13 @@
       scale="0.0"
       setNames="{ zneg, zpos }"/>
 
-	<!-- Sphinx_SourceFlux_InjSource -->
+    <!-- Sphinx_SourceFlux_InjSource -->
     <SourceFlux
       name="sourceTerm"
       objectPath="ElementRegions/Fracture"
       scale="-5e-2"
       setNames="{ source }"/>
-	<!-- Sphinx_SourceFlux_InjSource_End -->
+    <!-- Sphinx_SourceFlux_InjSource_End -->
   </FieldSpecifications>
   
   <Functions>
@@ -199,12 +189,39 @@
         values="{ 0.002e-3, 0.02e-3 }"/>
   </Functions>
 
+  <Tasks>
+    <PackCollection
+      name="pressureCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="pressure"/>
+
+    <PackCollection
+      name="apertureCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="elementAperture"/> 
+
+    <PackCollection
+      name="hydraulicApertureCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="hydraulicAperture"/>  
+
+    <PackCollection
+      name="areaCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="elementArea"/> 
+  </Tasks>
+
   <Outputs>
-    <Silo
-      name="siloOutput"
+    <VTK
+      name="vtkOutput"
       plotFileRoot="zeroViscosity"
       plotLevel="3"
       parallelThreads="48"/>
+
+    <TimeHistory
+      name="timeHistoryOutput"
+      sources="{/Tasks/pressureCollection, /Tasks/apertureCollection, /Tasks/hydraulicApertureCollection, /Tasks/areaCollection}"
+      filename="KGD_zeroViscosity_output" />  
 
     <Restart
       name="restartOutput"/>

--- a/inputFiles/hydraulicFracturing/kgdToughnessDominated_benchmark.xml
+++ b/inputFiles/hydraulicFracturing/kgdToughnessDominated_benchmark.xml
@@ -4,8 +4,9 @@
   <Included>
     <File name="./kgdToughnessDominated_base.xml"/>
   </Included>
+
   <Mesh>
-	<!-- Sphinx_Mesh_InternalMesh -->
+    <!-- Sphinx_Mesh_InternalMesh -->
     <InternalMesh 
       name="mesh1"
       elementTypes="{C3D8}"
@@ -15,48 +16,83 @@
       nx="{ 30, 30 }"
       ny="{ 100 }"
       nz="{ 2 }"
-	  xBias="{ 0.5, -0.5 }"
+      xBias="{ 0.5, -0.5 }"
       cellBlockNames="{cb1}"/>
-	<!-- Sphinx_Mesh_InternalMesh_End -->
+    <!-- Sphinx_Mesh_InternalMesh_End -->
   </Mesh>
 
   <Geometry>
 
-	<!-- Sphinx_Geometry_InitFracture -->
+    <!-- Sphinx_Geometry_InitFracture -->
     <Box
       name="fracture"
       xMin="{ -0.01, -0.01, -0.01 }"
       xMax="{  0.01,  1.01,  1.01 }"/>
-	<!-- Sphinx_Geometry_InitFracture_End -->
+    <!-- Sphinx_Geometry_InitFracture_End -->
 
-	<!-- Sphinx_Geometry_InjSource -->
+    <!-- Sphinx_Geometry_InjSource -->
     <Box
       name="source"
       xMin="{ -0.01, -0.01, -0.01 }"
       xMax="{  0.01,  1.01,  1.01 }"/>
-	<!-- Sphinx_Geometry_InjSource_End -->
+    <!-- Sphinx_Geometry_InjSource_End -->
 
     <!-- Sphinx_Geometry_FracturePlane -->
     <Box
       name="core"
       xMin="{ -0.01, -0.01, -0.01 }"
       xMax="{  0.01, 50.01,  1.01 }"/>
-	<!-- Sphinx_Geometry_FracturePlane_End -->
+    <!-- Sphinx_Geometry_FracturePlane_End -->
   </Geometry>
 
   <Events
-    maxTime="100.0">
-    <!-- SoloEvent 
-      name="initialPlot"
-      target="/Outputs/siloOutput"/-->
+    maxTime="100.1">
 
     <SoloEvent
       name="preFracture"
       target="/Solvers/SurfaceGen"/>
 
-    <!-- SoloEvent 
-      name="preFracturePlot"
-      target="/Outputs/siloOutput"/-->
+    <PeriodicEvent
+      name="outputs"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Outputs/vtkOutput"/>
+
+    <PeriodicEvent
+      name="timeHistoryCollection0"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/pressureCollection" />
+
+    <PeriodicEvent
+      name="timeHistoryCollection1"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/apertureCollection" />
+
+    <PeriodicEvent
+      name="timeHistoryCollection2"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/hydraulicApertureCollection" /> 
+
+    <PeriodicEvent
+      name="timeHistoryCollection3"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/areaCollection" />      
+
+    <PeriodicEvent
+      name="timeHistoryOutput"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Outputs/timeHistoryOutput"/> 
 
     <PeriodicEvent
       name="solverApplications0"
@@ -74,15 +110,8 @@
 
     <PeriodicEvent
       name="solverApplications2"
-      beginTime="20.0"
-      endTime="100.0"
+      beginTime="20.0"      
       forceDt="1.0"
       target="/Solvers/hydrofracture"/>
-
-    <PeriodicEvent
-      name="outputs"
-      timeFrequency="10.0"
-      targetExactTimestep="0"
-      target="/Outputs/siloOutput"/>
   </Events>
 </Problem>

--- a/inputFiles/hydraulicFracturing/kgdViscosityDominated_base.xml
+++ b/inputFiles/hydraulicFracturing/kgdViscosityDominated_base.xml
@@ -3,7 +3,7 @@
 <Problem>
   <Solvers
     gravityVector="{ 0.0, 0.0, -0.0 }">
-	<!-- Sphinx_Solvers_Hydrofracture -->
+    <!-- Sphinx_Solvers_Hydrofracture -->
     <Hydrofracture
       name="hydrofracture"
       solidSolverName="lagsolve"
@@ -14,7 +14,7 @@
       targetRegions="{ Fracture }"
       contactRelationName="fractureContact"
       maxNumResolves="2">
-	  <!-- Sphinx_Solvers_Hydrofracture_End -->
+    <!-- Sphinx_Solvers_Hydrofracture_End -->
 
       <NonlinearSolverParameters
         newtonTol="1.0e-5"
@@ -24,14 +24,14 @@
         directParallel="0"/>
     </Hydrofracture>
 
-	<!-- Sphinx_Solvers_SolidMechanicsLagrangianSSLE -->
+    <!-- Sphinx_Solvers_SolidMechanicsLagrangianSSLE -->
     <SolidMechanicsLagrangianSSLE
       name="lagsolve"
       timeIntegrationOption="QuasiStatic"
       discretization="FE1"
       targetRegions="{ Domain, Fracture }"
       contactRelationName="fractureContact"/>
-	<!-- Sphinx_Solvers_SolidMechanicsLagrangianSSLE_End -->
+    <!-- Sphinx_Solvers_SolidMechanicsLagrangianSSLE_End -->
 
     <!-- Sphinx_Solvers_SinglePhaseFVM -->
     <SinglePhaseFVM
@@ -64,7 +64,6 @@
     </FiniteVolume>
   </NumericalMethods>
 
-
   <ElementRegions>
     <CellElementRegion
       name="Domain"
@@ -78,7 +77,7 @@
   </ElementRegions>
 
   <Constitutive>
-	<!-- Sphinx_Constitutive_CompressibleSinglePhaseFluid -->
+    <!-- Sphinx_Constitutive_CompressibleSinglePhaseFluid -->
     <CompressibleSinglePhaseFluid
       name="water"
       defaultDensity="1000"
@@ -87,15 +86,15 @@
       compressibility="5e-10"
       referenceViscosity="1.0e-3"
       viscosibility="0.0"/>
-	<!-- Sphinx_Constitutive_CompressibleSinglePhaseFluid_End -->
+    <!-- Sphinx_Constitutive_CompressibleSinglePhaseFluid_End -->
 
-	<!-- Sphinx_Constitutive_ElasticIsotropic -->
+    <!-- Sphinx_Constitutive_ElasticIsotropic -->
     <ElasticIsotropic
       name="rock"
       defaultDensity="2700"
       defaultYoungModulus="30.0e9"
       defaultPoissonRatio="0.25"/>
-	<!-- Sphinx_Constitutive_ElasticIsotropic_End -->
+    <!-- Sphinx_Constitutive_ElasticIsotropic_End -->
 
     <CompressibleSolidParallelPlatesPermeability
       name="fractureFilling"
@@ -119,7 +118,6 @@
       name="fractureContact"
       penaltyStiffness="1.0e0"
       apertureTableName="aperTable"/>
-
   </Constitutive>
 
   <FieldSpecifications>
@@ -131,7 +129,7 @@
       fieldName="water_density"
       scale="1000"/>
 
-	<!-- Sphinx_FieldSpecifications_FracturePlane -->
+    <!-- Sphinx_FieldSpecifications_FracturePlane -->
     <FieldSpecification
       name="separableFace"
       initialCondition="1"
@@ -139,9 +137,9 @@
       objectPath="faceManager"
       fieldName="isFaceSeparable"
       scale="1"/>
-	<!-- Sphinx_FieldSpecifications_FracturePlane_End -->
+    <!-- Sphinx_FieldSpecifications_FracturePlane_End -->
 
-	<!-- Sphinx_FieldSpecifications_InitFracture -->
+    <!-- Sphinx_FieldSpecifications_InitFracture -->
     <FieldSpecification
       name="frac"
       initialCondition="1"
@@ -149,7 +147,7 @@
       objectPath="faceManager"
       fieldName="ruptureState"
       scale="1"/>
-	<!-- Sphinx_FieldSpecifications_InitFracture_End -->
+    <!-- Sphinx_FieldSpecifications_InitFracture_End -->
 
     <FieldSpecification
       name="xConstraint"
@@ -175,15 +173,14 @@
       scale="0.0"
       setNames="{ zneg, zpos }"/>
 
-	<!-- Sphinx_SourceFlux_InjSource -->
+    <!-- Sphinx_SourceFlux_InjSource -->
     <SourceFlux
       name="sourceTerm"
       objectPath="ElementRegions/Fracture"
       scale="-5e-2"
       setNames="{ source }"/>
-	<!-- Sphinx_SourceFlux_InjSource_End -->
+    <!-- Sphinx_SourceFlux_InjSource_End -->
   </FieldSpecifications>
-
   
   <Functions>
     <TableFunction
@@ -192,13 +189,39 @@
       values="{ 0.002e-3, 0.02e-3 }"/>
   </Functions>
  
+  <Tasks>
+    <PackCollection
+      name="pressureCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="pressure"/>
+
+    <PackCollection
+      name="apertureCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="elementAperture"/> 
+
+    <PackCollection
+      name="hydraulicApertureCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="hydraulicAperture"/>  
+
+    <PackCollection
+      name="areaCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="elementArea"/> 
+  </Tasks>
 
   <Outputs>
-    <Silo
-      name="siloOutput"
-      plotFileRoot="plot"
+    <VTK
+      name="vtkOutput"
+      plotFileRoot="zeroToughness"
       plotLevel="3"
       parallelThreads="48"/>
+
+    <TimeHistory
+      name="timeHistoryOutput"
+      sources="{/Tasks/pressureCollection, /Tasks/apertureCollection, /Tasks/hydraulicApertureCollection, /Tasks/areaCollection}"
+      filename="KGD_zeroToughness_output" /> 
 
     <Restart
       name="restartOutput"/>

--- a/inputFiles/hydraulicFracturing/kgdViscosityDominated_benchmark.xml
+++ b/inputFiles/hydraulicFracturing/kgdViscosityDominated_benchmark.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" ?>
 
 <Problem>
-   <Included>
+  <Included>
     <File name="./kgdViscosityDominated_base.xml"/>
   </Included>
   
-   <Mesh>
-	<!-- Sphinx_Mesh_InternalMesh -->
+  <Mesh>
+    <!-- Sphinx_Mesh_InternalMesh -->
     <InternalMesh 
       name="mesh1"
       elementTypes="{C3D8}"
@@ -16,41 +16,84 @@
       nx="{ 30, 30 }"
       ny="{ 100 }"
       nz="{ 2 }"
-	  xBias="{ 0.5, -0.5 }"
+      xBias="{ 0.5, -0.5 }"
       cellBlockNames="{cb1}"/>
-	<!-- Sphinx_Mesh_InternalMesh_End -->
+    <!-- Sphinx_Mesh_InternalMesh_End -->
   </Mesh>
 
   <Geometry>
 
-	<!-- Sphinx_Geometry_InitFracture -->
+    <!-- Sphinx_Geometry_InitFracture -->
     <Box
       name="fracture"
       xMin="{ -0.01, -0.01, -0.01 }"
       xMax="{  0.01,  1.01,  1.01 }"/>
-	<!-- Sphinx_Geometry_InitFracture_End -->
+    <!-- Sphinx_Geometry_InitFracture_End -->
 
-	<!-- Sphinx_Geometry_InjSource -->
+    <!-- Sphinx_Geometry_InjSource -->
     <Box
       name="source"
       xMin="{ -0.01, -0.01, -0.01 }"
       xMax="{  0.01,  1.01,  1.01 }"/>
-	<!-- Sphinx_Geometry_InjSource_End -->
+    <!-- Sphinx_Geometry_InjSource_End -->
 
     <!-- Sphinx_Geometry_FracturePlane -->
     <Box
       name="core"
       xMin="{ -0.01, -0.01, -0.01 }"
       xMax="{  0.01, 50.01,  1.01 }"/>
-	<!-- Sphinx_Geometry_FracturePlane_End -->
+    <!-- Sphinx_Geometry_FracturePlane_End -->
   </Geometry>
 
   <Events
-    maxTime="100.0">
+    maxTime="100.1">
+
     <SoloEvent
       name="preFracture"
       target="/Solvers/SurfaceGen"/>
-      
+    
+    <PeriodicEvent
+      name="outputs"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Outputs/vtkOutput"/>
+
+    <PeriodicEvent
+      name="timeHistoryCollection0"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/pressureCollection" />
+
+    <PeriodicEvent
+      name="timeHistoryCollection1"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/apertureCollection" />
+
+    <PeriodicEvent
+      name="timeHistoryCollection2"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/hydraulicApertureCollection" /> 
+
+    <PeriodicEvent
+      name="timeHistoryCollection3"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/areaCollection" />      
+
+    <PeriodicEvent
+      name="timeHistoryOutput"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Outputs/timeHistoryOutput"/> 
+  
     <PeriodicEvent
       name="solverApplications0"
       beginTime="0.0"
@@ -67,16 +110,8 @@
 
     <PeriodicEvent
       name="solverApplications2"
-      beginTime="20.0"
-      endTime="100.0"
+      beginTime="20.0"      
       forceDt="1.0"
       target="/Solvers/hydrofracture"/>
-
-    <PeriodicEvent
-      name="outputs"
-      timeFrequency="2.0"
-      targetExactTimestep="0"
-      target="/Outputs/siloOutput"/>
-  </Events>
-  
+  </Events>  
 </Problem>

--- a/inputFiles/hydraulicFracturing/pennyShapedToughnessDominated_base.xml
+++ b/inputFiles/hydraulicFracturing/pennyShapedToughnessDominated_base.xml
@@ -9,7 +9,7 @@
       materialList="{ water, rock }"/>
 
     <SurfaceElementRegion
-      name="Fracture"
+      name="Fracture"      
       defaultAperture="0.02e-3"
       materialList="{ water, rock, fractureFilling, fractureContact }"/>
   </ElementRegions>
@@ -138,13 +138,40 @@
       values="{ 0.002e-3, 0.02e-3 }"/>
   </Functions>
 
+  <Tasks>
+    <PackCollection
+      name="pressureCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="pressure"/>
+
+    <PackCollection
+      name="apertureCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="elementAperture"/> 
+
+    <PackCollection
+      name="hydraulicApertureCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="hydraulicAperture"/>  
+
+    <PackCollection
+      name="areaCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="elementArea"/> 
+  </Tasks>
+
   <!-- SPHINX_OUTPUT -->    
   <Outputs>
-    <Silo
-      name="siloOutput"
+    <VTK
+      name="vtkOutput"
       plotFileRoot="zeroViscosity"
       plotLevel="3"
       parallelThreads="48"/>
+
+    <TimeHistory
+      name="timeHistoryOutput"
+      sources="{/Tasks/pressureCollection, /Tasks/apertureCollection, /Tasks/hydraulicApertureCollection, /Tasks/areaCollection}"
+      filename="Penny_zeroViscosity_output" />  
 
     <Restart
       name="restartOutput"/>

--- a/inputFiles/hydraulicFracturing/pennyShapedToughnessDominated_benchmark.xml
+++ b/inputFiles/hydraulicFracturing/pennyShapedToughnessDominated_benchmark.xml
@@ -22,7 +22,8 @@
       initialDt="0.1">
       <NonlinearSolverParameters
         newtonTol="1.0e-4"
-        newtonMaxIter="50"/>
+        newtonMaxIter="50"
+        logLevel="1"/>
       <LinearSolverParameters
         solverType="gmres"
         preconditionerType="mgr"
@@ -35,6 +36,7 @@
     <SolidMechanicsLagrangianSSLE
       name="lagsolve"
       timeIntegrationOption="QuasiStatic"
+      logLevel="1"
       discretization="FE1"
       targetRegions="{ Domain, Fracture }"
       contactRelationName="fractureContact">
@@ -49,6 +51,7 @@
   <!-- SPHINX_SINGLEPHASEFVM -->
     <SinglePhaseFVM
       name="SinglePhaseFlow"
+      logLevel="1"
       discretization="singlePhaseTPFA"
       targetRegions="{ Fracture }"
       inputFluxEstimate="1.0">
@@ -110,10 +113,53 @@
   </Geometry>
 
   <Events
-    maxTime="400.0">
+    maxTime="400.1">
     <SoloEvent
       name="preFracture"
       target="/Solvers/SurfaceGen"/>
+
+    <PeriodicEvent
+      name="outputs"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Outputs/vtkOutput"/>
+
+    <PeriodicEvent
+      name="timeHistoryCollection0"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/pressureCollection" />
+
+    <PeriodicEvent
+      name="timeHistoryCollection1"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/apertureCollection" />
+
+    <PeriodicEvent
+      name="timeHistoryCollection2"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/hydraulicApertureCollection" /> 
+
+    <PeriodicEvent
+      name="timeHistoryCollection3"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/areaCollection" />      
+
+    <PeriodicEvent
+      name="timeHistoryOutput"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Outputs/timeHistoryOutput"/> 
+
     <PeriodicEvent
       name="solverApplications1"
       beginTime="0.0"
@@ -165,22 +211,8 @@
 
     <PeriodicEvent
       name="solverApplications8"
-      beginTime="200.0"
-      endTime="400.0"
+      beginTime="200.0"      
       forceDt="20.0"
       target="/Solvers/hydrofracture"/>
-
-    <PeriodicEvent
-      name="outputs2"
-      beginTime="2.0"
-      timeFrequency="2.0"
-      targetExactTimestep="0"
-      target="/Outputs/siloOutput"/>
-
-    <PeriodicEvent 
-      name="restarts"
-      timeFrequency="200.0"
-      targetExactTimestep="0"
-      target="/Outputs/restartOutput" />
   </Events>
 </Problem>

--- a/inputFiles/hydraulicFracturing/pennyShapedViscosityDominated_base.xml
+++ b/inputFiles/hydraulicFracturing/pennyShapedViscosityDominated_base.xml
@@ -139,13 +139,40 @@
       values="{ 0.005e-3, 0.01e-3, 0.02e-3 }"/>
   </Functions>
 
+  <Tasks>
+    <PackCollection
+      name="pressureCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="pressure"/>
+
+    <PackCollection
+      name="apertureCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="elementAperture"/> 
+
+    <PackCollection
+      name="hydraulicApertureCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="hydraulicAperture"/>  
+
+    <PackCollection
+      name="areaCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="elementArea"/> 
+  </Tasks>
+
   <!-- SPHINX_OUTPUT -->          
   <Outputs>
-    <Silo
-      name="siloOutput"
+    <VTK
+      name="vtkOutput"
       plotFileRoot="zeroToughness"
       plotLevel="3"
       parallelThreads="48"/>
+
+    <TimeHistory
+      name="timeHistoryOutput"
+      sources="{/Tasks/pressureCollection, /Tasks/apertureCollection, /Tasks/hydraulicApertureCollection, /Tasks/areaCollection}"
+      filename="Penny_zeroToughness_output" />  
 
     <Restart
       name="restartOutput"/>

--- a/inputFiles/hydraulicFracturing/pennyShapedViscosityDominated_benchmark.xml
+++ b/inputFiles/hydraulicFracturing/pennyShapedViscosityDominated_benchmark.xml
@@ -23,7 +23,8 @@
       <NonlinearSolverParameters
         newtonTol="1.0e-4"
         newtonMaxIter="10"
-        maxTimeStepCuts="5"/>
+        maxTimeStepCuts="5"
+        logLevel="1"/>
       <LinearSolverParameters
         solverType="gmres"
         preconditionerType="mgr"
@@ -36,6 +37,7 @@
     <SolidMechanicsLagrangianSSLE
       name="lagsolve"
       timeIntegrationOption="QuasiStatic"
+      logLevel="1"
       discretization="FE1"
       targetRegions="{ Domain, Fracture }"
       contactRelationName="fractureContact">
@@ -50,6 +52,7 @@
   <!-- SPHINX_SINGLEPHASEFVM -->
     <SinglePhaseFVM
       name="SinglePhaseFlow"
+      logLevel="1"
       discretization="singlePhaseTPFA"
       targetRegions="{ Fracture }"
       inputFluxEstimate="1.0">
@@ -111,10 +114,52 @@
   </Geometry>
 
   <Events
-    maxTime="400.0">
+    maxTime="400.1">
     <SoloEvent
       name="preFracture"
       target="/Solvers/SurfaceGen"/>
+
+    <PeriodicEvent
+      name="outputs"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Outputs/vtkOutput"/>
+
+    <PeriodicEvent
+      name="timeHistoryCollection0"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/pressureCollection" />
+
+    <PeriodicEvent
+      name="timeHistoryCollection1"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/apertureCollection" />
+
+    <PeriodicEvent
+      name="timeHistoryCollection2"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/hydraulicApertureCollection" /> 
+
+    <PeriodicEvent
+      name="timeHistoryCollection3"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/areaCollection" />      
+
+    <PeriodicEvent
+      name="timeHistoryOutput"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Outputs/timeHistoryOutput"/> 
 
     <PeriodicEvent
       name="solverApplications1"
@@ -167,22 +212,8 @@
 
     <PeriodicEvent
       name="solverApplications8"
-      beginTime="200.0"
-      endTime="400.0"
+      beginTime="200.0"      
       forceDt="20.0"
-      target="/Solvers/hydrofracture"/> 
-
-    <PeriodicEvent
-      name="outputs"
-      beginTime="2.0"
-      timeFrequency="2.0"
-      targetExactTimestep="0"
-      target="/Outputs/siloOutput"/>
-
-    <PeriodicEvent 
-      name="restarts"
-      timeFrequency="200.0"
-      targetExactTimestep="0"
-      target="/Outputs/restartOutput" />
+      target="/Solvers/hydrofracture"/>
   </Events>
 </Problem>

--- a/inputFiles/hydraulicFracturing/pknViscosityDominated_base.xml
+++ b/inputFiles/hydraulicFracturing/pknViscosityDominated_base.xml
@@ -139,13 +139,40 @@
       values="{ 0.005e-3, 0.01e-3, 0.02e-3 }"/>
   </Functions>
 
+  <Tasks>
+    <PackCollection
+      name="pressureCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="pressure"/>
+
+    <PackCollection
+      name="apertureCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="elementAperture"/> 
+
+    <PackCollection
+      name="hydraulicApertureCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="hydraulicAperture"/>  
+
+    <PackCollection
+      name="areaCollection"
+      objectPath="ElementRegions/Fracture/FractureSubRegion"
+      fieldName="elementArea"/> 
+  </Tasks>
+
   <!-- SPHINX_OUTPUT -->         
   <Outputs>
-    <Silo
-      name="siloOutput"
+    <VTK
+      name="vtkOutput"
       plotFileRoot="zeroToughness"
       plotLevel="3"
       parallelThreads="48"/>
+
+    <TimeHistory
+      name="timeHistoryOutput"
+      sources="{/Tasks/pressureCollection, /Tasks/apertureCollection, /Tasks/hydraulicApertureCollection, /Tasks/areaCollection}"
+      filename="Penny_zeroToughness_output" />  
 
     <Restart
       name="restartOutput"/>

--- a/inputFiles/hydraulicFracturing/pknViscosityDominated_benchmark.xml
+++ b/inputFiles/hydraulicFracturing/pknViscosityDominated_benchmark.xml
@@ -111,10 +111,52 @@
   </Geometry>
 
   <Events
-    maxTime="200.0"> 
+    maxTime="200.1"> 
     <SoloEvent
       name="preFracture"
       target="/Solvers/SurfaceGen"/>
+
+    <PeriodicEvent
+      name="outputs"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Outputs/vtkOutput"/>
+
+    <PeriodicEvent
+      name="timeHistoryCollection0"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/pressureCollection" />
+
+    <PeriodicEvent
+      name="timeHistoryCollection1"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/apertureCollection" />
+
+    <PeriodicEvent
+      name="timeHistoryCollection2"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/hydraulicApertureCollection" /> 
+
+    <PeriodicEvent
+      name="timeHistoryCollection3"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Tasks/areaCollection" />      
+
+    <PeriodicEvent
+      name="timeHistoryOutput"
+      beginTime="2.0"
+      timeFrequency="2.0"
+      targetExactTimestep="0"
+      target="/Outputs/timeHistoryOutput"/> 
  
     <PeriodicEvent
       name="solverApplications1"
@@ -161,21 +203,7 @@
     <PeriodicEvent
       name="solverApplications7"
       beginTime="100.0"
-      endTime="200.0"
       forceDt="10.0"
       target="/Solvers/hydrofracture"/>
-  
-    <PeriodicEvent
-      name="outputs"
-      beginTime="2.0"
-      timeFrequency="2.0"
-      targetExactTimestep="0"
-      target="/Outputs/siloOutput"/>
-
-    <PeriodicEvent 
-      name="restarts"
-      timeFrequency="100.0"
-      targetExactTimestep="0"
-      target="/Outputs/restartOutput" />
   </Events> 
 </Problem>


### PR DESCRIPTION
This PR 
- [x] update xml files of existing HF examples with HDF5 and vtk outputs and remove silo outputs 
- [ ] add python scripts for postprocessing HDF5 outputs to exact fracture characteristics (length, width and pressure)
- [ ] update the corresponding rst files 
No change of the existing smoke tests and hence no need of the rebaseline