### PR TITLE
Update Adiak 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ vm:
 
 env:
   global:
-  - GEOSX_TPL_TAG=209-895
+  - GEOSX_TPL_TAG=201-896
   - secure: CGs2uH6efq1Me6xJWRr0BnwtwxoujzlowC4FHXHdWbNOkPsXf7nCgdaW5vthfD3bhnOeEUQSrfxdhTRtyU/NfcKLmKgGBnZOdUG4/JJK4gDSJ2Wp8LZ/mB0QEoODKVxbh+YtoAiHe3y4M9PGCs+wkNDw/3eEU00cK12DZ6gad0RbLjI3xkhEr/ZEZDZkcYg9yHAhl5bmpqoh/6QGnIg8mxIqdAtGDw+6tT0EgUqjeqc5bG5WwsamKzJItHSXD5zx8IJAlgDk4EzEGjZe0m56YnNfb9iwqqUsmL3Cuwgs7ByVDYw78JC5Kv42YqoxA5BxMT2mFsEe37TpYNXlzofU7ma2Duw9DGXWQd4IkTCcBxlyR0I0bfo0TmgO+y7PYG9lIyHPUkENemdozsZcWamqqkqegiEdRhDVYlSRo3mu7iCwTS6ZTALliVyEYjYxYb7oAnR3cNywXjblTCI8oKfgLSY+8WijM9SRl57JruIHLkLMCjmRI+cZBfv5tS2tYQTBPkygGrigrrN77ZiC7/TGyfggSN0+y0oYtOAgqEnBcKcreiibMW7tKcV2Z1RFD9ZvIkSc1EXLUPDP8FX1oyhmqBMqVo8LksrYLDJHQ05+F3YNgl2taSt7uMjQ4e8iZ3/IjFeMnbylDw+cj/RbS520HXsFPbWFm2Pb9pceA9n6GnY=
 
 # The integrated test repository contains large data (using git lfs) and we do not use them here.

--- a/src/cmake/GeosxOptions.cmake
+++ b/src/cmake/GeosxOptions.cmake
@@ -128,7 +128,7 @@ include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG("-Wunused-but-set-variable" CXX_UNUSED_BUT_SET_VAR)
 if (ENABLE_GBENCHMARK)
     blt_add_target_compile_flags(TO benchmark
-                                FLAGS $<$<AND:${CXX_UNUSED_BUT_SET_VAR},$<COMPILE_LANGUAGE:CXX>>:-Wno-unused-but-set-variable>
+                                FLAGS $<$<AND:$<BOOL:${CXX_UNUSED_BUT_SET_VAR}>,$<COMPILE_LANGUAGE:CXX>>:-Wno-unused-but-set-variable>
                                 )
 endif()
 

--- a/src/cmake/thirdparty/SetupGeosxThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupGeosxThirdParty.cmake
@@ -314,11 +314,8 @@ if(DEFINED ADIAK_DIR)
                  PATHS ${ADIAK_DIR}
                  NO_DEFAULT_PATH)
 
-    extract_version_from_header( name adiak 
-                                 HEADER "${ADIAK_DIR}/include/adiak.h"
-                                 MAJOR_VERSION_STRING "ADIAK_VERSION"
-                                 MINOR_VERSION_STRING "ADIAK_MINOR_VERSION"
-                                 SUBMINOR_VERSION_STRING "ADIAK_POINT_VERSION")
+    # Header file provides incorrect version 0.3.0
+    message( " ----> adiak_VERSION = 0.2.2")
 
     set_property(TARGET adiak::adiak
                  APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES

--- a/src/cmake/thirdparty/SetupGeosxThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupGeosxThirdParty.cmake
@@ -317,15 +317,23 @@ if(DEFINED ADIAK_DIR)
     # Header file provides incorrect version 0.3.0
     message( " ----> adiak_VERSION = 0.2.2")
 
-    set_property(TARGET adiak::adiak
+    set(adiak_target "")
+    if(TARGET adiak::adiak)
+      set(adiak_target ${adiak_target} adiak::adiak)
+    endif()
+    if(TARGET adiak)
+      set(adiak_target ${adiak_target} adiak)
+    endif()
+
+    set_property(TARGET ${adiak_target}
                  APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
                  ${adiak_INCLUDE_DIR} )
-    set_property(TARGET adiak::adiak
+    set_property(TARGET ${adiak_target}
                  APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES
                  ${adiak_INCLUDE_DIR} )
 
     set(ENABLE_ADIAK ON CACHE BOOL "")
-    set(thirdPartyLibs ${thirdPartyLibs} adiak::adiak)
+    set(thirdPartyLibs ${thirdPartyLibs} ${adiak_target})
 else()
     if(ENABLE_ADIAK)
         message(WARNING "ENABLE_ADIAK is ON but ADIAK_DIR isn't defined.")

--- a/src/cmake/thirdparty/SetupGeosxThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupGeosxThirdParty.cmake
@@ -320,15 +320,15 @@ if(DEFINED ADIAK_DIR)
                                  MINOR_VERSION_STRING "ADIAK_MINOR_VERSION"
                                  SUBMINOR_VERSION_STRING "ADIAK_POINT_VERSION")
 
-                 set_property(TARGET adiak
+    set_property(TARGET adiak::adiak
                  APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
                  ${adiak_INCLUDE_DIR} )
-    set_property(TARGET adiak
+    set_property(TARGET adiak::adiak
                  APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES
                  ${adiak_INCLUDE_DIR} )
 
     set(ENABLE_ADIAK ON CACHE BOOL "")
-    set(thirdPartyLibs ${thirdPartyLibs} adiak)
+    set(thirdPartyLibs ${thirdPartyLibs} adiak::adiak)
 else()
     if(ENABLE_ADIAK)
         message(WARNING "ENABLE_ADIAK is ON but ADIAK_DIR isn't defined.")

--- a/src/coreComponents/common/CMakeLists.txt
+++ b/src/coreComponents/common/CMakeLists.txt
@@ -52,7 +52,7 @@ if( ENABLE_MPI )
 endif()
 
 if( ENABLE_CALIPER )
-  set( dependencyList ${dependencyList} caliper adiak )
+  set( dependencyList ${dependencyList} caliper adiak::adiak )
 endif()
 
 blt_add_library( NAME       common

--- a/src/coreComponents/common/CMakeLists.txt
+++ b/src/coreComponents/common/CMakeLists.txt
@@ -52,7 +52,15 @@ if( ENABLE_MPI )
 endif()
 
 if( ENABLE_CALIPER )
-  set( dependencyList ${dependencyList} caliper adiak::adiak )
+  set( dependencyList ${dependencyList} caliper )
+
+  if (TARGET adiak::adiak)
+    set( dependencyList ${dependencyList} adiak::adiak )
+  endif()
+
+  if (TARGET adiak)
+    set( dependencyList ${dependencyList} adiak )
+  endif()
 endif()
 
 blt_add_library( NAME       common

--- a/src/coreComponents/common/unitTests/CMakeLists.txt
+++ b/src/coreComponents/common/unitTests/CMakeLists.txt
@@ -7,6 +7,11 @@ set(gtest_geosx_tests
     testTypeDispatch.cpp
    )
 
+if ( ENABLE_CALIPER )
+  list( APPEND gtest_geosx_tests
+        testCaliperSmoke.cpp )
+endif()
+
 set( dependencyList common hdf5 gtest )
 
 if( ENABLE_CUDA )

--- a/src/coreComponents/common/unitTests/testCaliperSmoke.cpp
+++ b/src/coreComponents/common/unitTests/testCaliperSmoke.cpp
@@ -1,0 +1,58 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2022 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2022 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2022 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <string>
+
+#include "common/TimingMacros.hpp"
+#include <adiak.hpp>
+
+TEST( CaliperSmoke, SmokeTest )
+{
+
+  bool preset = false;
+
+  // Check for CALI_CONFIG environment variable
+  if( getenv( "CALI_CONFIG" ) != NULL )
+  {
+    std::string config( getenv( "CALI_CONFIG" ));
+    if( config.find( "runtime-report" ) != std::string::npos )
+    {
+      preset = true;
+    }
+    else
+    {
+      FAIL() << "testCaliperSmoke failed - environment variable "
+             << " CALI_CONFIG must contain 'runtime-report' or be unset";
+    }
+  }
+  else
+  {
+    setenv( "CALI_CONFIG", "runtime-report", 0 );
+  }
+
+  GEOSX_CALIPER_MARK_FUNCTION_BEGIN;
+  EXPECT_STRNE( cali_caliper_version(), NULL );
+  GEOSX_CALIPER_MARK_FUNCTION_END;
+
+  adiak::init( nullptr );
+  adiak::fini();
+
+  if( !preset )
+  {
+    unsetenv( "CALI_CONFIG" );
+  }
+}


### PR DESCRIPTION
This PR:
- Resolves #2129 
- Updates Adiak (v0.2.0 --> v0.2.2)
- Rebuilds TPLs with new Adiak version
- Adds smoke test for Caliper/Adiak
- Fixes reported generator expression bug:
```
CMake Error at cmake/blt/cmake/BLTPrivateMacros.cmake:435 (target_link_libraries):
  Error evaluating generator expression:
    $<AND:,$<COMPILE_LANGUAGE:CXX>>
  Parameters to $<AND> must resolve to either '0' or '1'.
Call Stack (most recent call first):
  cmake/blt/cmake/BLTMacros.cmake:788 (blt_setup_target)
  coreComponents/LvArray/benchmarks/CMakeLists.txt:33 (blt_add_executable)
```

Relates to GEOSX/thirdPartyLibs#201
Relates to GEOSX/LvArray#273