### PR TITLE
Allow choice of finite element types in Finite Element Dispatch

### DIFF
--- a/src/coreComponents/finiteElement/FiniteElementDispatch.hpp
+++ b/src/coreComponents/finiteElement/FiniteElementDispatch.hpp
@@ -30,178 +30,127 @@
 #include "elementFormulations/Q3_Hexahedron_Lagrange_GaussLobatto.hpp"
 #include "LvArray/src/system.hpp"
 
-
+#define BASE_FE_TYPES finiteElement::H1_Hexahedron_Lagrange1_GaussLegendre2, \
+  finiteElement::H1_Wedge_Lagrange1_Gauss6, \
+  finiteElement::H1_Tetrahedron_Lagrange1_Gauss1, \
+  finiteElement::H1_Pyramid_Lagrange1_Gauss5, \
+  finiteElement::Q3_Hexahedron_Lagrange_GaussLobatto
+#ifdef GEOSX_DISPATCH_VEM
+#define VEM_TYPES finiteElement::H1_Tetrahedron_VEM_Gauss1, \
+  finiteElement::H1_Wedge_VEM_Gauss1, \
+  finiteElement::H1_Hexahedron_VEM_Gauss1, \
+  finiteElement::H1_Prism5_VEM_Gauss1, \
+  finiteElement::H1_Prism6_VEM_Gauss1, \
+  finiteElement::H1_Prism7_VEM_Gauss1, \
+  finiteElement::H1_Prism8_VEM_Gauss1, \
+  finiteElement::H1_Prism9_VEM_Gauss1, \
+  finiteElement::H1_Prism10_VEM_Gauss1, \
+  finiteElement::H1_Prism11_VEM_Gauss1
+#define ALL_FE_TYPES BASE_FE_TYPES, VEM_TYPES
+#else
+#define ALL_FE_TYPES BASE_FE_TYPES
+#endif
 
 namespace geosx
 {
 namespace finiteElement
 {
 
-template< typename LAMBDA >
-void
-dispatch3D( FiniteElementBase const & input,
-            LAMBDA && lambda )
+/**
+ * @brief Helper structure for dynamic finite element dispatch
+ * @tparam FE_TYPES list of finite element types to handle
+ */
+template< typename ... FE_TYPES >
+struct FiniteElementDispatchHandler {};
+
+/**
+ * @brief Finite elemnt dispatch fall-through in case all casts were unsuccessful: always error
+ */
+template<>
+struct FiniteElementDispatchHandler<>
 {
-  if( auto const * const ptr1 = dynamic_cast< H1_Hexahedron_Lagrange1_GaussLegendre2 const * >(&input) )
+  template< typename LAMBDA >
+  static void
+  dispatch3D( FiniteElementBase const & input,
+              LAMBDA && lambda )
   {
-    lambda( *ptr1 );
-  }
-  else if( auto const * const ptr2 = dynamic_cast< H1_Wedge_Lagrange1_Gauss6 const * >(&input) )
-  {
-    lambda( *ptr2 );
-  }
-  else if( auto const * const ptr3 = dynamic_cast< H1_Tetrahedron_Lagrange1_Gauss1 const * >(&input) )
-  {
-    lambda( *ptr3 );
-  }
-  else if( auto const * const ptr4 = dynamic_cast< H1_Pyramid_Lagrange1_Gauss5 const * >(&input) )
-  {
-    lambda( *ptr4 );
-  }
-  else if( auto const * const ptr5 = dynamic_cast< Q3_Hexahedron_Lagrange_GaussLobatto const * >(&input) )
-  {
-    lambda( *ptr5 );
-  }
-#ifdef GEOSX_DISPATCH_VEM
-  else if( auto const * const ptr6 = dynamic_cast< H1_Tetrahedron_VEM_Gauss1 const * >(&input) ) // VEM on Tetrahedron
-  {
-    lambda( *ptr6 );
-  }
-  else if( auto const * const ptr7 = dynamic_cast< H1_Wedge_VEM_Gauss1 const * >(&input) ) // VEM on Wedge
-  {
-    lambda( *ptr7 );
-  }
-  else if( auto const * const ptr8 = dynamic_cast< H1_Hexahedron_VEM_Gauss1 const * >(&input) ) // VEM on Hexahedron
-  {
-    lambda( *ptr8 );
-  }
-  else if( auto const * const ptr9 = dynamic_cast< H1_Prism5_VEM_Gauss1 const * >(&input) ) // VEM on Prism5
-  {
-    lambda( *ptr9 );
-  }
-  else if( auto const * const ptr10 = dynamic_cast< H1_Prism6_VEM_Gauss1 const * >(&input) ) // VEM on Prism6
-  {
-    lambda( *ptr10 );
-  }
-  else if( auto const * const ptr11 = dynamic_cast< H1_Prism7_VEM_Gauss1 const * >(&input) ) // VEM on Prism7
-  {
-    lambda( *ptr11 );
-  }
-  else if( auto const * const ptr12 = dynamic_cast< H1_Prism8_VEM_Gauss1 const * >(&input) ) // VEM on Prism8
-  {
-    lambda( *ptr12 );
-  }
-  else if( auto const * const ptr13 = dynamic_cast< H1_Prism9_VEM_Gauss1 const * >(&input) ) // VEM on Prism9
-  {
-    lambda( *ptr13 );
-  }
-  else if( auto const * const ptr14 = dynamic_cast< H1_Prism10_VEM_Gauss1 const * >(&input) ) // VEM on Prism10
-  {
-    lambda( *ptr14 );
-  }
-  else if( auto const * const ptr15 = dynamic_cast< H1_Prism11_VEM_Gauss1 const * >(&input) ) // VEM on Prism11
-  {
-    lambda( *ptr15 );
-  }
-#endif
-  else
-  {
+    GEOSX_UNUSED_VAR( lambda );
     GEOSX_ERROR( "finiteElement::dispatch3D() is not implemented for input of "<<typeid(input).name() );
   }
-}
 
+  template< typename LAMBDA >
+  static void
+  dispatch3D( FiniteElementBase & input,
+              LAMBDA && lambda )
+  {
+    GEOSX_UNUSED_VAR( lambda );
+    GEOSX_ERROR( "finiteElement::dispatch3D() is not implemented for input of "<<typeid(input).name() );
+  }
 
-template< typename LAMBDA >
-void
-dispatch3D( FiniteElementBase & input,
-            LAMBDA && lambda )
-{
-  if( auto * const ptr1 = dynamic_cast< H1_Hexahedron_Lagrange1_GaussLegendre2 * >(&input) )
+  template< typename LAMBDA >
+  static void
+  dispatch2D( FiniteElementBase const & input,
+              LAMBDA && lambda )
   {
-    lambda( *ptr1 );
-  }
-  else if( auto * const ptr2 = dynamic_cast< H1_Wedge_Lagrange1_Gauss6 * >(&input) )
-  {
-    lambda( *ptr2 );
-  }
-  else if( auto * const ptr3 = dynamic_cast< H1_Tetrahedron_Lagrange1_Gauss1 * >(&input) )
-  {
-    lambda( *ptr3 );
-  }
-  else if( auto * const ptr4 = dynamic_cast< H1_Pyramid_Lagrange1_Gauss5 * >(&input) )
-  {
-    lambda( *ptr4 );
-  }
-  else if( auto * const ptr5 = dynamic_cast< Q3_Hexahedron_Lagrange_GaussLobatto * >(&input) )
-  {
-    lambda( *ptr5 );
-  }
-#ifdef GEOSX_DISPATCH_VEM
-  else if( auto * const ptr6 = dynamic_cast< H1_Tetrahedron_VEM_Gauss1 * >(&input) ) // VEM on Tetrahedron
-  {
-    lambda( *ptr6 );
-  }
-  else if( auto * const ptr7 = dynamic_cast< H1_Wedge_VEM_Gauss1 * >(&input) ) // VEM on Wedge
-  {
-    lambda( *ptr7 );
-  }
-  else if( auto * const ptr8 = dynamic_cast< H1_Hexahedron_VEM_Gauss1 * >(&input) ) // VEM on Hexahedron
-  {
-    lambda( *ptr8 );
-  }
-  else if( auto * const ptr9 = dynamic_cast< H1_Prism5_VEM_Gauss1 * >(&input) ) // VEM on Prism5
-  {
-    lambda( *ptr9 );
-  }
-  else if( auto * const ptr10 = dynamic_cast< H1_Prism6_VEM_Gauss1 * >(&input) ) // VEM on Prism6
-  {
-    lambda( *ptr10 );
-  }
-  else if( auto * const ptr11 = dynamic_cast< H1_Prism7_VEM_Gauss1 * >(&input) ) // VEM on Prism7
-  {
-    lambda( *ptr11 );
-  }
-  else if( auto * const ptr12 = dynamic_cast< H1_Prism8_VEM_Gauss1 * >(&input) ) // VEM on Prism8
-  {
-    lambda( *ptr12 );
-  }
-  else if( auto * const ptr13 = dynamic_cast< H1_Prism9_VEM_Gauss1 * >(&input) ) // VEM on Prism9
-  {
-    lambda( *ptr13 );
-  }
-  else if( auto * const ptr14 = dynamic_cast< H1_Prism10_VEM_Gauss1 * >(&input) ) // VEM on Prism10
-  {
-    lambda( *ptr14 );
-  }
-  else if( auto * const ptr15 = dynamic_cast< H1_Prism11_VEM_Gauss1 * >(&input) ) // VEM on Prism11
-  {
-    lambda( *ptr15 );
-  }
-#endif
-  else
-  {
-    GEOSX_ERROR( "finiteElement::dispatch3D() is not implemented for input of "<<LvArray::system::demangleType( &input ) );
-  }
-}
-
-template< typename LAMBDA >
-void
-dispatch2D( FiniteElementBase const & input,
-            LAMBDA && lambda )
-{
-  if( auto const * const ptr1 = dynamic_cast< H1_QuadrilateralFace_Lagrange1_GaussLegendre2 const * >(&input) )
-  {
-    lambda( *ptr1 );
-  }
-  else if( auto const * const ptr2 = dynamic_cast< H1_TriangleFace_Lagrange1_Gauss1 const * >(&input) )
-  {
-    lambda( *ptr2 );
-  }
-  else
-  {
+    GEOSX_UNUSED_VAR( lambda );
     GEOSX_ERROR( "finiteElement::dispatch2D() is not implemented for input of: "<<LvArray::system::demangleType( &input ) );
   }
-}
+};
+
+/**
+ * @brief Structure for recursive finite element dispatch implementation
+ * @tparam FE_TYPE first finite element type to handle
+ * @tparam FE_TYPES following finite element types to handle
+ */
+template< typename FE_TYPE, typename ... FE_TYPES >
+struct FiniteElementDispatchHandler< FE_TYPE, FE_TYPES... >
+{
+  template< typename LAMBDA >
+  static void
+  dispatch3D( FiniteElementBase const & input,
+              LAMBDA && lambda )
+  {
+    if( auto const * const ptr = dynamic_cast< FE_TYPE const * >(&input) )
+    {
+      lambda( *ptr );
+    }
+    else
+    {
+      FiniteElementDispatchHandler< FE_TYPES... >::dispatch3D( input, lambda );
+    }
+  }
+
+  template< typename LAMBDA >
+  static void
+  dispatch3D( FiniteElementBase & input,
+              LAMBDA && lambda )
+  {
+    if( auto * const ptr = dynamic_cast< FE_TYPE * >(&input) )
+    {
+      lambda( *ptr );
+    }
+    else
+    {
+      FiniteElementDispatchHandler< FE_TYPES... >::dispatch3D( input, lambda );
+    }
+  }
+
+  template< typename LAMBDA >
+  static void
+  dispatch2D( FiniteElementBase const & input,
+              LAMBDA && lambda )
+  {
+    if( auto const * const ptr = dynamic_cast< FE_TYPE const * >(&input) )
+    {
+      lambda( *ptr );
+    }
+    else
+    {
+      FiniteElementDispatchHandler< FE_TYPES... >::dispatch2D( input, lambda );
+    }
+  }
+};
+
 
 }
 }

--- a/src/coreComponents/finiteElement/FiniteElementDispatch.hpp
+++ b/src/coreComponents/finiteElement/FiniteElementDispatch.hpp
@@ -23,17 +23,16 @@
 #include "elementFormulations/ConformingVirtualElementOrder1.hpp"
 #include "elementFormulations/H1_Hexahedron_Lagrange1_GaussLegendre2.hpp"
 #include "elementFormulations/H1_Pyramid_Lagrange1_Gauss5.hpp"
-#include "elementFormulations/H1_QuadrilateralFace_Lagrange1_GaussLegendre2.hpp"
 #include "elementFormulations/H1_Tetrahedron_Lagrange1_Gauss1.hpp"
-#include "elementFormulations/H1_TriangleFace_Lagrange1_Gauss1.hpp"
 #include "elementFormulations/H1_Wedge_Lagrange1_Gauss6.hpp"
 #include "elementFormulations/Q3_Hexahedron_Lagrange_GaussLobatto.hpp"
 #include "elementFormulations/H1_QuadrilateralFace_Lagrange1_GaussLegendre2.hpp"
-#include "elementFormulations/H1_TriangleFace_Lagrange1_Gauss1.hpp" 
+#include "elementFormulations/H1_TriangleFace_Lagrange1_Gauss1.hpp"
 #include "LvArray/src/system.hpp"
 
 #define BASE_FE_TYPES \
   finiteElement::H1_Hexahedron_Lagrange1_GaussLegendre2, \
+  finiteElement::Q3_Hexahedron_Lagrange_GaussLobatto, \
   finiteElement::H1_Wedge_Lagrange1_Gauss6, \
   finiteElement::H1_Tetrahedron_Lagrange1_Gauss1, \
   finiteElement::H1_Pyramid_Lagrange1_Gauss5
@@ -56,7 +55,7 @@
 
 #define FE_TYPES_2D \
   finiteElement::H1_QuadrilateralFace_Lagrange1_GaussLegendre2.hpp  \
-  finiteElement::H1_TriangleFace_Lagrange1_Gauss1.hpp 
+  finiteElement::H1_TriangleFace_Lagrange1_Gauss1.hpp
 
 namespace geosx
 {

--- a/src/coreComponents/finiteElement/FiniteElementDispatch.hpp
+++ b/src/coreComponents/finiteElement/FiniteElementDispatch.hpp
@@ -28,6 +28,8 @@
 #include "elementFormulations/H1_TriangleFace_Lagrange1_Gauss1.hpp"
 #include "elementFormulations/H1_Wedge_Lagrange1_Gauss6.hpp"
 #include "elementFormulations/Q3_Hexahedron_Lagrange_GaussLobatto.hpp"
+#include "elementFormulations/H1_QuadrilateralFace_Lagrange1_GaussLegendre2.hpp"
+#include "elementFormulations/H1_TriangleFace_Lagrange1_Gauss1.hpp" 
 #include "LvArray/src/system.hpp"
 
 #define BASE_FE_TYPES \
@@ -51,6 +53,10 @@
 #else
 #define ALL_FE_TYPES BASE_FE_TYPES
 #endif
+
+#define FE_TYPES_2D \
+  finiteElement::H1_QuadrilateralFace_Lagrange1_GaussLegendre2.hpp  \
+  finiteElement::H1_TriangleFace_Lagrange1_Gauss1.hpp 
 
 namespace geosx
 {

--- a/src/coreComponents/finiteElement/FiniteElementDispatch.hpp
+++ b/src/coreComponents/finiteElement/FiniteElementDispatch.hpp
@@ -30,13 +30,14 @@
 #include "elementFormulations/Q3_Hexahedron_Lagrange_GaussLobatto.hpp"
 #include "LvArray/src/system.hpp"
 
-#define BASE_FE_TYPES finiteElement::H1_Hexahedron_Lagrange1_GaussLegendre2, \
+#define BASE_FE_TYPES \
+  finiteElement::H1_Hexahedron_Lagrange1_GaussLegendre2, \
   finiteElement::H1_Wedge_Lagrange1_Gauss6, \
   finiteElement::H1_Tetrahedron_Lagrange1_Gauss1, \
-  finiteElement::H1_Pyramid_Lagrange1_Gauss5, \
-  finiteElement::Q3_Hexahedron_Lagrange_GaussLobatto
+  finiteElement::H1_Pyramid_Lagrange1_Gauss5
 #ifdef GEOSX_DISPATCH_VEM
-#define VEM_TYPES finiteElement::H1_Tetrahedron_VEM_Gauss1, \
+#define VEM_TYPES \
+  finiteElement::H1_Tetrahedron_VEM_Gauss1, \
   finiteElement::H1_Wedge_VEM_Gauss1, \
   finiteElement::H1_Hexahedron_VEM_Gauss1, \
   finiteElement::H1_Prism5_VEM_Gauss1, \

--- a/src/coreComponents/finiteElement/kernelInterface/KernelBase.hpp
+++ b/src/coreComponents/finiteElement/kernelInterface/KernelBase.hpp
@@ -27,6 +27,10 @@
 #include "mesh/MeshLevel.hpp"
 #include "common/GEOS_RAJA_Interface.hpp"
 
+#ifndef SELECTED_FE_TYPES
+#define SELECTED_FE_TYPES ALL_FE_TYPES
+#endif
+
 namespace geosx
 {
 
@@ -418,16 +422,16 @@ real64 regionBasedKernelApplication( MeshLevel & mesh,
       FiniteElementBase &
       subRegionFE = elementSubRegion.template getReference< FiniteElementBase >( finiteElementName );
 
-      finiteElement::FiniteElementDispatchHandler< ALL_FE_TYPES >::dispatch3D( subRegionFE,
-                                                                               [&maxResidualContribution,
-                                                                                &nodeManager,
-                                                                                &edgeManager,
-                                                                                &faceManager,
-                                                                                targetRegionIndex,
-                                                                                &kernelFactory,
-                                                                                &elementSubRegion,
-                                                                                numElems,
-                                                                                &castedConstitutiveRelation] ( auto const finiteElement )
+      finiteElement::FiniteElementDispatchHandler< SELECTED_FE_TYPES >::dispatch3D( subRegionFE,
+                                                                                    [&maxResidualContribution,
+                                                                                     &nodeManager,
+                                                                                     &edgeManager,
+                                                                                     &faceManager,
+                                                                                     targetRegionIndex,
+                                                                                     &kernelFactory,
+                                                                                     &elementSubRegion,
+                                                                                     numElems,
+                                                                                     &castedConstitutiveRelation] ( auto const finiteElement )
       {
         auto kernel = kernelFactory.createKernel( nodeManager,
                                                   edgeManager,

--- a/src/coreComponents/finiteElement/kernelInterface/KernelBase.hpp
+++ b/src/coreComponents/finiteElement/kernelInterface/KernelBase.hpp
@@ -29,7 +29,7 @@
 
 /**
  * @brief This macro allows solvers to select a subset of FE_TYPES on which the dispatch is done. If none are selected, by default all the
- *FE_TYPES apply.
+ * FE_TYPES apply.
  */
 #ifndef SELECTED_FE_TYPES
 #define SELECTED_FE_TYPES ALL_FE_TYPES

--- a/src/coreComponents/finiteElement/kernelInterface/KernelBase.hpp
+++ b/src/coreComponents/finiteElement/kernelInterface/KernelBase.hpp
@@ -27,6 +27,10 @@
 #include "mesh/MeshLevel.hpp"
 #include "common/GEOS_RAJA_Interface.hpp"
 
+/**
+ * @brief This macro allows solvers to select a subset of FE_TYPES on which the dispatch is done. If none are selected, by default all the
+ *FE_TYPES apply.
+ */
 #ifndef SELECTED_FE_TYPES
 #define SELECTED_FE_TYPES ALL_FE_TYPES
 #endif

--- a/src/coreComponents/finiteElement/kernelInterface/KernelBase.hpp
+++ b/src/coreComponents/finiteElement/kernelInterface/KernelBase.hpp
@@ -418,16 +418,16 @@ real64 regionBasedKernelApplication( MeshLevel & mesh,
       FiniteElementBase &
       subRegionFE = elementSubRegion.template getReference< FiniteElementBase >( finiteElementName );
 
-      finiteElement::dispatch3D( subRegionFE,
-                                 [&maxResidualContribution,
-                                  &nodeManager,
-                                  &edgeManager,
-                                  &faceManager,
-                                  targetRegionIndex,
-                                  &kernelFactory,
-                                  &elementSubRegion,
-                                  numElems,
-                                  &castedConstitutiveRelation] ( auto const finiteElement )
+      finiteElement::FiniteElementDispatchHandler< ALL_FE_TYPES >::dispatch3D( subRegionFE,
+                                                                               [&maxResidualContribution,
+                                                                                &nodeManager,
+                                                                                &edgeManager,
+                                                                                &faceManager,
+                                                                                targetRegionIndex,
+                                                                                &kernelFactory,
+                                                                                &elementSubRegion,
+                                                                                numElems,
+                                                                                &castedConstitutiveRelation] ( auto const finiteElement )
       {
         auto kernel = kernelFactory.createKernel( nodeManager,
                                                   edgeManager,

--- a/src/coreComponents/mainInterface/ProblemManager.cpp
+++ b/src/coreComponents/mainInterface/ProblemManager.cpp
@@ -833,8 +833,8 @@ map< std::tuple< string, string, string, string >, localIndex > ProblemManager::
                        setRestartFlags( dataRepository::RestartFlags::NO_WRITE ).reference();
                 subRegion.excludeWrappersFromPacking( { discretizationName } );
 
-                finiteElement::dispatch3D( fe,
-                                           [&] ( auto & finiteElement )
+                finiteElement::FiniteElementDispatchHandler< ALL_FE_TYPES >::dispatch3D( fe,
+                                                                                         [&] ( auto & finiteElement )
                 {
                   using FE_TYPE = std::remove_const_t< TYPEOFREF( finiteElement ) >;
                   using SUBREGION_TYPE = TYPEOFREF( subRegion );

--- a/src/coreComponents/physicsSolvers/multiphysics/PhaseFieldFractureSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/PhaseFieldFractureSolver.cpp
@@ -333,7 +333,7 @@ void PhaseFieldFractureSolver::mapDamageToQuadrature( DomainPartition & domain )
         finiteElement::FiniteElementBase const &
         fe = elementSubRegion.getReference< finiteElement::FiniteElementBase >( m_discretizationName );
 
-        finiteElement::dispatch3D( fe, [nodalDamage, &elementSubRegion, damageFieldOnMaterial, elemNodes]( auto & finiteElement )
+        finiteElement::FiniteElementDispatchHandler< ALL_FE_TYPES >::dispatch3D( fe, [nodalDamage, &elementSubRegion, damageFieldOnMaterial, elemNodes]( auto & finiteElement )
         {
           using FE_TYPE = TYPEOFREF( finiteElement );
           constexpr localIndex numNodesPerElement = FE_TYPE::numNodes;

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
@@ -354,8 +354,8 @@ void SolidMechanicsLagrangianFEM::initializePostInitialConditionsPreSubGroups()
 
         finiteElement::FiniteElementBase const &
         fe = elementSubRegion.getReference< finiteElement::FiniteElementBase >( getDiscretizationName() );
-        finiteElement::dispatch3D( fe,
-                                   [&] ( auto const finiteElement )
+        finiteElement::FiniteElementDispatchHandler< ALL_FE_TYPES >::dispatch3D( fe,
+                                                                                 [&] ( auto const finiteElement )
         {
           using FE_TYPE = TYPEOFREF( finiteElement );
 

--- a/src/coreComponents/physicsSolvers/wavePropagation/AcousticWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/AcousticWaveEquationSEM.cpp
@@ -313,9 +313,7 @@ void AcousticWaveEquationSEM::precomputeSourceAndReceiverTerm( MeshLevel & mesh,
 
     finiteElement::FiniteElementBase const &
     fe = elementSubRegion.getReference< finiteElement::FiniteElementBase >( getDiscretizationName() );
-    finiteElement::dispatch3D( fe,
-                               [&]
-                                 ( auto const finiteElement )
+    finiteElement::FiniteElementDispatchHandler< SEM_FE_TYPES >::dispatch3D( fe, [&] ( auto const finiteElement )
     {
       using FE_TYPE = TYPEOFREF( finiteElement );
 
@@ -503,9 +501,7 @@ void AcousticWaveEquationSEM::initializePostInitialConditionsPreSubGroups()
 
       finiteElement::FiniteElementBase const &
       fe = elementSubRegion.getReference< finiteElement::FiniteElementBase >( getDiscretizationName() );
-      finiteElement::dispatch3D( fe,
-                                 [&]
-                                   ( auto const finiteElement )
+      finiteElement::FiniteElementDispatchHandler< SEM_FE_TYPES >::dispatch3D( fe, [&] ( auto const finiteElement )
       {
         using FE_TYPE = TYPEOFREF( finiteElement );
 
@@ -773,9 +769,7 @@ void AcousticWaveEquationSEM::initializePML()
       real32 const xMin[3]{param.xMinPML[0], param.xMinPML[1], param.xMinPML[2]};
       real32 const xMax[3]{param.xMaxPML[0], param.xMaxPML[1], param.xMaxPML[2]};
 
-      finiteElement::dispatch3D( fe,
-                                 [&]
-                                   ( auto const finiteElement )
+      finiteElement::FiniteElementDispatchHandler< SEM_FE_TYPES >::dispatch3D( fe, [&] ( auto const finiteElement )
       {
         using FE_TYPE = TYPEOFREF( finiteElement );
 
@@ -922,9 +916,7 @@ void AcousticWaveEquationSEM::applyPML( real64 const time, DomainPartition & dom
       real32 const r = param.reflectivityPML;
 
       /// Get the type of the elements in the subregion
-      finiteElement::dispatch3D( fe,
-                                 [&]
-                                   ( auto const finiteElement )
+      finiteElement::FiniteElementDispatchHandler< SEM_FE_TYPES >::dispatch3D( fe, [&] ( auto const finiteElement )
       {
         using FE_TYPE = TYPEOFREF( finiteElement );
 

--- a/src/coreComponents/physicsSolvers/wavePropagation/AcousticWaveEquationSEM.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/AcousticWaveEquationSEM.hpp
@@ -20,9 +20,9 @@
 #ifndef GEOSX_PHYSICSSOLVERS_WAVEPROPAGATION_ACOUSTICWAVEEQUATIONSEM_HPP_
 #define GEOSX_PHYSICSSOLVERS_WAVEPROPAGATION_ACOUSTICWAVEEQUATIONSEM_HPP_
 
+#include "WaveSolverBase.hpp"
 #include "mesh/MeshFields.hpp"
 #include "physicsSolvers/SolverBase.hpp"
-#include "WaveSolverBase.hpp"
 
 namespace geosx
 {

--- a/src/coreComponents/physicsSolvers/wavePropagation/ElasticWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/ElasticWaveEquationSEM.cpp
@@ -292,9 +292,7 @@ void ElasticWaveEquationSEM::precomputeSourceAndReceiverTerm( MeshLevel & mesh, 
 
     finiteElement::FiniteElementBase const &
     fe = elementSubRegion.getReference< finiteElement::FiniteElementBase >( getDiscretizationName() );
-    finiteElement::dispatch3D( fe,
-                               [&]
-                                 ( auto const finiteElement )
+    finiteElement::FiniteElementDispatchHandler< SEM_FE_TYPES >::dispatch3D( fe, [&] ( auto const finiteElement )
     {
       using FE_TYPE = TYPEOFREF( finiteElement );
 
@@ -566,9 +564,7 @@ void ElasticWaveEquationSEM::initializePostInitialConditionsPreSubGroups()
 
       finiteElement::FiniteElementBase const &
       fe = elementSubRegion.getReference< finiteElement::FiniteElementBase >( getDiscretizationName() );
-      finiteElement::dispatch3D( fe,
-                                 [&]
-                                   ( auto const finiteElement )
+      finiteElement::FiniteElementDispatchHandler< SEM_FE_TYPES >::dispatch3D( fe, [&] ( auto const finiteElement )
       {
         using FE_TYPE = TYPEOFREF( finiteElement );
 

--- a/src/coreComponents/physicsSolvers/wavePropagation/ElasticWaveEquationSEM.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/ElasticWaveEquationSEM.hpp
@@ -20,11 +20,9 @@
 #ifndef SRC_CORECOMPONENTS_PHYSICSSOLVERS_WAVEPROPAGATION_ELASTICWAVEEQUATIONSEM_HPP_
 #define SRC_CORECOMPONENTS_PHYSICSSOLVERS_WAVEPROPAGATION_ELASTICWAVEEQUATIONSEM_HPP_
 
+#include "WaveSolverBase.hpp"
 #include "mesh/MeshFields.hpp"
 #include "physicsSolvers/SolverBase.hpp"
-#include "WaveSolverBase.hpp"
-
-
 
 namespace geosx
 {

--- a/src/coreComponents/physicsSolvers/wavePropagation/WaveSolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/WaveSolverBase.hpp
@@ -20,6 +20,7 @@
 #ifndef GEOSX_PHYSICSSOLVERS_WAVEPROPAGATION_WAVESOLVERBASE_HPP_
 #define GEOSX_PHYSICSSOLVERS_WAVEPROPAGATION_WAVESOLVERBASE_HPP_
 
+
 #include "mesh/MeshFields.hpp"
 #include "physicsSolvers/SolverBase.hpp"
 #include "finiteElement/elementFormulations/H1_Hexahedron_Lagrange1_GaussLegendre2.hpp"
@@ -28,6 +29,8 @@
 #define SEM_FE_TYPES \
   finiteElement::H1_Hexahedron_Lagrange1_GaussLegendre2, \
   finiteElement::Q3_Hexahedron_Lagrange_GaussLobatto
+
+#define SELECTED_FE_TYPES SEM_FE_TYPES
 
 namespace geosx
 {

--- a/src/coreComponents/physicsSolvers/wavePropagation/WaveSolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/WaveSolverBase.hpp
@@ -25,7 +25,8 @@
 #include "finiteElement/elementFormulations/H1_Hexahedron_Lagrange1_GaussLegendre2.hpp"
 #include "finiteElement/elementFormulations/Q3_Hexahedron_Lagrange_GaussLobatto.hpp"
 
-#define SEM_FE_TYPES finiteElement::H1_Hexahedron_Lagrange1_GaussLegendre2, \
+#define SEM_FE_TYPES \
+  finiteElement::H1_Hexahedron_Lagrange1_GaussLegendre2, \
   finiteElement::Q3_Hexahedron_Lagrange_GaussLobatto
 
 namespace geosx

--- a/src/coreComponents/physicsSolvers/wavePropagation/WaveSolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/WaveSolverBase.hpp
@@ -22,7 +22,11 @@
 
 #include "mesh/MeshFields.hpp"
 #include "physicsSolvers/SolverBase.hpp"
+#include "finiteElement/elementFormulations/H1_Hexahedron_Lagrange1_GaussLegendre2.hpp"
+#include "finiteElement/elementFormulations/Q3_Hexahedron_Lagrange_GaussLobatto.hpp"
 
+#define SEM_FE_TYPES finiteElement::H1_Hexahedron_Lagrange1_GaussLegendre2, \
+  finiteElement::Q3_Hexahedron_Lagrange_GaussLobatto
 
 namespace geosx
 {


### PR DESCRIPTION
This PR is a partial answer to Issue [2145](https://github.com/GEOSX/GEOSX/issues/2145).

As of now, solvers calling the `finiteElement::dispatch3D` method have no way of limiting the number of template instantiations of the lambda function given as a parameter to the function. This can create useless specializations, causing large compilation units and a bloated compilation process, as well as increasing the size of the `geosx` executable. With the advent of higher order elements, this risks becoming an issue, as the number of dispatched types increases and differences between formulations start to appear (e.g., Gauss hexahedra vs. Gauss-Lobatto hexahedra).

This PR replaces the finite element dispatcher (defined in `FiniteElementDispatch.hpp`) with a recursive version based on a variadic template, in the vein of `ConstitutivePassThruHandler`. This allows each solver that calls the `finiteElement::dispatch3D` method to specify the types of finite elements on which the dispatch must happen. 

Notice that in this PR, very little actual optimization is done: all the current dispatch calls are still done with all the available order 1 finite element types (using an alias `ALL_FE_TYPES` that contains the whole list). Only the SEM wave propagators are specialized to Gauss-Lobatto hexahedra.

What is left to be done:
 - Further specialize the types of finite elements in the dispatch to the actual types that are handled by the solver, as needed;
 - Use a mechanism similar to that of PR [2086](https://github.com/GEOSX/GEOSX/pull/2086) to create separate compilation units for each dispatch. This might require writing the lambda function passed to the dispatch in a separate compilation unit, and thus is best left for another time.