### PR TITLE
Fix vtk labels for stress.

### DIFF
--- a/src/coreComponents/constitutive/solid/SolidBase.cpp
+++ b/src/coreComponents/constitutive/solid/SolidBase.cpp
@@ -38,7 +38,7 @@ SolidBase::SolidBase( string const & name, Group * const parent ):
     setPlotLevel( PlotLevel::LEVEL_0 ).
     setApplyDefaultValue( 0 ). // default to zero initial stress
     setDescription( "Current Material Stress" ).
-    setDimLabels( 1, voightLabels );
+    setDimLabels( 2, voightLabels );
 
   registerWrapper( viewKeyStruct::oldStressString(), &m_oldStress ).
     setApplyDefaultValue( 0 ). // default to zero initial stress


### PR DESCRIPTION
The vtk labels for the stress were not properly set so the default paraview ones were used which resulted in the wrong order of the labels of the stress components, `XX, YY, ZZ, XY, XZ, YZ` instead of `XX, YY, ZZ, YZ, XZ, XY`, i.e.

![Screen Shot 2022-11-17 at 4 55 50 PM](https://user-images.githubusercontent.com/49037133/202591738-4308eba5-32a7-465e-a1c8-9ecc3396ec82.png)

This PR fixes so that we now have:

![image (1)](https://user-images.githubusercontent.com/49037133/202591913-e0c719da-b8ea-40a3-bb8a-5c095578fcc6.png)


I don't think this requires a rebaseline but I am not 100% sure.

Thanks @povolny1 for noticing!
