### PR TITLE
Added a poromechanics option to solve only mechanics in the burdens

### DIFF
--- a/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoromechanicsKernel.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoromechanicsKernel.hpp
@@ -93,14 +93,14 @@ public:
               FE_TYPE const & finiteElementSpace,
               CONSTITUTIVE_TYPE & inputConstitutiveType,
               arrayView1d< globalIndex const > const inputDispDofNumber,
-              string const inputFlowDofKey,
               globalIndex const rankOffset,
+              CRSMatrixView< real64, globalIndex const > const inputMatrix,
+              arrayView1d< real64 > const inputRhs,
               real64 const (&inputGravityVector)[3],
+              string const inputFlowDofKey,
               localIndex const numComponents,
               localIndex const numPhases,
-              string const fluidModelKey,
-              CRSMatrixView< real64, globalIndex const > const inputMatrix,
-              arrayView1d< real64 > const inputRhs ):
+              string const fluidModelKey ):
     Base( nodeManager,
           edgeManager,
           faceManager,
@@ -656,14 +656,14 @@ protected:
 
 using MultiphaseKernelFactory = finiteElement::KernelFactory< Multiphase,
                                                               arrayView1d< globalIndex const > const,
-                                                              string const,
                                                               globalIndex const,
-                                                              real64 const (&)[3],
-                                                              localIndex const,
-                                                              localIndex const,
-                                                              string const,
                                                               CRSMatrixView< real64, globalIndex const > const,
-                                                              arrayView1d< real64 > const >;
+                                                              arrayView1d< real64 > const,
+                                                              real64 const (&)[3],
+                                                              string const,
+                                                              localIndex const,
+                                                              localIndex const,
+                                                              string const >;
 
 } // namespace poromechanicsKernels
 

--- a/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoromechanicsSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/MultiphasePoromechanicsSolver.cpp
@@ -25,6 +25,7 @@
 #include "physicsSolvers/multiphysics/MultiphasePoromechanicsKernel.hpp"
 #include "physicsSolvers/solidMechanics/SolidMechanicsFields.hpp"
 #include "physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.hpp"
+#include "physicsSolvers/solidMechanics/kernels/ImplicitSmallStrainQuasiStatic.hpp"
 
 namespace geosx
 {
@@ -105,46 +106,79 @@ void MultiphasePoromechanicsSolver::assembleSystem( real64 const GEOSX_UNUSED_PA
 {
   GEOSX_MARK_FUNCTION;
 
+  real64 poromechanicsMaxForce = 0.0;
+  real64 mechanicsMaxForce = 0.0;
+
+  // step 1: apply the full poromechanics coupling on the target regions on the poromechanics solver
+
+  set< string > poromechanicsRegionNames;
+
   forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
                                                                 MeshLevel & mesh,
                                                                 arrayView1d< string const > const & regionNames )
   {
-    NodeManager const & nodeManager = mesh.getNodeManager();
-
-    string const displacementDofKey = dofManager.getKey( solidMechanics::totalDisplacement::key() );
-    arrayView1d< globalIndex const > const & displacementDofNumber = nodeManager.getReference< globalIndex_array >( displacementDofKey );
+    poromechanicsRegionNames.insert( regionNames.begin(), regionNames.end() );
 
     string const flowDofKey = dofManager.getKey( CompositionalMultiphaseBase::viewKeyStruct::elemDofFieldString() );
 
-    localIndex const numComponents = flowSolver()->numFluidComponents();
-    localIndex const numPhases = flowSolver()->numFluidPhases();
+    poromechanicsMaxForce =
+      assemblyLaunch< constitutive::PorousSolidBase,
+                      poromechanicsKernels::MultiphaseKernelFactory >( mesh,
+                                                                       dofManager,
+                                                                       regionNames,
+                                                                       viewKeyStruct::porousMaterialNamesString(),
+                                                                       localMatrix,
+                                                                       localRhs,
+                                                                       flowDofKey,
+                                                                       flowSolver()->numFluidComponents(),
+                                                                       flowSolver()->numFluidPhases(),
+                                                                       FlowSolverBase::viewKeyStruct::fluidNamesString() );
 
-    real64 const gravityVectorData[3] = LVARRAY_TENSOROPS_INIT_LOCAL_3( gravityVector() );
-
-    poromechanicsKernels::MultiphaseKernelFactory kernelFactory( displacementDofNumber,
-                                                                 flowDofKey,
-                                                                 dofManager.rankOffset(),
-                                                                 gravityVectorData,
-                                                                 numComponents,
-                                                                 numPhases,
-                                                                 FlowSolverBase::viewKeyStruct::fluidNamesString(),
-                                                                 localMatrix,
-                                                                 localRhs );
-
-    // Cell-based contributions
-    solidMechanicsSolver()->getMaxForce() =
-      finiteElement::
-        regionBasedKernelApplication< parallelDevicePolicy< 32 >,
-                                      constitutive::PorousSolidBase,
-                                      CellElementSubRegion >( mesh,
-                                                              regionNames,
-                                                              solidMechanicsSolver()->getDiscretizationName(),
-                                                              viewKeyStruct::porousMaterialNamesString(),
-                                                              kernelFactory );
   } );
 
 
-  // Face-based contributions
+  // step 2: apply mechanics solver on its target regions not included in the poromechanics solver target regions
+
+  solidMechanicsSolver()->forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
+                                                                                        MeshLevel & mesh,
+                                                                                        arrayView1d< string const > const & regionNames )
+  {
+
+    // collect the target region of the mechanics solver not included in the poromechanics target regions
+    array1d< string > filteredRegionNames;
+    filteredRegionNames.reserve( regionNames.size() );
+    for( string const & regionName : regionNames )
+    {
+      // if the mechanics target region is not included in the poromechanics target region, save the string
+      if( poromechanicsRegionNames.count( regionName ) == 0 )
+      {
+        filteredRegionNames.emplace_back( regionName );
+      }
+    }
+
+    // if the array is empty, the mechanics and poromechanics solver target regions overlap perfectly, there is nothing to do
+    if( filteredRegionNames.empty() )
+    {
+      return;
+    }
+
+    mechanicsMaxForce =
+      assemblyLaunch< constitutive::SolidBase,
+                      solidMechanicsLagrangianFEMKernels::QuasiStaticFactory >( mesh,
+                                                                                dofManager,
+                                                                                filteredRegionNames.toViewConst(),
+                                                                                SolidMechanicsLagrangianFEM::viewKeyStruct::solidMaterialNamesString(),
+                                                                                localMatrix,
+                                                                                localRhs );
+
+  } );
+
+
+  solidMechanicsSolver()->getMaxForce() = LvArray::math::max( mechanicsMaxForce, poromechanicsMaxForce );
+
+
+  // step 3: compute the fluxes (face-based contributions)
+
   if( m_stabilizationType == StabilizationType::Global ||
       m_stabilizationType == StabilizationType::Local )
   {

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsKernel.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsKernel.hpp
@@ -92,11 +92,11 @@ public:
                FE_TYPE const & finiteElementSpace,
                CONSTITUTIVE_TYPE & inputConstitutiveType,
                arrayView1d< globalIndex const > const inputDispDofNumber,
-               string const inputFlowDofKey,
                globalIndex const rankOffset,
                CRSMatrixView< real64, globalIndex const > const inputMatrix,
                arrayView1d< real64 > const inputRhs,
                real64 const (&inputGravityVector)[3],
+               string const inputFlowDofKey,
                string const fluidModelKey ):
     Base( nodeManager,
           edgeManager,
@@ -503,11 +503,11 @@ protected:
 
 using SinglePhaseKernelFactory = finiteElement::KernelFactory< SinglePhase,
                                                                arrayView1d< globalIndex const > const,
-                                                               string const,
                                                                globalIndex const,
                                                                CRSMatrixView< real64, globalIndex const > const,
                                                                arrayView1d< real64 > const,
                                                                real64 const (&)[3],
+                                                               string const,
                                                                string const >;
 
 } // namespace poromechanicsKernels

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolver.cpp
@@ -26,6 +26,7 @@
 #include "physicsSolvers/multiphysics/SinglePhasePoromechanicsKernel.hpp"
 #include "physicsSolvers/solidMechanics/SolidMechanicsFields.hpp"
 #include "physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.hpp"
+#include "physicsSolvers/solidMechanics/kernels/ImplicitSmallStrainQuasiStatic.hpp"
 
 namespace geosx
 {
@@ -157,39 +158,78 @@ void SinglePhasePoromechanicsSolver::assembleSystem( real64 const time_n,
 {
 
   GEOSX_MARK_FUNCTION;
+
+  real64 poromechanicsMaxForce = 0.0;
+  real64 mechanicsMaxForce = 0.0;
+
+
+  // step 1: apply the full poromechanics coupling on the target regions on the poromechanics solver
+
+  set< string > poromechanicsRegionNames;
+
   forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
                                                                 MeshLevel & mesh,
                                                                 arrayView1d< string const > const & regionNames )
   {
-    NodeManager const & nodeManager = mesh.getNodeManager();
+    poromechanicsRegionNames.insert( regionNames.begin(), regionNames.end() );
 
-    string const dofKey = dofManager.getKey( solidMechanics::totalDisplacement::key() );
-    arrayView1d< globalIndex const > const & dispDofNumber = nodeManager.getReference< globalIndex_array >( dofKey );
+    string const flowDofKey = dofManager.getKey( SinglePhaseBase::viewKeyStruct::elemDofFieldString() );
 
-    string const pDofKey = dofManager.getKey( SinglePhaseBase::viewKeyStruct::elemDofFieldString() );
+    poromechanicsMaxForce =
+      assemblyLaunch< constitutive::PorousSolidBase,
+                      poromechanicsKernels::SinglePhaseKernelFactory >( mesh,
+                                                                        dofManager,
+                                                                        regionNames,
+                                                                        viewKeyStruct::porousMaterialNamesString(),
+                                                                        localMatrix,
+                                                                        localRhs,
+                                                                        flowDofKey,
+                                                                        FlowSolverBase::viewKeyStruct::fluidNamesString() );
 
-    real64 const gravityVectorData[3] = LVARRAY_TENSOROPS_INIT_LOCAL_3( gravityVector() );
 
-    poromechanicsKernels::SinglePhaseKernelFactory kernelFactory( dispDofNumber,
-                                                                  pDofKey,
-                                                                  dofManager.rankOffset(),
-                                                                  localMatrix,
-                                                                  localRhs,
-                                                                  gravityVectorData,
-                                                                  FlowSolverBase::viewKeyStruct::fluidNamesString() );
-
-    // Cell-based contributions
-    solidMechanicsSolver()->getMaxForce() =
-      finiteElement::
-        regionBasedKernelApplication< parallelDevicePolicy< 32 >,
-                                      constitutive::PorousSolidBase,
-                                      CellElementSubRegion >( mesh,
-                                                              regionNames,
-                                                              solidMechanicsSolver()->getDiscretizationName(),
-                                                              viewKeyStruct::porousMaterialNamesString(),
-                                                              kernelFactory );
 
   } );
+
+
+  // step 2: apply mechanics solver on its target regions not included in the poromechanics solver target regions
+
+  solidMechanicsSolver()->forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
+                                                                                        MeshLevel & mesh,
+                                                                                        arrayView1d< string const > const & regionNames )
+  {
+
+    // collect the target region of the mechanics solver not included in the poromechanics target regions
+    array1d< string > filteredRegionNames;
+    filteredRegionNames.reserve( regionNames.size() );
+    for( string const & regionName : regionNames )
+    {
+      // if the mechanics target region is not included in the poromechanics target region, save the string
+      if( poromechanicsRegionNames.count( regionName ) == 0 )
+      {
+        filteredRegionNames.emplace_back( regionName );
+      }
+    }
+
+    // if the array is empty, the mechanics and poromechanics solver target regions overlap perfectly, there is nothing to do
+    if( filteredRegionNames.empty() )
+    {
+      return;
+    }
+
+    mechanicsMaxForce =
+      assemblyLaunch< constitutive::SolidBase,
+                      solidMechanicsLagrangianFEMKernels::QuasiStaticFactory >( mesh,
+                                                                                dofManager,
+                                                                                filteredRegionNames.toViewConst(),
+                                                                                SolidMechanicsLagrangianFEM::viewKeyStruct::solidMaterialNamesString(),
+                                                                                localMatrix,
+                                                                                localRhs );
+  } );
+
+  solidMechanicsSolver()->getMaxForce() = LvArray::math::max( mechanicsMaxForce, poromechanicsMaxForce );
+
+
+  // step 3: compute the fluxes (face-based contributions)
 
   flowSolver()->assemblePoroelasticFluxTerms( time_n, dt,
                                               domain,

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolver.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolver.hpp
@@ -132,7 +132,56 @@ private:
 
   void createPreconditioner();
 
+  template< typename CONSTITUTIVE_BASE,
+            typename KERNEL_WRAPPER,
+            typename ... PARAMS >
+  real64 assemblyLaunch( MeshLevel & mesh,
+                         DofManager const & dofManager,
+                         arrayView1d< string const > const & regionNames,
+                         string const & materialNamesString,
+                         CRSMatrixView< real64, globalIndex const > const & localMatrix,
+                         arrayView1d< real64 > const & localRhs,
+                         PARAMS && ... params );
+
 };
+
+template< typename CONSTITUTIVE_BASE,
+          typename KERNEL_WRAPPER,
+          typename ... PARAMS >
+real64 SinglePhasePoromechanicsSolver::assemblyLaunch( MeshLevel & mesh,
+                                                       DofManager const & dofManager,
+                                                       arrayView1d< string const > const & regionNames,
+                                                       string const & materialNamesString,
+                                                       CRSMatrixView< real64, globalIndex const > const & localMatrix,
+                                                       arrayView1d< real64 > const & localRhs,
+                                                       PARAMS && ... params )
+{
+  GEOSX_MARK_FUNCTION;
+
+  NodeManager const & nodeManager = mesh.getNodeManager();
+
+  string const dofKey = dofManager.getKey( fields::solidMechanics::totalDisplacement::key() );
+  arrayView1d< globalIndex const > const & dofNumber = nodeManager.getReference< globalIndex_array >( dofKey );
+
+  real64 const gravityVectorData[3] = LVARRAY_TENSOROPS_INIT_LOCAL_3( gravityVector() );
+
+  KERNEL_WRAPPER kernelWrapper( dofNumber,
+                                dofManager.rankOffset(),
+                                localMatrix,
+                                localRhs,
+                                gravityVectorData,
+                                std::forward< PARAMS >( params )... );
+
+  return finiteElement::
+           regionBasedKernelApplication< parallelDevicePolicy< 32 >,
+                                         CONSTITUTIVE_BASE,
+                                         CellElementSubRegion >( mesh,
+                                                                 regionNames,
+                                                                 solidMechanicsSolver()->getDiscretizationName(),
+                                                                 materialNamesString,
+                                                                 kernelWrapper );
+}
+
 
 } /* namespace geosx */
 

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolverEmbeddedFractures.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolverEmbeddedFractures.cpp
@@ -417,11 +417,11 @@ void SinglePhasePoromechanicsSolverEmbeddedFractures::assembleSystem( real64 con
 
     // 1. Cell-based contributions of standard poroelasticity
     poromechanicsKernels::SinglePhaseKernelFactory kernelFactory( dispDofNumber,
-                                                                  pDofKey,
                                                                   dofManager.rankOffset(),
                                                                   localMatrix,
                                                                   localRhs,
                                                                   gravityVectorData,
+                                                                  pDofKey,
                                                                   FlowSolverBase::viewKeyStruct::fluidNamesString() );
 
     solidMechanicsSolver()->getMaxForce() =


### PR DESCRIPTION
In poromechanics simulations, this PR makes it possible to identify some regions in which we only solve for mechanics (and not for flow). This is achieved thanks to a slight refactoring in `MultiphasePoromechanicsSolver::assembleSystem` and does not require any change in the xml. 

Now, we can do:
```
 <Solvers>                                                                                                                                                                            
    <MultiphasePoromechanics                                                                                                                                                           
      [...]                                                                                                                                                                
      targetRegions="{ reservoir }"/>     
    <SolidMechanicsLagrangianSSLE 
      [...]                                                                                                                                                                                                                                                                                                                
      targetRegions="{ reservoir, underburden, overburden }"/> 
  <CompositionalMultiphaseFVM                                                                                                                                                        
      [...]                                                                                                                                                     
      targetRegions="{ reservoir }"/>    
</Solvers>
```
to have poromechanics coupling (flow + mechanics) in `reservoir` but only mechanics in `underburden` and `overburden`.

Ready for review, does not require rebaseline.

