### PR TITLE
Added MGR recipe for fully coupled single-phase THM solver

### DIFF
--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreMGR.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreMGR.cpp
@@ -35,6 +35,7 @@
 #include "linearAlgebra/interfaces/hypre/mgrStrategies/SinglePhaseReservoirFVM.hpp"
 #include "linearAlgebra/interfaces/hypre/mgrStrategies/SinglePhaseReservoirHybridFVM.hpp"
 #include "linearAlgebra/interfaces/hypre/mgrStrategies/ThermalCompositionalMultiphaseFVM.hpp"
+#include "linearAlgebra/interfaces/hypre/mgrStrategies/ThermalSinglePhasePoromechanics.hpp"
 
 #include "LvArray/src/output.hpp"
 
@@ -98,6 +99,11 @@ void hypre::mgr::createMGR( LinearSolverParameters const & params,
     case LinearSolverParameters::MGR::StrategyType::hybridSinglePhasePoromechanics:
     {
       setStrategy< HybridSinglePhasePoromechanics >( params.mgr, numComponentsPerField, precond, mgrData );
+      break;
+    }
+    case LinearSolverParameters::MGR::StrategyType::thermalSinglePhasePoromechanics:
+    {
+      setStrategy< ThermalSinglePhasePoromechanics >( params.mgr, numComponentsPerField, precond, mgrData );
       break;
     }
     case LinearSolverParameters::MGR::StrategyType::hydrofracture:

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/mgrStrategies/ThermalSinglePhasePoromechanics.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/mgrStrategies/ThermalSinglePhasePoromechanics.hpp
@@ -1,0 +1,113 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file ThermalSinglePhasePoromechanics.hpp
+ */
+
+#ifndef GEOSX_LINEARALGEBRA_INTERFACES_HYPREMGRTHERMALSINGLEPHASEPOROMECHANICS_HPP_
+#define GEOSX_LINEARALGEBRA_INTERFACES_HYPREMGRTHERMALSINGLEPHASEPOROMECHANICS_HPP_
+
+#include "linearAlgebra/interfaces/hypre/HypreMGR.hpp"
+
+namespace geosx
+{
+
+namespace hypre
+{
+
+namespace mgr
+{
+
+/**
+ * @brief ThermalSinglePhasePoromechanics strategy.
+ *
+ * dofLabel: 0 = displacement, x-component
+ * dofLabel: 1 = displacement, y-component
+ * dofLabel: 2 = displacement, z-component
+ * dofLabel: 3 = pressure
+ * dofLabel: 4 = temperature  
+ *
+ * Ingredients:
+ * 1. F-points displacement (0,1,2), C-points pressure and temperature (3-4)
+ * 2. F-points smoother: AMG, single V-cycle, separate displacement components
+ * 3. C-points coarse-grid/Schur complement solver: boomer AMG for pressure and temperature
+ * 4. Global smoother: none
+ */
+class ThermalSinglePhasePoromechanics : public MGRStrategyBase< 1 >
+{
+public:
+
+  /**
+   * @brief Constructor.
+   */
+  explicit ThermalSinglePhasePoromechanics( arrayView1d< int const > const & )
+    : MGRStrategyBase( 5 )
+  {
+    m_labels[0].push_back( 3 );
+    m_labels[0].push_back( 4 );    
+
+    setupLabels();
+
+    // Level 0
+    m_levelFRelaxMethod[0]     = MGRFRelaxationMethod::amgVCycle;
+    m_levelInterpType[0]       = MGRInterpolationType::jacobi;
+    m_levelRestrictType[0]     = MGRRestrictionType::injection;
+    m_levelCoarseGridMethod[0] = MGRCoarseGridMethod::nonGalerkin;
+
+    m_numGlobalSmoothSweeps = 0;
+  }
+
+  /**
+   * @brief Setup the MGR strategy.
+   * @param precond preconditioner wrapper
+   * @param mgrData auxiliary MGR data
+   */
+  void setup( LinearSolverParameters::MGR const &,
+              HyprePrecWrapper & precond,
+              HypreMGRData & mgrData )
+  {
+    GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetCpointsByPointMarkerArray( precond.ptr,
+                                                                  m_numBlocks, numLevels,
+                                                                  m_numLabels, m_ptrLabels,
+                                                                  mgrData.pointMarkers.data() ) );
+
+    GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetLevelFRelaxMethod( precond.ptr, toUnderlyingPtr( m_levelFRelaxMethod ) ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetLevelInterpType( precond.ptr, toUnderlyingPtr( m_levelInterpType ) ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetLevelRestrictType( precond.ptr, toUnderlyingPtr( m_levelRestrictType ) ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetCoarseGridMethod( precond.ptr, toUnderlyingPtr( m_levelCoarseGridMethod ) ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetNonCpointsToFpoints( precond.ptr, 1 ));
+    GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetPMaxElmts( precond.ptr, 0 ));
+    GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetMaxGlobalSmoothIters( precond.ptr, m_numGlobalSmoothSweeps ) );
+
+    GEOSX_LAI_CHECK_ERROR( HYPRE_BoomerAMGCreate( &mgrData.coarseSolver.ptr ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_BoomerAMGSetPrintLevel( mgrData.coarseSolver.ptr, 0 ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_BoomerAMGSetMaxIter( mgrData.coarseSolver.ptr, 1 ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_BoomerAMGSetTol( mgrData.coarseSolver.ptr, 0.0 ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_BoomerAMGSetNumFunctions( mgrData.coarseSolver.ptr, 2 ) ); // pressure and temperature    
+    GEOSX_LAI_CHECK_ERROR( HYPRE_BoomerAMGSetRelaxOrder( mgrData.coarseSolver.ptr, 1 ) );
+
+    mgrData.coarseSolver.setup = HYPRE_BoomerAMGSetup;
+    mgrData.coarseSolver.solve = HYPRE_BoomerAMGSolve;
+    mgrData.coarseSolver.destroy = HYPRE_BoomerAMGDestroy;
+  }
+};
+
+} // namespace mgr
+
+} // namespace hypre
+
+} // namespace geosx
+
+#endif /*GEOSX_LINEARALGEBRA_INTERFACES_HYPREMGRTHERMALSINGLEPHASEPOROMECHANICS_HPP_*/

--- a/src/coreComponents/linearAlgebra/utilities/LinearSolverParameters.hpp
+++ b/src/coreComponents/linearAlgebra/utilities/LinearSolverParameters.hpp
@@ -215,6 +215,7 @@ struct LinearSolverParameters
       singlePhaseHybridFVM,                      ///< hybrid finite volume single-phase flow
       singlePhaseReservoirHybridFVM,             ///< hybrid finite volume single-phase flow with wells
       singlePhasePoromechanics,                  ///< single phase poromechanics with finite volume single phase flow
+      thermalSinglePhasePoromechanics,           ///< thermal single phase poromechanics with finite volume single phase flow
       hybridSinglePhasePoromechanics,            ///< single phase poromechanics with hybrid finite volume single phase flow
       singlePhasePoromechanicsEmbeddedFractures, ///< single phase poromechanics with finite volume single phase flow and embedded fractures
       singlePhasePoromechanicsReservoirFVM,      ///< single phase poromechanics with finite volume single phase flow with wells
@@ -301,6 +302,7 @@ ENUM_STRINGS( LinearSolverParameters::MGR::StrategyType,
               "singlePhaseHybridFVM",
               "singlePhaseReservoirHybridFVM",
               "singlePhasePoromechanics",
+              "thermalSinglePhasePoromechanics",
               "hybridSinglePhasePoromechanics",
               "singlePhasePoromechanicsEmbeddedFractures",
               "singlePhasePoromechanicsReservoirFVM",

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseHybridFVM.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseHybridFVM.cpp
@@ -75,6 +75,11 @@ void SinglePhaseHybridFVM::initializePreSubGroups()
 {
   SinglePhaseBase::initializePreSubGroups();
 
+  GEOSX_THROW_IF( m_isThermal,
+                  GEOSX_FMT( "{} {}: The thermal option is not supported by SinglePhaseHybridFVM",
+                             catalogName(), getName() ),
+                  InputError );
+
   DomainPartition & domain = this->getGroupByPath< DomainPartition >( "/Problem/domain" );
   NumericalMethodsManager const & numericalMethodManager = domain.getNumericalMethodManager();
   FiniteVolumeManager const & fvManager = numericalMethodManager.getFiniteVolumeManager();

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolver.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsSolver.hpp
@@ -122,6 +122,7 @@ protected:
   struct viewKeyStruct : SolverBase::viewKeyStruct
   {
     constexpr static char const * porousMaterialNamesString() { return "porousMaterialNames"; }
+    constexpr static char const * isThermalString() { return "isThermal"; }
   };
 
   virtual void initializePostInitialConditionsPreSubGroups() override;
@@ -131,6 +132,9 @@ protected:
 private:
 
   void createPreconditioner();
+
+  /// flag to determine whether or not this is a thermal simulation
+  integer m_isThermal;
 
 };
 


### PR DESCRIPTION
This PR adds an MGR recipe for the new fully coupled single-phase THM solver implemented in https://github.com/GEOSX/GEOSX/pull/2179.

In this solver, we have 5 dofs (3 displacements dofs per node, 2 dof per elem: pressure and temperature).
In the new MGR recipe:
- We eliminate the displacements (F points)
- We solve the C-point system using Boomer AMG with `numFunctions = 2`