### PR TITLE
Changed abs to LvArray::math::abs

### DIFF
--- a/src/coreComponents/physicsSolvers/wavePropagation/ElasticWaveEquationSEMKernel.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/ElasticWaveEquationSEMKernel.hpp
@@ -335,15 +335,18 @@ struct DampingMatrixKernel
 
         for( localIndex q = 0; q < numNodesPerFace; ++q )
         {
-          real32 const localIncrementx = density[k] * (velocityVp[k]*abs( faceNormal[f][0] ) + velocityVs[k]*sqrt( faceNormal[f][1]*faceNormal[f][1] +
-                                                                                                                   faceNormal[f][2]*faceNormal[f][2] ) )* m_finiteElement.computeDampingTerm( q,
-                                                                                                                                                                                              xLocal );
-          real32 const localIncrementy = density[k] * (velocityVp[k]*abs( faceNormal[f][1] ) + velocityVs[k]*sqrt( faceNormal[f][0]*faceNormal[f][0] +
-                                                                                                                   faceNormal[f][2]*faceNormal[f][2] ) )* m_finiteElement.computeDampingTerm( q,
-                                                                                                                                                                                              xLocal );
-          real32 const localIncrementz = density[k] * (velocityVp[k]*abs( faceNormal[f][2] ) + velocityVs[k]*sqrt( faceNormal[f][0]*faceNormal[f][0] +
-                                                                                                                   faceNormal[f][1]*faceNormal[f][1] ) )*  m_finiteElement.computeDampingTerm( q,
-                                                                                                                                                                                               xLocal );
+          real32 const localIncrementx = density[k] * (velocityVp[k]*LvArray::math::abs( faceNormal[f][0] ) + velocityVs[k]*sqrt( faceNormal[f][1]*faceNormal[f][1] +
+                                                                                                                                  faceNormal[f][2]*faceNormal[f][2] ) )* m_finiteElement.computeDampingTerm(
+            q,
+            xLocal );
+          real32 const localIncrementy = density[k] * (velocityVp[k]*LvArray::math::abs( faceNormal[f][1] ) + velocityVs[k]*sqrt( faceNormal[f][0]*faceNormal[f][0] +
+                                                                                                                                  faceNormal[f][2]*faceNormal[f][2] ) )* m_finiteElement.computeDampingTerm(
+            q,
+            xLocal );
+          real32 const localIncrementz = density[k] * (velocityVp[k]*LvArray::math::abs( faceNormal[f][2] ) + velocityVs[k]*sqrt( faceNormal[f][0]*faceNormal[f][0] +
+                                                                                                                                  faceNormal[f][1]*faceNormal[f][1] ) )*  m_finiteElement.computeDampingTerm(
+            q,
+            xLocal );
 
           RAJA::atomicAdd< ATOMIC_POLICY >( &dampingx[facesToNodes[f][q]], localIncrementx );
           RAJA::atomicAdd< ATOMIC_POLICY >( &dampingy[facesToNodes[f][q]], localIncrementy );

--- a/src/coreComponents/physicsSolvers/wavePropagation/WaveSolverUtils.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/WaveSolverUtils.hpp
@@ -78,7 +78,7 @@ struct WaveSolverUtils
   {
     real64 const time_np1 = time_n + dt;
 
-    real32 const a1 = (std::abs( dt ) < 1e-8) ? 1.0 : (time_np1 - timeSeismo)/dt;
+    real32 const a1 = (LvArray::math::abs( dt ) < 1e-8) ? 1.0 : (time_np1 - timeSeismo)/dt;
     real32 const a2 = 1.0 - a1;
 
     if( nsamplesSeismoTrace > 0 )


### PR DESCRIPTION
This PR removes the remaining abs that are causing some compilation issues in the wave propagation solvers.

@cj215 @untereiner can you please try it and let me know if it compiles for you? I cannot check on my side