### PR TITLE
Fix for async wait bug #2173

### DIFF
--- a/src/coreComponents/mesh/mpiCommunications/CommunicationTools.cpp
+++ b/src/coreComponents/mesh/mpiCommunications/CommunicationTools.cpp
@@ -666,7 +666,11 @@ void CommunicationTools::setupGhosts( MeshLevel & meshLevel,
   //   can eliminate this. But at present runtimes are the same in either case, as time is mostly just
   //   shifted from the waitall in UnpackAndRebuildSyncLists since the processes are more 'in-sync' when
   //   hitting that point after introducing this barrier.
-  MpiWrapper::barrier();
+  // MpiWrapper::barrier();
+  MpiWrapper::waitAll( commData.size(), commData.mpiSendBufferSizeRequest(), commData.mpiSendBufferSizeStatus() );
+  MpiWrapper::waitAll( commData.size(), commData.mpiSendBufferRequest(), commData.mpiSendBufferStatus() );
+
+
 
   auto sendSyncLists = [&] ( int idx )
   {
@@ -695,7 +699,12 @@ void CommunicationTools::setupGhosts( MeshLevel & meshLevel,
   // from each other, and resolves some non-deterministic errors.
   // IMO, this is a hack and we should revisit the async communication strategy
   // here.
-  MpiWrapper::barrier();
+  //MpiWrapper::barrier();
+  MpiWrapper::waitAll( commData.size(), commData.mpiSendBufferSizeRequest(), commData.mpiSendBufferSizeStatus() );
+  MpiWrapper::waitAll( commData.size(), commData.mpiSendBufferRequest(), commData.mpiSendBufferStatus() );
+
+
+
 
   fixReceiveLists( nodeManager, neighbors );
   fixReceiveLists( edgeManager, neighbors );
@@ -705,7 +714,11 @@ void CommunicationTools::setupGhosts( MeshLevel & meshLevel,
 
   // See above comments for the reason behind this barrier.
   // RE: isolate multiple async-wait
-  MpiWrapper::barrier();
+  //MpiWrapper::barrier();
+  MpiWrapper::waitAll( commData.size(), commData.mpiSendBufferSizeRequest(), commData.mpiSendBufferSizeStatus() );
+  MpiWrapper::waitAll( commData.size(), commData.mpiSendBufferRequest(), commData.mpiSendBufferStatus() );
+
+
 
   nodeManager.fixUpDownMaps( false );
   verifyGhostingConsistency( nodeManager, neighbors );

--- a/src/coreComponents/mesh/mpiCommunications/CommunicationTools.cpp
+++ b/src/coreComponents/mesh/mpiCommunications/CommunicationTools.cpp
@@ -652,25 +652,18 @@ void CommunicationTools::setupGhosts( MeshLevel & meshLevel,
 
   waitOrderedOrWaitAll( neighbors.size(), { sendGhosts, postRecv, unpackGhosts }, unorderedComms );
 
-  nodeManager.setReceiveLists();
-  edgeManager.setReceiveLists();
-  faceManager.setReceiveLists();
-
-  // at present removing this barrier allows a nondeterministic mpi error to happen on lassen
-  //   it occurs less than 5% of the time and happens when a process enters the recv phase in
-  //   the sync list exchange while another process still has not unpacked the ghosts received from
-  //   the first process. Depending on the mpi implementation the sync send from the first process
-  //   can be recv'd by the second process instead of the ghost send which has already been sent but
-  //   not necessarily received.
-  // Some restructuring to ensure this can't happen ( can also probably just change the send/recv tagging )
-  //   can eliminate this. But at present runtimes are the same in either case, as time is mostly just
-  //   shifted from the waitall in UnpackAndRebuildSyncLists since the processes are more 'in-sync' when
-  //   hitting that point after introducing this barrier.
-  // MpiWrapper::barrier();
+  // There are cases where the multiple waitOrderedOrWaitAll methods here will clash with
+  // each other. This typically occurs at higher processor counts (>256) and large meshes
+  // with ~14M elements. Adding the following waitAll methods ensures that the underlying
+  // async MPI communication will not interfere with subsequent async communication calls.
+  // The underlying problem is that for a given phase of async communication, the same
+  // tag numbers are used. This will at least isolate the async calls from each other.
   MpiWrapper::waitAll( commData.size(), commData.mpiSendBufferSizeRequest(), commData.mpiSendBufferSizeStatus() );
   MpiWrapper::waitAll( commData.size(), commData.mpiSendBufferRequest(), commData.mpiSendBufferStatus() );
 
-
+  nodeManager.setReceiveLists();
+  edgeManager.setReceiveLists();
+  faceManager.setReceiveLists();
 
   auto sendSyncLists = [&] ( int idx )
   {
@@ -693,18 +686,10 @@ void CommunicationTools::setupGhosts( MeshLevel & meshLevel,
 
   waitOrderedOrWaitAll( neighbors.size(), { sendSyncLists, postRecv, rebuildSyncLists }, unorderedComms );
 
-  // There are cases where the multiple waitOrderedOrWaitAll methods will clash
-  // with each other. Mostly at high processor counts (>256) and large
-  // meshes (~14M elements). Adding in these barriers isolates the wait calls
-  // from each other, and resolves some non-deterministic errors.
-  // IMO, this is a hack and we should revisit the async communication strategy
-  // here.
-  //MpiWrapper::barrier();
+  // See above comments for the reason behind these waitAll commands
+  // RE: isolate multiple async-wait calls
   MpiWrapper::waitAll( commData.size(), commData.mpiSendBufferSizeRequest(), commData.mpiSendBufferSizeStatus() );
   MpiWrapper::waitAll( commData.size(), commData.mpiSendBufferRequest(), commData.mpiSendBufferStatus() );
-
-
-
 
   fixReceiveLists( nodeManager, neighbors );
   fixReceiveLists( edgeManager, neighbors );
@@ -712,13 +697,10 @@ void CommunicationTools::setupGhosts( MeshLevel & meshLevel,
 
   waitOrderedOrWaitAll( neighbors.size(), { sendSyncLists, postRecv, rebuildSyncLists }, unorderedComms );
 
-  // See above comments for the reason behind this barrier.
+  // See above comments for the reason behind these waitAll commands
   // RE: isolate multiple async-wait
-  //MpiWrapper::barrier();
   MpiWrapper::waitAll( commData.size(), commData.mpiSendBufferSizeRequest(), commData.mpiSendBufferSizeStatus() );
   MpiWrapper::waitAll( commData.size(), commData.mpiSendBufferRequest(), commData.mpiSendBufferStatus() );
-
-
 
   nodeManager.fixUpDownMaps( false );
   verifyGhostingConsistency( nodeManager, neighbors );


### PR DESCRIPTION
Related to issue #2173, where there are system dependent nondeterministic mpi errors. This fix isolates multiple calls to mpi-wait with barriers.

This is a short-term hack which will resolve the issues seen with large processor counts on certain machines. This can open a discussion on the overall async mpi strategy used in the neighbor communication scheme.

resolves #2173 