### PR TITLE
Remove hardcoded number of degrees of freedom

### DIFF
--- a/src/coreComponents/physicsSolvers/wavePropagation/ElasticWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/ElasticWaveEquationSEM.cpp
@@ -261,7 +261,7 @@ void ElasticWaveEquationSEM::postProcessInput()
   }
   localIndex const nsamples = int(maxTime/dt) + 1;
 
-  localIndex numNodesPerElem = 8;
+  localIndex numNodesPerElem = getNumNodesPerElem();
 
   localIndex const numSourcesGlobal = m_sourceCoordinates.size( 0 );
   m_sourceNodeIds.resize( numSourcesGlobal, numNodesPerElem );


### PR DESCRIPTION
This is a little bugfix, where we remove the last (I hope) hardcoded number of degrees of freedom.