### PR TITLE
Added dedicated MGR recipe for OBL

### DIFF
--- a/src/coreComponents/linearAlgebra/CMakeLists.txt
+++ b/src/coreComponents/linearAlgebra/CMakeLists.txt
@@ -107,12 +107,14 @@ if( ENABLE_HYPRE )
           interfaces/hypre/mgrStrategies/Hydrofracture.hpp
           interfaces/hypre/mgrStrategies/LagrangianContactMechanics.hpp      
           interfaces/hypre/mgrStrategies/MultiphasePoromechanics.hpp
-          interfaces/hypre/mgrStrategies/MultiphasePoromechanicsReservoirFVM.hpp	  
+          interfaces/hypre/mgrStrategies/MultiphasePoromechanicsReservoirFVM.hpp
+	  interfaces/hypre/mgrStrategies/ReactiveCompositionalMultiphaseOBL.hpp
           interfaces/hypre/mgrStrategies/SinglePhaseHybridFVM.hpp
           interfaces/hypre/mgrStrategies/SinglePhasePoromechanics.hpp
           interfaces/hypre/mgrStrategies/SinglePhasePoromechanicsReservoirFVM.hpp	  
           interfaces/hypre/mgrStrategies/SinglePhaseReservoirFVM.hpp
           interfaces/hypre/mgrStrategies/SinglePhaseReservoirHybridFVM.hpp
+	  interfaces/hypre/mgrStrategies/ThermalCompositionalMultiphaseFVM.hpp
         )
 
     list( APPEND linearAlgebra_sources

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreMGR.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreMGR.cpp
@@ -29,6 +29,7 @@
 #include "linearAlgebra/interfaces/hypre/mgrStrategies/LagrangianContactMechanics.hpp"
 #include "linearAlgebra/interfaces/hypre/mgrStrategies/MultiphasePoromechanics.hpp"
 #include "linearAlgebra/interfaces/hypre/mgrStrategies/MultiphasePoromechanicsReservoirFVM.hpp"
+#include "linearAlgebra/interfaces/hypre/mgrStrategies/ReactiveCompositionalMultiphaseOBL.hpp"
 #include "linearAlgebra/interfaces/hypre/mgrStrategies/SinglePhaseHybridFVM.hpp"
 #include "linearAlgebra/interfaces/hypre/mgrStrategies/SinglePhasePoromechanics.hpp"
 #include "linearAlgebra/interfaces/hypre/mgrStrategies/SinglePhasePoromechanicsReservoirFVM.hpp"
@@ -88,6 +89,11 @@ void hypre::mgr::createMGR( LinearSolverParameters const & params,
     case LinearSolverParameters::MGR::StrategyType::compositionalMultiphaseReservoirHybridFVM:
     {
       setStrategy< CompositionalMultiphaseReservoirHybridFVM >( params.mgr, numComponentsPerField, precond, mgrData );
+      break;
+    }
+    case LinearSolverParameters::MGR::StrategyType::reactiveCompositionalMultiphaseOBL:
+    {
+      setStrategy< ReactiveCompositionalMultiphaseOBL >( params.mgr, numComponentsPerField, precond, mgrData );
       break;
     }
     case LinearSolverParameters::MGR::StrategyType::thermalCompositionalMultiphaseFVM:

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/mgrStrategies/ReactiveCompositionalMultiphaseOBL.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/mgrStrategies/ReactiveCompositionalMultiphaseOBL.hpp
@@ -1,0 +1,135 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file ReactiveCompositionalMultiphaseOBL.hpp
+ */
+
+#ifndef GEOSX_LINEARALGEBRA_INTERFACES_HYPREMGRREACTIVECOMPOSITIONALMULTIPHASEOBL_HPP_
+#define GEOSX_LINEARALGEBRA_INTERFACES_HYPREMGRREACTIVECOMPOSITIONALMULTIPHASEOBL_HPP_
+
+#include "linearAlgebra/interfaces/hypre/HypreMGR.hpp"
+
+namespace geosx
+{
+
+namespace hypre
+{
+
+namespace mgr
+{
+
+/**
+ * @brief ReactiveCompositionalMultiphaseOBL strategy.
+ *
+ * Labels description stored in point_marker_array
+ *               0 = pressure
+ *               1 = component fraction c = 0
+ *             ... = component fraction
+ *   numLabels - 1 = component fraction c = NC-2 where NC is the number of components
+ *
+ * 1-level MGR reduction strategy:
+ *   - Eliminate the (NC-1) reservoir component fractions
+ *   - The coarse grid (pressure system) is solved with BoomerAMG.
+ *
+ * Note: in the OBL formulation, we have the following primary variables
+ *   - Cell-centered pressure
+ *   - NC-1 cell-centered component fractions
+ * so there is no need for the first elimination of CompositionalMultiphaseFVM
+ */
+class ReactiveCompositionalMultiphaseOBL : public MGRStrategyBase< 1 >
+{
+public:
+  /**
+   * @brief Constructor.
+   * @param numComponentsPerField array with number of components for each field
+   */
+  explicit ReactiveCompositionalMultiphaseOBL( arrayView1d< int const > const & numComponentsPerField )
+    : MGRStrategyBase( LvArray::integerConversion< HYPRE_Int >( numComponentsPerField[0] ) )
+  {
+    // Level 0: eliminate the NC-1 component fractions
+    m_labels[0].push_back( 0 );
+
+    setupLabels();
+
+    m_levelFRelaxMethod[0]     = MGRFRelaxationMethod::singleLevel; //default, i.e. Jacobi
+    m_levelInterpType[0]       = MGRInterpolationType::injection;
+    m_levelRestrictType[0]     = MGRRestrictionType::injection;
+    m_levelCoarseGridMethod[0] = MGRCoarseGridMethod::cprLikeBlockDiag;
+
+    // ILU smoothing for the system made of pressure and densities (except the last one)
+    m_levelSmoothType[0]  = 16;
+    m_levelSmoothIters[0] = 1;
+  }
+
+  /**
+   * @brief Setup the MGR strategy.
+   * @param precond preconditioner wrapper
+   * @param mgrData auxiliary MGR data
+   */
+  void setup( LinearSolverParameters::MGR const &,
+              HyprePrecWrapper & precond,
+              HypreMGRData & mgrData )
+  {
+    GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetCpointsByPointMarkerArray( precond.ptr,
+                                                                  m_numBlocks, numLevels,
+                                                                  m_numLabels, m_ptrLabels,
+                                                                  mgrData.pointMarkers.data() ) );
+
+
+    GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetLevelInterpType( precond.ptr, toUnderlyingPtr( m_levelInterpType ) ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetLevelRestrictType( precond.ptr, toUnderlyingPtr( m_levelRestrictType ) ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetCoarseGridMethod( precond.ptr, toUnderlyingPtr( m_levelCoarseGridMethod ) ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetNonCpointsToFpoints( precond.ptr, 1 ));
+    GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetLevelSmoothType( precond.ptr, m_levelSmoothType ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetLevelSmoothIters( precond.ptr, m_levelSmoothIters ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetTruncateCoarseGridThreshold( precond.ptr, 1e-20 )); // truncate intermediate/coarse grids
+
+    // Note: uncommenting HYPRE_MGRSetLevelFRelaxMethod and commenting HYPRE_MGRSetRelaxType breaks the recipe. This requires further
+    // investigation
+    //GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetLevelFRelaxMethod( precond.ptr, toUnderlyingPtr( m_levelFRelaxMethod ) ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetRelaxType( precond.ptr, 0 ));
+    GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetNumRelaxSweeps( precond.ptr, 1 ));
+#ifdef GEOSX_USE_HYPRE_CUDA
+    GEOSX_LAI_CHECK_ERROR( HYPRE_MGRSetRelaxType( precond.ptr, getAMGRelaxationType( LinearSolverParameters::AMG::SmootherType::l1jacobi ) ) );
+#endif
+
+    GEOSX_LAI_CHECK_ERROR( HYPRE_BoomerAMGCreate( &mgrData.coarseSolver.ptr ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_BoomerAMGSetPrintLevel( mgrData.coarseSolver.ptr, 0 ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_BoomerAMGSetMaxIter( mgrData.coarseSolver.ptr, 1 ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_BoomerAMGSetAggNumLevels( mgrData.coarseSolver.ptr, 1 ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_BoomerAMGSetTol( mgrData.coarseSolver.ptr, 0.0 ) );
+#ifdef GEOSX_USE_HYPRE_CUDA
+    GEOSX_LAI_CHECK_ERROR( HYPRE_BoomerAMGSetPrintLevel( mgrData.coarseSolver.ptr, 1 ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_BoomerAMGSetCoarsenType( mgrData.coarseSolver.ptr, toUnderlying( AMGCoarseningType::PMIS ) ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_BoomerAMGSetRelaxType( mgrData.coarseSolver.ptr, getAMGRelaxationType( LinearSolverParameters::AMG::SmootherType::l1jacobi ) ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_BoomerAMGSetNumSweeps( mgrData.coarseSolver.ptr, 2 ) );
+    GEOSX_LAI_CHECK_ERROR( HYPRE_BoomerAMGSetMaxRowSum( mgrData.coarseSolver.ptr, 1.0 ) );
+#else
+    GEOSX_LAI_CHECK_ERROR( HYPRE_BoomerAMGSetRelaxOrder( mgrData.coarseSolver.ptr, 1 ) );
+#endif
+
+    mgrData.coarseSolver.setup = HYPRE_BoomerAMGSetup;
+    mgrData.coarseSolver.solve = HYPRE_BoomerAMGSolve;
+    mgrData.coarseSolver.destroy = HYPRE_BoomerAMGDestroy;
+  }
+};
+
+} // namespace mgr
+
+} // namespace hypre
+
+} // namespace geosx
+
+#endif /*GEOSX_LINEARALGEBRA_INTERFACES_HYPREMGRREACTIVECOMPOSITIONALMULTIPHASEOBL_HPP_*/

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/mgrStrategies/ReactiveCompositionalMultiphaseOBL.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/mgrStrategies/ReactiveCompositionalMultiphaseOBL.hpp
@@ -43,10 +43,12 @@ namespace mgr
  *   - Eliminate the (NC-1) reservoir component fractions
  *   - The coarse grid (pressure system) is solved with BoomerAMG.
  *
- * Note: in the OBL formulation, we have the following primary variables
+ * Note: in the OBL isothermal formulation, we have the following primary variables
  *   - Cell-centered pressure
  *   - NC-1 cell-centered component fractions
  * so there is no need for the first elimination of CompositionalMultiphaseFVM
+ *
+ * TODO: the thermal formulation may require a specific treatment in which temperature is treated as an elliptic variable
  */
 class ReactiveCompositionalMultiphaseOBL : public MGRStrategyBase< 1 >
 {
@@ -68,7 +70,7 @@ public:
     m_levelRestrictType[0]     = MGRRestrictionType::injection;
     m_levelCoarseGridMethod[0] = MGRCoarseGridMethod::cprLikeBlockDiag;
 
-    // ILU smoothing for the system made of pressure and densities (except the last one)
+    // ILU smoothing for the system made of pressure and component fractions
     m_levelSmoothType[0]  = 16;
     m_levelSmoothIters[0] = 1;
   }

--- a/src/coreComponents/linearAlgebra/utilities/LinearSolverParameters.hpp
+++ b/src/coreComponents/linearAlgebra/utilities/LinearSolverParameters.hpp
@@ -222,6 +222,7 @@ struct LinearSolverParameters
       compositionalMultiphaseHybridFVM,          ///< hybrid finite volume compositional multiphase flow
       compositionalMultiphaseReservoirFVM,       ///< finite volume compositional multiphase flow with wells
       compositionalMultiphaseReservoirHybridFVM, ///< hybrid finite volume compositional multiphase flow with wells
+      reactiveCompositionalMultiphaseOBL,        ///< finite volume reactive compositional flow with OBL
       thermalCompositionalMultiphaseFVM,         ///< finite volume thermal compositional multiphase flow
       multiphasePoromechanics,                   ///< multiphase poromechanics with finite volume compositional multiphase flow
       multiphasePoromechanicsReservoirFVM,       ///< multiphase poromechanics with finite volume compositional multiphase flow with wells
@@ -308,6 +309,7 @@ ENUM_STRINGS( LinearSolverParameters::MGR::StrategyType,
               "compositionalMultiphaseHybridFVM",
               "compositionalMultiphaseReservoirFVM",
               "compositionalMultiphaseReservoirHybridFVM",
+              "reactiveCompositionalMultiphaseOBL",
               "thermalCompositionalMultiphaseFVM",
               "multiphasePoromechanics",
               "multiphasePoromechanicsReservoirFVM",

--- a/src/coreComponents/physicsSolvers/fluidFlow/ReactiveCompositionalMultiphaseOBL.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/ReactiveCompositionalMultiphaseOBL.cpp
@@ -115,7 +115,7 @@ ReactiveCompositionalMultiphaseOBL::ReactiveCompositionalMultiphaseOBL( const st
     setInputFlag( InputFlags::OPTIONAL ).
     setDescription( "List of fluid phases" );
 
-  m_linearSolverParameters.get().mgr.strategy = LinearSolverParameters::MGR::StrategyType::compositionalMultiphaseFVM;
+  m_linearSolverParameters.get().mgr.strategy = LinearSolverParameters::MGR::StrategyType::reactiveCompositionalMultiphaseOBL;
 }
 
 void ReactiveCompositionalMultiphaseOBL::initializePreSubGroups()


### PR DESCRIPTION
This PR adds an MGR recipe for `ReactiveCompositionalMultiphaseOBL`. 

In the OBL formulation, the dofs are 1 pressure and NC-1 component fractions, so it is slightly different from our standard formulation and does not require the elimination of a saturation equation. As a result we can use a one-level recipe in which we eliminate all the component fractions in one pass, and then solve the coarse (pressure) system with BoomerAMG.

It seems to work well on thermal and reactive OBL tests. 

Ready for review.