### PR TITLE
Fixed bug in MGR recipe

### DIFF
--- a/src/coreComponents/linearAlgebra/interfaces/hypre/mgrStrategies/MultiphasePoromechanicsReservoirFVM.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/mgrStrategies/MultiphasePoromechanicsReservoirFVM.hpp
@@ -84,7 +84,7 @@ public:
 
     // Level 0
     m_levelFRelaxMethod[0]     = MGRFRelaxationMethod::amgVCycle;
-    m_levelFRelaxType[0]       = MGRFRelaxationType::jacobi;
+    m_levelFRelaxType[0]       = MGRFRelaxationType::amgVCycle;
     m_levelInterpType[0]       = MGRInterpolationType::jacobi;
     m_levelRestrictType[0]     = MGRRestrictionType::injection;
     m_levelCoarseGridMethod[0] = MGRCoarseGridMethod::nonGalerkin;


### PR DESCRIPTION
This one-line PR fixes a bug that I introduced in #2238 in the MGR recipe called `MultiphasePoromechanicsReservoirFVM` (multiphase poromechanics with wells). 

I did not pay attention (despite the [warning](https://github.com/GEOSX/GEOSX/pull/2238#discussion_r1066458862)!) and specified conflicting options for `levelFRelaxType` and `levelFRelaxMethod` for the first level of the recipe (the mechanical problem). The correct `levelFRelaxType` option should be `amgVCycle` to preserve the behavior that we had before when specifying only `levelFRelaxMethod = amgVCycle` (ultimately `levelFRelaxMethod` will be removed).