### PR TITLE
Fix bug in reinit() for acoustic wave solver (pygeosx)

### DIFF
--- a/src/coreComponents/physicsSolvers/wavePropagation/WaveSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/WaveSolverBase.cpp
@@ -117,6 +117,7 @@ WaveSolverBase::~WaveSolverBase()
 
 void WaveSolverBase::reinit()
 {
+  initializePreSubGroups();
   postProcessInput();
   initializePostInitialConditionsPreSubGroups();
 }


### PR DESCRIPTION
This PR fix a bug we found when we use Pygeosx interface. 
Due to last changes, we need to add a call to initializePreSubGroups inside reinit function to be able to do several shots with the acoustic solver.