### PR TITLE
Changed FaceManager::MAX_FACE_NODES from 9 to 11.

### DIFF
--- a/src/coreComponents/mesh/FaceManager.hpp
+++ b/src/coreComponents/mesh/FaceManager.hpp
@@ -470,7 +470,7 @@ private:
   array2d< real64 > m_faceNormal;
 
   /// constant expression of the maximum number of nodes per faces
-  constexpr static int MAX_FACE_NODES = 9;
+  constexpr static int MAX_FACE_NODES = 11;
 
 };
 


### PR DESCRIPTION
In order to be consistent with the documentation (https://geosx-geosx.readthedocs-hosted.com/en/latest/coreComponents/mesh/docs/Mesh.html?highlight=prism#supported-formats) and the ElementType enum (which go up to Prism11), I'm changing FaceManager::MAX_FACE_NODES from 9 to 11 to support more nodes per face.
The issue #2243 should be solved.

@TotoGaz 