### PR TITLE
Use cell block name instead of region name in VTK field import.

### DIFF
--- a/src/coreComponents/mesh/MeshManager.cpp
+++ b/src/coreComponents/mesh/MeshManager.cpp
@@ -143,7 +143,7 @@ void MeshManager::importFields( DomainPartition & domain )
                                               region.getName(), subRegion.getName() ) );
 
         bool const isMaterialField = materialWrapperNames.count( geosxFieldName ) > 0 && wrapper.numArrayDims() > 1;
-        generator.importFieldsOnArray( region.getName(), meshFieldName, isMaterialField, wrapper );
+        generator.importFieldsOnArray( subRegion.getName(), meshFieldName, isMaterialField, wrapper );
       }
     } );
 

--- a/src/coreComponents/mesh/MeshManager.cpp
+++ b/src/coreComponents/mesh/MeshManager.cpp
@@ -111,43 +111,46 @@ void MeshManager::importFields( DomainPartition & domain )
     FieldIdentifiers fieldsToBeSync;
     std::map< string, string > fieldNamesMapping = generator.getFieldsMapping();
 
-    MeshLevel & meshLevel = domain.getMeshBody( generator.getName() ).getBaseDiscretization();
-    ElementRegionManager & elemManager = meshLevel.getElemManager();
-    elemManager.forElementSubRegionsComplete< CellElementSubRegion >( [&]( localIndex,
-                                                                           localIndex,
-                                                                           ElementRegionBase const & region,
-                                                                           CellElementSubRegion & subRegion )
+    dataRepository::Group & meshLevels = domain.getMeshBody( generator.getName() ).getMeshLevels();
+    meshLevels.forSubGroups< MeshLevel >( [&] ( MeshLevel & meshLevel ) 
     {
-      std::unordered_set< string > const materialWrapperNames = getMaterialWrapperNames( subRegion );
-      // Writing properties
-      for( auto const & pair : fieldNamesMapping )
+      ElementRegionManager & elemManager = meshLevel.getElemManager();
+      elemManager.forElementSubRegionsComplete< CellElementSubRegion >( [&]( localIndex,
+                                                                             localIndex,
+                                                                             ElementRegionBase const & region,
+                                                                             CellElementSubRegion & subRegion )
       {
-        string const & meshFieldName = pair.first;
-        string const & geosxFieldName = pair.second;
-        // Find destination
-        if( !subRegion.hasWrapper( geosxFieldName ) )
+        std::unordered_set< string > const materialWrapperNames = getMaterialWrapperNames( subRegion );
+        // Writing properties
+        for( auto const & pair : fieldNamesMapping )
         {
-          // Skip - the user may have not enabled a particular physics model/solver on this dstRegion.
-          GEOSX_LOG_LEVEL_RANK_0( 1, GEOSX_FMT( "Skipping import of {} -> {} on {}/{} (field not found)",
-                                                meshFieldName, geosxFieldName, region.getName(), subRegion.getName() ) );
+          string const & meshFieldName = pair.first;
+          string const & geosxFieldName = pair.second;
+          // Find destination
+          if( !subRegion.hasWrapper( geosxFieldName ) )
+          {
+            // Skip - the user may have not enabled a particular physics model/solver on this dstRegion.
+            GEOSX_LOG_LEVEL_RANK_0( 1, GEOSX_FMT( "Skipping import of {} -> {} on {}/{} (field not found)",
+                                                  meshFieldName, geosxFieldName, region.getName(), subRegion.getName() ) );
 
-          continue;
+            continue;
+          }
+
+          // Now that we know that the subRegion has this wrapper, we can add the geosxFieldName to the list of fields to
+          // synchronize
+          fieldsToBeSync.addElementFields( {geosxFieldName}, {region.getName()} );
+          WrapperBase & wrapper = subRegion.getWrapperBase( geosxFieldName );
+          GEOSX_LOG_LEVEL_RANK_0( 1, GEOSX_FMT( "Importing field {} -> {} on {}/{}",
+                                                meshFieldName, geosxFieldName,
+                                                region.getName(), subRegion.getName() ) );
+
+          bool const isMaterialField = materialWrapperNames.count( geosxFieldName ) > 0 && wrapper.numArrayDims() > 1;
+          generator.importFieldsOnArray( subRegion.getName(), meshFieldName, isMaterialField, wrapper );
         }
+      } );
 
-        // Now that we know that the subRegion has this wrapper, we can add the geosxFieldName to the list of fields to
-        // synchronize
-        fieldsToBeSync.addElementFields( {geosxFieldName}, {region.getName()} );
-        WrapperBase & wrapper = subRegion.getWrapperBase( geosxFieldName );
-        GEOSX_LOG_LEVEL_RANK_0( 1, GEOSX_FMT( "Importing field {} -> {} on {}/{}",
-                                              meshFieldName, geosxFieldName,
-                                              region.getName(), subRegion.getName() ) );
-
-        bool const isMaterialField = materialWrapperNames.count( geosxFieldName ) > 0 && wrapper.numArrayDims() > 1;
-        generator.importFieldsOnArray( subRegion.getName(), meshFieldName, isMaterialField, wrapper );
-      }
+      CommunicationTools::getInstance().synchronizeFields( fieldsToBeSync, meshLevel, domain.getNeighbors(), false );
     } );
-
-    CommunicationTools::getInstance().synchronizeFields( fieldsToBeSync, meshLevel, domain.getNeighbors(), false );
     generator.freeResources();
   } );
 }

--- a/src/coreComponents/mesh/MeshManager.cpp
+++ b/src/coreComponents/mesh/MeshManager.cpp
@@ -112,7 +112,7 @@ void MeshManager::importFields( DomainPartition & domain )
     std::map< string, string > fieldNamesMapping = generator.getFieldsMapping();
 
     dataRepository::Group & meshLevels = domain.getMeshBody( generator.getName() ).getMeshLevels();
-    meshLevels.forSubGroups< MeshLevel >( [&] ( MeshLevel & meshLevel ) 
+    meshLevels.forSubGroups< MeshLevel >( [&]( MeshLevel & meshLevel )
     {
       ElementRegionManager & elemManager = meshLevel.getElemManager();
       elemManager.forElementSubRegionsComplete< CellElementSubRegion >( [&]( localIndex,

--- a/src/coreComponents/mesh/generators/VTKMeshGenerator.cpp
+++ b/src/coreComponents/mesh/generators/VTKMeshGenerator.cpp
@@ -152,7 +152,7 @@ void VTKMeshGenerator::importFieldsOnArray( string const & cellBlockName, string
     }
   }
 
-  GEOSX_ERROR("Could not import field \"" << meshFieldName << "\" from cell block \"" << cellBlockName << "\".");
+  GEOSX_ERROR( "Could not import field \"" << meshFieldName << "\" from cell block \"" << cellBlockName << "\"." );
 }
 
 void VTKMeshGenerator::freeResources()

--- a/src/coreComponents/mesh/generators/VTKMeshGenerator.cpp
+++ b/src/coreComponents/mesh/generators/VTKMeshGenerator.cpp
@@ -123,12 +123,9 @@ void VTKMeshGenerator::generateMesh( DomainPartition & domain )
   vtk::printMeshStatistics( *m_vtkMesh, m_cellMap, comm );
 }
 
-void VTKMeshGenerator::importFieldsOnArray( string const & regionName, string const & meshFieldName, bool isMaterialField, WrapperBase & wrapper ) const
+void VTKMeshGenerator::importFieldsOnArray( string const & cellBlockName, string const & meshFieldName, bool isMaterialField, WrapperBase & wrapper ) const
 {
-  // GEOSX_LOG_RANK_0( GEOSX_FMT( "{} '{}': importing field data from mesh dataset", catalogName(), getName() ) );
   GEOSX_ASSERT_MSG( m_vtkMesh, "Must call generateMesh() before importFields()" );
-
-  vtkDataArray * vtkArray = vtk::findArrayForImport( *m_vtkMesh, meshFieldName );
 
   for( auto const & typeRegions : m_cellMap )
   {
@@ -137,22 +134,25 @@ void VTKMeshGenerator::importFieldsOnArray( string const & regionName, string co
     {
       for( auto const & regionCells: typeRegions.second )
       {
-        string const cellBlockName = vtk::buildCellBlockName( typeRegions.first, regionCells.first );
+        string const currentCellBlockName = vtk::buildCellBlockName( typeRegions.first, regionCells.first );
         // We don't know how the user mapped cell blocks to regions, so we must check all of them
-        if( regionName != cellBlockName )
+        if( cellBlockName != currentCellBlockName )
           continue;
 
+        vtkDataArray * vtkArray = vtk::findArrayForImport( *m_vtkMesh, meshFieldName );
         if( isMaterialField )
         {
-          vtk::importMaterialField( regionCells.second, vtkArray, wrapper );
+          return vtk::importMaterialField( regionCells.second, vtkArray, wrapper );
         }
         else
         {
-          vtk::importRegularField( regionCells.second, vtkArray, wrapper );
+          return vtk::importRegularField( regionCells.second, vtkArray, wrapper );
         }
       }
     }
   }
+
+  GEOSX_ERROR("Could not import field \"" << meshFieldName << "\" from cell block \"" << cellBlockName << "\".");
 }
 
 void VTKMeshGenerator::freeResources()

--- a/src/coreComponents/mesh/generators/VTKMeshGenerator.hpp
+++ b/src/coreComponents/mesh/generators/VTKMeshGenerator.hpp
@@ -87,7 +87,7 @@ public:
    */
   virtual void generateMesh( DomainPartition & domain ) override;
 
-  void importFieldsOnArray( string const & regionName, string const & meshFieldNam, bool isMaterialField, WrapperBase & wrapper ) const override;
+  void importFieldsOnArray( string const & cellBlockName, string const & meshFieldNam, bool isMaterialField, WrapperBase & wrapper ) const override;
 
   virtual void freeResources() override;
 


### PR DESCRIPTION
- Uses the `subRegion` name instead of the `regionName` when importing the fields.
- Fixes the discrepancy between an argument name member function `MeshGeneratorBase::importFieldsOnArray` (was `cellBlockName`/`regioName`). Now always `cellBlockName`.
- Killing the simulation if no field could be imported: it's not normal I think.

I could run a simulation with fields imported from a `vtk` mesh.
@sframba @XL64 can you validate the fix?

Fixes https://github.com/GEOSX/GEOSX/issues/2266