### PR TITLE
Validate well to reservoir connections

### DIFF
--- a/src/coreComponents/physicsSolvers/multiphysics/CoupledReservoirAndWellsBase.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/CoupledReservoirAndWellsBase.cpp
@@ -142,10 +142,12 @@ bool validateWellPerforations( SolverBase const * const solver,
       }
     } );
   } );
+
+  localIndex const badPerforationCount = MpiWrapper::max( badPerforation.first.empty() ? 0 : 1 );
+
   GEOSX_THROW_IF( !badPerforation.first.empty(),
                   GEOSX_FMT( "The well {} has a connection to the region {} which is not targeted by the solver", badPerforation.first, badPerforation.second ),
                   std::runtime_error );
-  localIndex const badPerforationCount = MpiWrapper::max( badPerforation.first.empty() ? 0 : 1 );
   return badPerforationCount == 0;
 }
 

--- a/src/coreComponents/physicsSolvers/multiphysics/CoupledReservoirAndWellsBase.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/CoupledReservoirAndWellsBase.cpp
@@ -110,14 +110,18 @@ addCouplingNumNonzeros( SolverBase const * const solver,
   } );
 }
 
-bool validateWellPerforations( SolverBase const * const solver,
+bool validateWellPerforations( SolverBase const * const reservoirSolver,
                                WellSolverBase const * const wellSolver,
                                DomainPartition const & domain )
 {
   std::pair< string, string > badPerforation;
-  solver->forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
-                                                                        MeshLevel const & meshLevel,
-                                                                        arrayView1d< string const > const & regionNames )
+
+  arrayView1d< string const > const flowTargetRegionNames =
+    reservoirSolver->getReference< array1d< string > >( SolverBase::viewKeyStruct::targetRegionsString() );
+
+  wellSolver->forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
+                                                                            MeshLevel const & meshLevel,
+                                                                            arrayView1d< string const > const & regionNames )
   {
     ElementRegionManager const & elemManager = meshLevel.getElemManager();
     elemManager.forElementSubRegions< WellElementSubRegion >( regionNames, [&]( localIndex const, WellElementSubRegion const & subRegion )
@@ -134,7 +138,7 @@ bool validateWellPerforations( SolverBase const * const solver,
       {
         localIndex const er = resElementRegion[iperf];
         string const regionName = elemManager.getRegion( er ).getName();
-        if( std::find( regionNames.begin(), regionNames.end(), regionName ) == regionNames.end())
+        if( std::find( flowTargetRegionNames.begin(), flowTargetRegionNames.end(), regionName ) == flowTargetRegionNames.end())
         {
           badPerforation = {wellControls.getName(), regionName};
           break;

--- a/src/coreComponents/physicsSolvers/multiphysics/CoupledReservoirAndWellsBase.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/CoupledReservoirAndWellsBase.cpp
@@ -143,12 +143,12 @@ bool validateWellPerforations( SolverBase const * const solver,
     } );
   } );
 
-  localIndex const badPerforationCount = MpiWrapper::max( badPerforation.first.empty() ? 0 : 1 );
+  localIndex const hasBadPerforations = MpiWrapper::max( badPerforation.first.empty() ? 0 : 1 );
 
   GEOSX_THROW_IF( !badPerforation.first.empty(),
                   GEOSX_FMT( "The well {} has a connection to the region {} which is not targeted by the solver", badPerforation.first, badPerforation.second ),
                   std::runtime_error );
-  return badPerforationCount == 0;
+  return hasBadPerforations == 0;
 }
 
 }

--- a/src/coreComponents/physicsSolvers/multiphysics/CoupledReservoirAndWellsBase.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/CoupledReservoirAndWellsBase.hpp
@@ -195,7 +195,7 @@ public:
     if( !validateWellPerforations( domain ))
       return;
 
-    this->template forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const & meshName,
+    this->template forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
                                                                                  MeshLevel & meshLevel,
                                                                                  arrayView1d< string const > const & regionNames )
     {

--- a/src/coreComponents/physicsSolvers/multiphysics/CoupledReservoirAndWellsBase.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/CoupledReservoirAndWellsBase.hpp
@@ -58,11 +58,11 @@ addCouplingNumNonzeros( SolverBase const * const solver,
 /**
  * @brief Validate the well perforations ensuring that each perforation is located in a reservoir region that is also
  * targetted by the solver
- * @param solver the coupled solver
+ * @param reservoirSolver the reservoir solver
  * @param wellSolver the well solver
  * @param domain the physical domain object
  */
-bool validateWellPerforations( SolverBase const * const solver,
+bool validateWellPerforations( SolverBase const * const reservoirSolver,
                                WellSolverBase const * const wellSolver,
                                DomainPartition const & domain );
 
@@ -193,7 +193,9 @@ public:
 
     // Validate well perforations: Ensure that each perforation is in a region targetted by the solver
     if( !validateWellPerforations( domain ))
+    {
       return;
+    }
 
     this->template forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
                                                                                  MeshLevel & meshLevel,
@@ -291,7 +293,7 @@ private:
    */
   bool validateWellPerforations( DomainPartition const & domain ) const
   {
-    return coupledReservoirAndWellsInternal::validateWellPerforations( this, wellSolver(), domain );
+    return coupledReservoirAndWellsInternal::validateWellPerforations( reservoirSolver(), wellSolver(), domain );
   }
 
 };


### PR DESCRIPTION
Implements a check on well to reservoir connections to ensure that all reservoir cells connected to wells are also targeted by a flow solver.

Should improve the error message related to issue #2263 