### PR TITLE
Improve doc for docker development.

### DIFF
--- a/src/docs/sphinx/developerGuide/Contributing/Dockerfile-remote-dev.example
+++ b/src/docs/sphinx/developerGuide/Contributing/Dockerfile-remote-dev.example
@@ -28,7 +28,7 @@ RUN apt-get autoremove -y
 
 # The default user is root. If you plan your docker instance to be a disposable environment,
 # with no sensitive information that a "root/normal user split" could protect,
-# then this is a choice which can make sense. Feel free to adapt.
+# then this is a choice which can make sense. Make your own decision.
 RUN echo "PermitRootLogin prohibit-password" >> /etc/ssh/sshd_config
 RUN echo "PermitUserEnvironment yes" >> /etc/ssh/sshd_config
 RUN mkdir -p -m 700 /root/.ssh

--- a/src/docs/sphinx/developerGuide/Contributing/Dockerfile-remote-dev.example
+++ b/src/docs/sphinx/developerGuide/Contributing/Dockerfile-remote-dev.example
@@ -27,7 +27,7 @@ RUN apt-get autoremove -y
 # This is the part where I configure sshd.
 
 # The default user is root. If you plan your docker instance to be a disposable environment,
-# with no sensitive information that a "root/normal user split" could protect,
+# with no sensitive information that a split between root and normal user could protect,
 # then this is a choice which can make sense. Make your own decision.
 RUN echo "PermitRootLogin prohibit-password" >> /etc/ssh/sshd_config
 RUN echo "PermitUserEnvironment yes" >> /etc/ssh/sshd_config

--- a/src/docs/sphinx/developerGuide/Contributing/Dockerfile-remote-dev.example
+++ b/src/docs/sphinx/developerGuide/Contributing/Dockerfile-remote-dev.example
@@ -12,6 +12,10 @@ RUN apt-get update
 RUN apt-get remove --purge -y texlive graphviz
 RUN apt-get install --no-install-recommends -y openssh-server gdb rsync gdbserver ninja-build
 
+# You may need to define your time zone. This is a way to do it. Please adapt to your own needs.
+RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime && \
+    dpkg-reconfigure -f noninteractive tzdata
+
 # You will need cmake to build GEOSX.
 ARG CMAKE_VERSION=3.16.8
 RUN apt-get install -y --no-install-recommends curl ca-certificates && \
@@ -22,8 +26,9 @@ RUN apt-get autoremove -y
 # You'll most likely need ssh/sshd too (e.g. CLion and VSCode allow remote dev through ssh).
 # This is the part where I configure sshd.
 
-# I'm developing in a version of docker that requires root.
-# So by default I use root. Feel free to adapt.
+# The default user is root. If you plan your docker instance to be a disposable environment,
+# with no sensitive information that a "root/normal user split" could protect,
+# then this is a choice which can make sense. Feel free to adapt.
 RUN echo "PermitRootLogin prohibit-password" >> /etc/ssh/sshd_config
 RUN echo "PermitUserEnvironment yes" >> /etc/ssh/sshd_config
 RUN mkdir -p -m 700 /root/.ssh
@@ -43,9 +48,14 @@ RUN touch /root/.ssh/environment &&\
     echo "OMPI_CC=${CC}" >> /root/.ssh/environment &&\
     echo "OMPI_CXX=${CXX}" >> /root/.ssh/environment &&\
     echo "GEOSX_TPL_DIR=${GEOSX_TPL_DIR}" >> /root/.ssh/environment
+# If you decide to work as root in your container, you may consider adding
+# `OMPI_ALLOW_RUN_AS_ROOT=1` and `OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1`
+# to your environment. This will prevent you from adding the `--allow-run-as-root` option
+# when you run mpi. Of course, weigh the benefits and risks and make your own decision.
 
-# This is the default ssh port that we do not need to modify.
-EXPOSE 22
+# Default ssh port 22 is exposed. For _development_ purposes,
+# it can be useful to expose other ports for remote tools.
+EXPOSE 22 64010-64020
 # sshd's option -D prevents it from detaching and becoming a daemon.
 # Otherwise, sshd would not block the process and `docker run` would quit.
 RUN mkdir -p /run/sshd

--- a/src/docs/sphinx/developerGuide/Contributing/Dockerfile-remote-dev.example
+++ b/src/docs/sphinx/developerGuide/Contributing/Dockerfile-remote-dev.example
@@ -55,7 +55,7 @@ RUN touch /root/.ssh/environment &&\
 
 # Default ssh port 22 is exposed. For _development_ purposes,
 # it can be useful to expose other ports for remote tools.
-EXPOSE 22 64010-64020
+EXPOSE 22 11111 64010-64020
 # sshd's option -D prevents it from detaching and becoming a daemon.
 # Otherwise, sshd would not block the process and `docker run` would quit.
 RUN mkdir -p /run/sshd

--- a/src/docs/sphinx/developerGuide/Contributing/InstallWin.rst
+++ b/src/docs/sphinx/developerGuide/Contributing/InstallWin.rst
@@ -130,8 +130,8 @@ Now that we have the image build, let us run a container from,
 
     PS > docker run --cap-add=SYS_PTRACE  -d --name ${env:REMOTE_DEV_IMG}-${env:VERSION} -p 64000:22 --mount 'type=bind,source=D:/install_geosx_docker/,target=/app' ${env:REMOTE_DEV_IMG}:${env:VERSION}
 
-Note that in addition to the detached flag (*-d*) and the name tage (*--name*), we provide ``Docker`` with the port the container should be associated to
-communicate with ssh port 22, as well as a binding between a host mount point (*D:/install_geosx_docker/*) and a container mount point (*/app*) to have a peristent storage
+Note that in addition to the detached flag (``-d``) and the name tage (``--name``), we provide ``Docker`` with the port the container should be associated to
+communicate with ssh port 22, as well as a binding between a host mount point (``D:/install_geosx_docker/``) and a container mount point (``/app``) to have a peristent storage
 for our development/geosx builds. More details on the `--mount options <https://docs.docker.com/storage/bind-mounts/>`_
 
 A similar step can be achieved using the *Docker Desktop* GUI in the image tabs, clicking on the *run* button and filling the same information in the interface,
@@ -193,7 +193,7 @@ Once the code is configured and compiled, let us check the status of the build,
 
     root@b105f9ead860:~# cd [path-to-build]/ && ./bin/geosx --help
 
-Trying to launch a case using *mpirun*, you might get the following warning
+Trying to launch a case using ``mpirun``, you might get the following warning
 
 .. code:: console
 

--- a/src/docs/sphinx/developerGuide/Contributing/InstallWin.rst
+++ b/src/docs/sphinx/developerGuide/Contributing/InstallWin.rst
@@ -81,13 +81,13 @@ There are two things you may have noticed reading through the ``Dockerfile`` :
 
 .. code:: shell
 
-    PS> $env:VERSION='164-677'
-    PS> $env:IMG='ubuntu18.04-gcc8'
+    PS> $env:VERSION='212-910'
+    PS> $env:IMG='ubuntu20.04-gcc9'
     PS> $env:REMOTE_DEV_IMG="remote-dev-${env:IMG}"
 
 
 Please note the preposition of ``env:`` in the windows formalisme. The ``${ORG}`` variable will be hard-coded as ``geosx``. The last variable will be use
-as the image name. ``164-677`` refers to a specific version of the TPLs which may not be up to date. Please refer to :ref:`Continuous_Integration_process` for further info.
+as the image name. ``212-910`` refers to a specific version of the TPLs which may not be up to date. Please refer to :ref:`Continuous_Integration_process` for further info.
 
 - You'll need to generate a ssh-key to be able to access the container without the need for defining a password. This can be done from the *PowerShell*,
 
@@ -145,7 +145,7 @@ Coming back to our ``PowerShell`` terminal, we can check that our container is r
 
     PS > docker ps -a
     CONTAINER ID   IMAGE                                 COMMAND               CREATED                  STATUS          PORTS                                     NAMES
-    1efffac66c4c   remote-dev-ubuntu18.04-gcc8:156-642   "/usr/sbin/sshd -D"   Less than a second ago   Up 18 seconds   0.0.0.0:64000->22/tcp, :::64000->22/tcp   remote-dev-ubuntu18.04-gcc8-156-642
+    1efffac66c4c   remote-dev-ubuntu20.04-gcc9:212-910   "/usr/sbin/sshd -D"   Less than a second ago   Up 18 seconds   0.0.0.0:64000->22/tcp, :::64000->22/tcp   remote-dev-ubuntu20.04-gcc9-212-910
 
     PS > ssh root@localhost -p 64000
     Enter passphrase for key 'C:\***********/.ssh/id_rsa':

--- a/src/docs/sphinx/developerGuide/Contributing/UsingDocker.rst
+++ b/src/docs/sphinx/developerGuide/Contributing/UsingDocker.rst
@@ -31,12 +31,12 @@ You'll have to add extra tools.
 The following `example` is for our ``ubuntu`` flavors.
 You'll notice the arguments ``IMG``, ``VERSION``, ``ORG``.
 While surely overkill for most cases, if you develop in GEOSX on a regular basis you'll appreciate being able to switch containers easily.
-For example, simply create the image ``remote-dev-ubuntu18.04-gcc8:156-642`` by running
+For example, simply create the image ``remote-dev-ubuntu20.04-gcc9:212-910`` by running
 
 .. code-block:: console
 
-    export VERSION=156-642
-    export IMG=ubuntu18.04-gcc8
+    export VERSION=212-910
+    export IMG=ubuntu20.04-gcc9
     export REMOTE_DEV_IMG=remote-dev-${IMG}
     docker build --build-arg ORG=geosx --build-arg IMG=${IMG} --build-arg VERSION=${VERSION} -t ${REMOTE_DEV_IMG}:${VERSION} -f /path/to/Dockerfile .
 
@@ -52,7 +52,7 @@ I like to do
 
     docker run --cap-add=SYS_PTRACE -d --name ${REMOTE_DEV_IMG}-${VERSION} -p 64000:22 -p 64010-64020:64010-64020 ${REMOTE_DEV_IMG}:${VERSION}
 
-that creates the container ``remote-dev-ubuntu18.04-gcc8-156-642``, running instance of ``remote-dev-ubuntu18.04-gcc8:156-642``.
+that creates the container ``remote-dev-ubuntu20.04-gcc9-212-910``, running instance of ``remote-dev-ubuntu20.04-gcc9:212-910``.
 
 - Note that you'll have to access your remote development instance though port ``64000`` (forwarded to standard port ``22`` by docker).
 - Additional ports from ``64010`` to ``64020`` will be open if you need them (multiple instances of ``gdbserver``, remote ``paraview`` connection, ...). 

--- a/src/docs/sphinx/developerGuide/Contributing/UsingDocker.rst
+++ b/src/docs/sphinx/developerGuide/Contributing/UsingDocker.rst
@@ -50,12 +50,12 @@ I like to do
 
 .. code-block:: console
 
-    docker run --cap-add=SYS_PTRACE -d --name ${REMOTE_DEV_IMG}-${VERSION} -p 64000:22 -p 64010-64020:64010-64020 ${REMOTE_DEV_IMG}:${VERSION}
+    docker run --cap-add=SYS_PTRACE -d --name ${REMOTE_DEV_IMG}-${VERSION} -p 64000:22 -p 11111:11111 -p 64010-64020:64010-64020 ${REMOTE_DEV_IMG}:${VERSION}
 
 that creates the container ``remote-dev-ubuntu20.04-gcc9-212-910``, running instance of ``remote-dev-ubuntu20.04-gcc9:212-910``.
 
 - Note that you'll have to access your remote development instance though port ``64000`` (forwarded to standard port ``22`` by docker).
-- Additional ports from ``64010`` to ``64020`` will be open if you need them (multiple instances of ``gdbserver``, remote ``paraview`` connection, ...). 
+- Additional port ``11111`` and ports from ``64010`` to ``64020`` will be open if you need them (remote `paraview connection <https://docs.paraview.org/en/latest/ReferenceManual/parallelDataVisualization.html>`_ , multiple instances of `gdbserver <https://sourceware.org/gdb/current/onlinedocs/gdb.html/Server.html>`_, ...).
 - Please be aware of how to retrieve your code back: you may want to bind mount volumes and store you code there (``-v``/``--volume=`` options of `docker run <https://docs.docker.com/engine/reference/run/>`_).
 - Change ``docker`` to ``nvidia-docker`` and add the ``--gpus=...`` option for GPUs.
 

--- a/src/docs/sphinx/developerGuide/Contributing/UsingDocker.rst
+++ b/src/docs/sphinx/developerGuide/Contributing/UsingDocker.rst
@@ -3,7 +3,7 @@
 [Unsupported] Developing inside Docker with precompiled TPL binaries
 ====================================================================
 
-For development purposes, you may want to use the publicly available docker images or the OSX tarball instead of compiling them yourself.
+For development purposes, you may want to use the publicly available docker images instead of compiling them yourself.
 While this is possible and this page will help you in through this journey, please note that *this is not officially supported by the GEOSX team that reserves the right to modify its workflow or delete elements on which you may have build your own workflow*.
 
 There are multiple options to use the exposed docker images.
@@ -50,11 +50,12 @@ I like to do
 
 .. code-block:: console
 
-    docker run --cap-add=SYS_PTRACE -d --name ${REMOTE_DEV_IMG}-${VERSION} -p 64000:22 ${REMOTE_DEV_IMG}:${VERSION}
+    docker run --cap-add=SYS_PTRACE -d --name ${REMOTE_DEV_IMG}-${VERSION} -p 64000:22 -p 64010-64020:64010-64020 ${REMOTE_DEV_IMG}:${VERSION}
 
 that creates the container ``remote-dev-ubuntu18.04-gcc8-156-642``, running instance of ``remote-dev-ubuntu18.04-gcc8:156-642``.
 
 - Note that you'll have to access your remote development instance though port ``64000`` (forwarded to standard port ``22`` by docker).
+- Additional ports from ``64010`` to ``64020`` will be open if you need them (multiple instances of ``gdbserver``, remote ``paraview`` connection, ...). 
 - Please be aware of how to retrieve your code back: you may want to bind mount volumes and store you code there (``-v``/``--volume=`` options of `docker run <https://docs.docker.com/engine/reference/run/>`_).
 - Change ``docker`` to ``nvidia-docker`` and add the ``--gpus=...`` option for GPUs.
 


### PR DESCRIPTION
- Comments to use `open-mpi` as `root`, use at your own risk.
- Expose more ports if you need to connect to more tools.