### PR TITLE
Docs about how to fill ElementRegions

### DIFF
--- a/src/coreComponents/constitutive/docs/Constitutive.rst
+++ b/src/coreComponents/constitutive/docs/Constitutive.rst
@@ -22,7 +22,7 @@ These models are grouped together based on their input/output interface.
 
 In an input XML file, constitutive models are listed in the ``<Constitutive>`` block.
 Each parameterized model has its own XML tag, and each must be assigned a unique name via the ``name`` attribute.
-Names are used to assign models to regions of the physical domain via the ``materialList`` attribute of the ``<ElementRegion>`` node (see :ref:`XML_ElementRegions`).
+Names are used to assign models to regions of the physical domain via the ``materialList`` attribute of the ``<CellElementRegion>`` node (see :ref:`XML_ElementRegions`).
 In some cases, physics solvers must also be assigned specific constitutive models to use (see :ref:`Solvers`).
 
 A typical ``<Constitutive>`` and ``<ElementRegions>`` block will look like:
@@ -47,10 +47,10 @@ A typical ``<Constitutive>`` and ``<ElementRegions>`` block will look like:
     <ElementRegions>
 
       <!--Add water to the material list for region 1-->
-      <ElementRegion
+      <CellElementRegion
          name="region1"
-         cellBlocks="cellBlock1"
-         materialList="water"/>
+         cellBlocks="{ cellBlock1 }"
+         materialList="{ water }"/>
 
     </ElementRegions>
 

--- a/src/coreComponents/mesh/docs/Mesh.rst
+++ b/src/coreComponents/mesh/docs/Mesh.rst
@@ -191,7 +191,7 @@ We advise users to use absolute path to the mesh file.
 
 GEOSX uses ``ElementRegions`` to support different physics
 or to define different constitutive properties.
-An ``ElementRegion`` is defined as a set of ``CellBlocks``.
+The ``ElementRegions`` block can contain several ``CellElementRegion`` blocks. A ``CellElementRegion`` is defined as a set of ``CellBlocks``.
 A ``CellBlock`` is an ensemble of elements with the same element geometry.
 
 .. figure:: mesh_multi.png
@@ -206,14 +206,14 @@ The ``ElementRegions`` are defined as below :
 .. code-block:: xml
 
   <ElementRegions>
-    <ElementRegion
+    <CellElementRegion
       name="Top"
-      cellBlocks="Top_hexahedra Top_wedges Top_tetrahedra"
-      materialList="water rock"/>
-    <ElementRegion
+      cellBlocks="{ Top_hexahedra, Top_wedges, Top_tetrahedra }"
+      materialList="{ water, rock }"/>
+    <CellElementRegion
       name="Bot"
-      cellBlocks="Bot_hexahedra Bot_wedges Bot_tetrahedra"
-      materialList="water rock"/>
+      cellBlocks="{ Bot_hexahedra, Bot_wedges, Bot_tetrahedra }"
+      materialList="{ water, rock }"/>
   </ElementRegions>
 
 You have to use the following syntax to declare your ``CellBlocks`` :


### PR DESCRIPTION
Here is a proposal for modifications of the docs about how to fill `ElementRegions`:
- `ElementRegion` wasn't replaced by `CellElementRegion` everywhere in the exemples.
- `cellBlocks` & `materialList` attributes need brace symbols, but there weren't any in some exemples