### PR TITLE
Chombo Coupling Fixes

### DIFF
--- a/src/coreComponents/fileIO/Outputs/ChomboIO.cpp
+++ b/src/coreComponents/fileIO/Outputs/ChomboIO.cpp
@@ -75,17 +75,21 @@ bool ChomboIO::execute( real64 const GEOSX_UNUSED_PARAM( time_n ),
                         real64 const GEOSX_UNUSED_PARAM( eventProgress ),
                         DomainPartition & domain )
 {
-  if( m_coupler == nullptr )
-  {
-    GEOSX_ERROR_IF( m_waitForInput && m_inputPath == "/INVALID_INPUT_PATH", "Waiting for input but no input path was specified." );
-
-    m_coupler = new ChomboCoupler( MPI_COMM_GEOSX, m_outputPath, m_inputPath, domain.getMeshBody( 0 ).getBaseDiscretization() );
-  }
-
   if( cycleNumber < m_beginCycle )
   {
     return false;
   }
+  GEOSX_LOG_RANK_0( "Executing chombo coupling." );
+
+  if( m_coupler == nullptr )
+  {
+    GEOSX_ERROR_IF( m_waitForInput && m_inputPath == "/INVALID_INPUT_PATH", "Waiting for input but no input path was specified." );
+
+    GEOSX_LOG_RANK_0( "Initializing chombo coupling" );
+
+    m_coupler = new ChomboCoupler( MPI_COMM_GEOSX, m_outputPath, m_inputPath, domain.getMeshBody( 0 ).getBaseDiscretization() );
+  }
+
 
   m_coupler->write( dt );
 

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
@@ -146,20 +146,17 @@ void SolidMechanicsLagrangianFEM::registerDataOnMesh( Group & meshBodies )
     nodes.registerField< solidMechanics::incrementalDisplacement >( getName() ).
       reference().resizeDimension< 1 >( 3 );
 
-    if( m_timeIntegrationOption != TimeIntegrationOption::QuasiStatic )
-    {
-      nodes.registerField< solidMechanics::velocity >( getName() ).
-        reference().resizeDimension< 1 >( 3 );
+    nodes.registerField< solidMechanics::velocity >( getName() ).
+      reference().resizeDimension< 1 >( 3 );
 
-      nodes.registerField< solidMechanics::acceleration >( getName() ).
-        reference().resizeDimension< 1 >( 3 );
+    nodes.registerField< solidMechanics::acceleration >( getName() ).
+      reference().resizeDimension< 1 >( 3 );
 
-      nodes.registerField< solidMechanics::velocityTilde >( getName() ).
-        reference().resizeDimension< 1 >( 3 );
+    nodes.registerField< solidMechanics::velocityTilde >( getName() ).
+      reference().resizeDimension< 1 >( 3 );
 
-      nodes.registerField< solidMechanics::uhatTilde >( getName() ).
-        reference().resizeDimension< 1 >( 3 );
-    }
+    nodes.registerField< solidMechanics::uhatTilde >( getName() ).
+      reference().resizeDimension< 1 >( 3 );
 
     nodes.registerField< solidMechanics::mass >( getName() );
 


### PR DESCRIPTION
Requires hdf5_interface submodule update: https://github.com/GEOSX/hdf5_interface/pull/10

Probably going to impact some restart baselines since it reactivates several fields when using Quasistatic solver.