### PR TITLE
Fixed waitOrderedOrWaitAll signature

### DIFF
--- a/src/coreComponents/common/MpiWrapper.cpp
+++ b/src/coreComponents/common/MpiWrapper.cpp
@@ -308,7 +308,7 @@ double MpiWrapper::wtime( void )
 
 }
 
-int MpiWrapper::activeWaitAny( const int count, MPI_Request array_of_requests[], MPI_Status array_of_statuses[], std::function< void ( int ) > func )
+int MpiWrapper::activeWaitAny( const int count, MPI_Request array_of_requests[], MPI_Status array_of_statuses[], std::function< MPI_Request ( int ) > func )
 {
   int cmp = 0;
   while( cmp < count )
@@ -329,7 +329,7 @@ int MpiWrapper::activeWaitAny( const int count, MPI_Request array_of_requests[],
 int MpiWrapper::activeWaitSome( const int count,
                                 MPI_Request array_of_requests[],
                                 MPI_Status array_of_statuses[],
-                                std::function< void ( int ) > func )
+                                std::function< MPI_Request ( int ) > func )
 {
   int cmp = 0;
   while( cmp < count )
@@ -356,7 +356,7 @@ int MpiWrapper::activeWaitSome( const int count,
 
 
 int MpiWrapper::activeWaitSomeCompletePhase( const int participants,
-                                             std::vector< std::tuple< MPI_Request *, MPI_Status *, std::function< void ( int ) > > > const & phases )
+                                             std::vector< std::tuple< MPI_Request *, MPI_Status *, std::function< MPI_Request ( int ) > > > const & phases )
 {
   const int num_phases = phases.size();
   int err = 0;
@@ -364,7 +364,7 @@ int MpiWrapper::activeWaitSomeCompletePhase( const int participants,
   {
     MPI_Request * const requests = std::get< 0 >( phases[phase] );
     MPI_Status * const statuses = std::get< 1 >( phases[phase] );
-    std::function< void ( int ) > func = std::get< 2 >( phases[phase] );
+    std::function< MPI_Request ( int ) > func = std::get< 2 >( phases[phase] );
     if( requests!=nullptr )
     {
       err = activeWaitSome( participants,
@@ -386,14 +386,14 @@ int MpiWrapper::activeWaitSomeCompletePhase( const int participants,
 }
 
 int MpiWrapper::activeWaitOrderedCompletePhase( const int participants,
-                                                std::vector< std::tuple< MPI_Request *, MPI_Status *, std::function< void ( int ) > > > const & phases )
+                                                std::vector< std::tuple< MPI_Request *, MPI_Status *, std::function< MPI_Request ( int ) > > > const & phases )
 {
   const int num_phases = phases.size();
   for( int phase = 0; phase < num_phases; ++phase )
   {
     MPI_Request * const requests = std::get< 0 >( phases[phase] );
     MPI_Status * const statuses = std::get< 1 >( phases[phase] );
-    std::function< void ( int ) > func = std::get< 2 >( phases[phase] );
+    std::function< MPI_Request ( int ) > func = std::get< 2 >( phases[phase] );
 
     for( int idx = 0; idx < participants; ++idx )
     {

--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -229,7 +229,7 @@ public:
   static int activeWaitAny( const int count,
                             MPI_Request array_of_requests[],
                             MPI_Status array_of_statuses[],
-                            std::function< void ( int ) > func );
+                            std::function< MPI_Request ( int ) > func );
 
   /**
    * Wait on MPI_Requests to complete on or more at a time and trigger a callback to
@@ -243,7 +243,7 @@ public:
   static int activeWaitSome( const int count,
                              MPI_Request array_of_requests[],
                              MPI_Status array_of_statuses[],
-                             std::function< void ( int ) > func );
+                             std::function< MPI_Request ( int ) > func );
 
   /**
    * Active non-blocking phased communication with multiple participants,
@@ -258,7 +258,7 @@ public:
    * @return MPI_SUCCESS or and MPI_ERROR from internal calls to MPI_WaitAny.
    */
   static int activeWaitSomeCompletePhase( const int participants,
-                                          std::vector< std::tuple< MPI_Request *, MPI_Status *, std::function< void ( int ) > > > const & phases );
+                                          std::vector< std::tuple< MPI_Request *, MPI_Status *, std::function< MPI_Request ( int ) > > > const & phases );
 
   /**
    * Active blocking phased communication with multiple participants,
@@ -274,7 +274,7 @@ public:
    * @return MPI_SUCCESS or and MPI_ERROR from internal calls to MPI_WaitAny.
    */
   static int activeWaitOrderedCompletePhase( const int participants,
-                                             std::vector< std::tuple< MPI_Request *, MPI_Status *, std::function< void ( int ) > > > const & phases );
+                                             std::vector< std::tuple< MPI_Request *, MPI_Status *, std::function< MPI_Request ( int ) > > > const & phases );
   ///@}
 
 #if !defined(GEOSX_USE_MPI)

--- a/src/coreComponents/mesh/mpiCommunications/CommunicationTools.cpp
+++ b/src/coreComponents/mesh/mpiCommunications/CommunicationTools.cpp
@@ -606,7 +606,7 @@ void removeUnusedNeighbors( NodeManager & nodeManager,
  * @param unorderedComms if true complete the communications of each phase in the order they are received.
  */
 void waitOrderedOrWaitAll( int const n,
-                           std::vector< std::tuple< MPI_Request *, MPI_Status *, std::function< void ( int ) > > > const & phases,
+                           std::vector< std::tuple< MPI_Request *, MPI_Status *, std::function< MPI_Request ( int ) > > > const & phases,
                            bool const unorderedComms )
 {
   if( unorderedComms )
@@ -657,9 +657,9 @@ void CommunicationTools::setupGhosts( MeshLevel & meshLevel,
   };
 
   waitOrderedOrWaitAll( neighbors.size(),
-                        { { static_cast< MPI_Request * >(nullptr), static_cast< MPI_Status * >(nullptr), sendGhosts},
-                          { commData.mpiRecvBufferSizeRequest(), commData.mpiRecvBufferSizeStatus(), postRecv},
-                          { commData.mpiRecvBufferRequest(), commData.mpiRecvBufferStatus(), unpackGhosts} },
+                        { std::make_tuple( static_cast< MPI_Request * >(nullptr), static_cast< MPI_Status * >(nullptr), sendGhosts ),
+                          std::make_tuple( commData.mpiRecvBufferSizeRequest(), commData.mpiRecvBufferSizeStatus(), postRecv ),
+                          std::make_tuple( commData.mpiRecvBufferRequest(), commData.mpiRecvBufferStatus(), unpackGhosts ) },
                         unorderedComms );
 
   // There are cases where the multiple waitOrderedOrWaitAll methods here will clash with
@@ -695,9 +695,9 @@ void CommunicationTools::setupGhosts( MeshLevel & meshLevel,
   };
 
   waitOrderedOrWaitAll( neighbors.size(),
-                        { { static_cast< MPI_Request * >(nullptr), static_cast< MPI_Status * >(nullptr), sendSyncLists },
-                          { commData.mpiRecvBufferSizeRequest(), commData.mpiRecvBufferSizeStatus(), postRecv },
-                          { commData.mpiRecvBufferRequest(), commData.mpiRecvBufferStatus(), rebuildSyncLists} },
+                        { std::make_tuple( static_cast< MPI_Request * >(nullptr), static_cast< MPI_Status * >(nullptr), sendSyncLists ),
+                          std::make_tuple( commData.mpiRecvBufferSizeRequest(), commData.mpiRecvBufferSizeStatus(), postRecv ),
+                          std::make_tuple( commData.mpiRecvBufferRequest(), commData.mpiRecvBufferStatus(), rebuildSyncLists ) },
                         unorderedComms );
 
   // See above comments for the reason behind these waitAll commands
@@ -710,9 +710,9 @@ void CommunicationTools::setupGhosts( MeshLevel & meshLevel,
   fixReceiveLists( faceManager, neighbors );
 
   waitOrderedOrWaitAll( neighbors.size(),
-                        { { static_cast< MPI_Request * >(nullptr), static_cast< MPI_Status * >(nullptr), sendSyncLists },
-                          { commData.mpiRecvBufferSizeRequest(), commData.mpiRecvBufferSizeStatus(), postRecv },
-                          { commData.mpiRecvBufferRequest(), commData.mpiRecvBufferStatus(), rebuildSyncLists} },
+                        { std::make_tuple( static_cast< MPI_Request * >(nullptr), static_cast< MPI_Status * >(nullptr), sendSyncLists ),
+                          std::make_tuple( commData.mpiRecvBufferSizeRequest(), commData.mpiRecvBufferSizeStatus(), postRecv ),
+                          std::make_tuple( commData.mpiRecvBufferRequest(), commData.mpiRecvBufferStatus(), rebuildSyncLists ) },
                         unorderedComms );
 
   // See above comments for the reason behind these waitAll commands


### PR DESCRIPTION
This PR fixes the compilation issue on Lassen. The error message was:
```
src/coreComponents/mesh/mpiCommunications/CommunicationTools.cpp(660): 
error: no instance of constructor 
"std::vector<_Tp, _Alloc>::vector [with _Tp=std::tuple<MPI_Request *, MPI_Status *, std::function<void (int)>>, _Alloc=std::allocator<std::tuple<MPI_Request *, MPI_Status *, std::function<void (int)>>>]" 
matches the argument list         
            argument types are: ({...}, {...}, {...})  
```
[here](https://github.com/GEOSX/GEOSX/blob/4a2a12bcd345a8e4cec3f4607acbb814ce0dbb12/src/coreComponents/mesh/mpiCommunications/CommunicationTools.cpp#L659)

Resolves #2329 