### PR TITLE
Fixed isCoordInObject for cylinder

### DIFF
--- a/src/coreComponents/mesh/simpleGeometricObjects/Cylinder.cpp
+++ b/src/coreComponents/mesh/simpleGeometricObjects/Cylinder.cpp
@@ -48,7 +48,7 @@ Cylinder::Cylinder( const string & name, Group * const parent ):
   registerWrapper( viewKeyStruct::innerRadiusString(), &m_innerRadius ).
     setApplyDefaultValue( -1 ).
     setInputFlag( InputFlags::OPTIONAL ).
-    setDescription( "Inner radius of the anulus" );
+    setDescription( "Inner radius of the annulus" );
 
 }
 
@@ -56,26 +56,41 @@ Cylinder::~Cylinder()
 {}
 
 
-bool Cylinder::isCoordInObject( real64 const ( &coord ) [3] ) const
+bool Cylinder::isCoordInObject( real64 const ( &targetPt ) [3] ) const
 {
   bool rval = false;
 
-  real64 axisVector[3] = LVARRAY_TENSOROPS_INIT_LOCAL_3( m_point2 );
-  LvArray::tensorOps::subtract< 3 >( axisVector, m_point1 );
-  real64 const height = LvArray::tensorOps::normalize< 3 >( axisVector );
+  // Assuming the cylinder is defined by (pt1,pt2,innerRadius,outerRadius),
+  // we check that the target point is inside using the following formulas
+  //
+  // 1) Check that the target point lies between the planes of the two circular facets of the cylinder
+  // ( \vec{targetPt} - \vec{pt1} ) \cdot ( \vec{pt2} - \vec{pt1} ) > 0
+  // ( \vec{targetPt} - \vec{pt2} ) \cdot ( \vec{pt2} - \vec{pt1} ) < 0
+  //
+  // 2) Check that the target point lies inside the curved surface of the cylinder
+  // \frac{| ( \vec{targetPt} - \vec{pt1} ) x ( \vec{pt2} - \vec{pt1} ) |}{| \vec{pt2} - \vec{pt1} |} \geq innerRadius
+  // \frac{| ( \vec{targetPt} - \vec{pt1} ) x ( \vec{pt2} - \vec{pt1} ) |}{| \vec{pt2} - \vec{pt1} |} < outerRadius
 
-  real64 coord_minus_point1[3] = LVARRAY_TENSOROPS_INIT_LOCAL_3( coord );
-  LvArray::tensorOps::subtract< 3 >( coord_minus_point1, m_point1 );
+  real64 pt2Pt1[3] = LVARRAY_TENSOROPS_INIT_LOCAL_3( m_point2 );
+  LvArray::tensorOps::subtract< 3 >( pt2Pt1, m_point1 );
 
-  real64 projection[3] = LVARRAY_TENSOROPS_INIT_LOCAL_3( axisVector );
-  LvArray::tensorOps::scale< 3 >( projection, LvArray::tensorOps::AiBi< 3 >( axisVector, coord_minus_point1 ) );
+  real64 targetPtPt1[3] = LVARRAY_TENSOROPS_INIT_LOCAL_3( targetPt );
+  LvArray::tensorOps::subtract< 3 >( targetPtPt1, m_point1 );
 
-  real64 distance[3] = LVARRAY_TENSOROPS_INIT_LOCAL_3( coord_minus_point1 );
-  LvArray::tensorOps::subtract< 3 >( distance, projection );
+  real64 targetPtPt2[3] = LVARRAY_TENSOROPS_INIT_LOCAL_3( targetPt );
+  LvArray::tensorOps::subtract< 3 >( targetPtPt2, m_point2 );
 
-  if( LvArray::tensorOps::l2Norm< 3 >( distance ) < m_radius &&
-      LvArray::tensorOps::l2Norm< 3 >( distance ) >= m_innerRadius &&
-      LvArray::tensorOps::l2Norm< 3 >( projection ) < height )
+  real64 const dotProd_pt2Pt1_targetPtPt1 = LvArray::tensorOps::AiBi< 3 >( pt2Pt1, targetPtPt1 );
+  real64 const dotProd_pt2Pt1_targetPtPt2 = LvArray::tensorOps::AiBi< 3 >( pt2Pt1, targetPtPt2 );
+
+  real64 crossProd[3]{};
+  LvArray::tensorOps::crossProduct( crossProd, targetPtPt1, pt2Pt1 );
+  real64 const radius = LvArray::tensorOps::l2Norm< 3 >( crossProd ) / LvArray::tensorOps::l2Norm< 3 >( pt2Pt1 );
+
+  if( radius < m_radius &&
+      radius >= m_innerRadius &&
+      dotProd_pt2Pt1_targetPtPt1 > 0 &&
+      dotProd_pt2Pt1_targetPtPt2 < 0 )
   {
     rval = true;
   }

--- a/src/coreComponents/mesh/simpleGeometricObjects/Cylinder.hpp
+++ b/src/coreComponents/mesh/simpleGeometricObjects/Cylinder.hpp
@@ -68,18 +68,6 @@ public:
 
   bool isCoordInObject( real64 const ( &coord ) [3] ) const override final;
 
-
-private:
-
-  /// Center point of one (upper or lower) face of the cylinder
-  R1Tensor m_point1;
-  /// Center point of the other face of the cylinder
-  R1Tensor m_point2;
-  /// Radius of the cylinder
-  real64 m_radius = 0.0;
-
-  real64 m_innerRadius = 0.0;
-
   /// @cond DO_NOT_DOCUMENT
 
   struct viewKeyStruct
@@ -91,6 +79,17 @@ private:
   };
 
   /// @endcond
+
+private:
+
+  /// Center point of one (upper or lower) face of the cylinder
+  R1Tensor m_point1;
+  /// Center point of the other face of the cylinder
+  R1Tensor m_point2;
+  /// Radius of the cylinder
+  real64 m_radius = 0.0;
+  /// Inner radius of the cylinder
+  real64 m_innerRadius = 0.0;
 
 };
 } /* namespace geosx */

--- a/src/coreComponents/mesh/unitTests/CMakeLists.txt
+++ b/src/coreComponents/mesh/unitTests/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 set( mesh_tests
      testMeshObjectPath.cpp
+     testGeometricObjects.cpp
    )
 
 set( dependencyList gtest mesh )

--- a/src/coreComponents/mesh/unitTests/testGeometricObjects.cpp
+++ b/src/coreComponents/mesh/unitTests/testGeometricObjects.cpp
@@ -1,0 +1,151 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file testGeometricObjects.cpp
+ */
+
+#include "mesh/simpleGeometricObjects/Cylinder.hpp"
+
+#include <gtest/gtest.h>
+
+namespace geosx
+{
+using namespace dataRepository;
+
+void setCylinderParameters( Cylinder & cylinder,
+                            real64 const (&inputPoint1)[3],
+                            real64 const (&inputPoint2)[3],
+                            real64 const & inputRadius,
+                            real64 const & inputInnerRadius )
+{
+  auto & point1 = cylinder.getReference< R1Tensor >( Cylinder::viewKeyStruct::point1String() );
+  point1[0] = inputPoint1[0]; point1[1] = inputPoint1[1]; point1[2] = inputPoint1[2];
+  auto & point2 = cylinder.getReference< R1Tensor >( Cylinder::viewKeyStruct::point2String() );
+  point2[0] = inputPoint2[0]; point2[1] = inputPoint2[1]; point2[2] = inputPoint2[2];
+  auto & radius = cylinder.getReference< real64 >( Cylinder::viewKeyStruct::radiusString() );
+  radius = inputRadius;
+  auto & innerRadius = cylinder.getReference< real64 >( Cylinder::viewKeyStruct::innerRadiusString() );
+  innerRadius = inputInnerRadius;
+}
+
+TEST( GeometricObjectTests, Cylinder )
+{
+  real64 testCoord[3]{};
+  integer const numSamples = 10;
+
+  conduit::Node node;
+  dataRepository::Group parent( "testGroup", node );
+
+  // Step 1: checks for Cylinder 1
+
+  Cylinder cylinder1( "cylinder1", &parent );
+
+  real64 const inputPoint1Cylinder1[3] = { 0, 0, -2650.1 };
+  real64 const inputPoint2Cylinder1[3] = { 0, 0, -2500.0 };
+  real64 const inputRadiusCylinder1 = 750.0;
+  real64 const inputInnerRadiusCylinder1 = 1.0;
+  setCylinderParameters( cylinder1,
+                         inputPoint1Cylinder1, inputPoint2Cylinder1,
+                         inputRadiusCylinder1, inputInnerRadiusCylinder1 );
+
+  real64 startX = -100;
+  real64 endX   =  100;
+  real64 startY = -100;
+  real64 endY   =  100;
+  real64 startZ = -2649;
+  real64 endZ   = -2501;
+
+  testCoord[1] = -100;
+  testCoord[2] = -2480;
+  for( integer i = 0; i < numSamples; ++i )
+  {
+    testCoord[0] = startX + i * (endX-startX)/numSamples;
+    EXPECT_FALSE( cylinder1.isCoordInObject( testCoord ) );
+  }
+
+  testCoord[0] = -100;
+  testCoord[2] = -2660;
+  for( integer j = 0; j < numSamples; ++j )
+  {
+    testCoord[1] = startY + j * (endY-startY)/numSamples;
+    EXPECT_FALSE( cylinder1.isCoordInObject( testCoord ) );
+  }
+
+  testCoord[0] = 0.24;
+  testCoord[1] = 0.1;
+  for( integer k = 0; k < numSamples; ++k )
+  {
+    testCoord[2] = startZ + k * (endZ-startZ)/numSamples;
+    EXPECT_FALSE( cylinder1.isCoordInObject( testCoord ) );
+  }
+
+  testCoord[0] = 10;
+  testCoord[1] = 70;
+  for( integer k = 0; k < numSamples; ++k )
+  {
+    testCoord[2] = startZ + k * (endZ-startZ)/numSamples;
+    EXPECT_TRUE( cylinder1.isCoordInObject( testCoord ) );
+  }
+
+  // Step 2: checks for Cylinder 2
+
+  Cylinder cylinder2( "cylinder2", &parent );
+
+  real64 const inputPoint1Cylinder2[3] = {  1, 1, 0 };
+  real64 const inputPoint2Cylinder2[3] = { -1, -1, 0 };
+  real64 const inputRadiusCylinder2 = 1.0;
+  real64 const inputInnerRadiusCylinder2 = 0.1;
+  setCylinderParameters( cylinder2,
+                         inputPoint1Cylinder2, inputPoint2Cylinder2,
+                         inputRadiusCylinder2, inputInnerRadiusCylinder2 );
+
+  startX = -0.9;
+  endX   =  0.9;
+  startY = -0.9;
+  endY   =  0.9;
+
+  testCoord[1] = -1;
+  testCoord[2] = -2;
+  for( integer i = 0; i < numSamples; ++i )
+  {
+    testCoord[0] = startX + i * (endX-startX)/numSamples;
+    EXPECT_FALSE( cylinder2.isCoordInObject( testCoord ) );
+  }
+
+  testCoord[0] = -1;
+  testCoord[2] = 1.5;
+  for( integer j = 0; j < numSamples; ++j )
+  {
+    testCoord[1] = startY + j * (endY-startY)/numSamples;
+    EXPECT_FALSE( cylinder2.isCoordInObject( testCoord ) );
+  }
+
+  testCoord[2] = 0;
+  for( integer j = 0; j < numSamples; ++j )
+  {
+    testCoord[1] = startY + j * (endY-startY)/numSamples;
+    testCoord[0] = testCoord[1];
+    EXPECT_FALSE( cylinder2.isCoordInObject( testCoord ) );
+  }
+  for( integer j = 0; j < numSamples; ++j )
+  {
+    testCoord[1] = startY + j * (endY-startY)/numSamples;
+    testCoord[0] = testCoord[1]+0.3;
+    EXPECT_TRUE( cylinder2.isCoordInObject( testCoord ) );
+  }
+}
+
+
+} /* namespace geosx */

--- a/src/coreComponents/schema/docs/Cylinder.rst
+++ b/src/coreComponents/schema/docs/Cylinder.rst
@@ -3,7 +3,7 @@
 =========== ======== ======== ========================================================= 
 Name        Type     Default  Description                                               
 =========== ======== ======== ========================================================= 
-innerRadius real64   -1       Inner radius of the anulus                                
+innerRadius real64   -1       Inner radius of the annulus                               
 name        string   required A name is required for any non-unique nodes               
 point1      R1Tensor required Center point of one (upper or lower) face of the cylinder 
 point2      R1Tensor required Center point of the other face of the cylinder            

--- a/src/coreComponents/schema/schema.xsd
+++ b/src/coreComponents/schema/schema.xsd
@@ -1237,7 +1237,7 @@ stress - traction is applied to the faces as specified by the inner product of i
 		<xsd:attribute name="name" type="string" use="required" />
 	</xsd:complexType>
 	<xsd:complexType name="CylinderType">
-		<!--innerRadius => Inner radius of the anulus-->
+		<!--innerRadius => Inner radius of the annulus-->
 		<xsd:attribute name="innerRadius" type="real64" default="-1" />
 		<!--point1 => Center point of one (upper or lower) face of the cylinder-->
 		<xsd:attribute name="point1" type="R1Tensor" use="required" />


### PR DESCRIPTION
@jhuang2601 found out that the cylinder implementation was not capturing the expected cells. The cylinder is not used anywhere, so most likely no one ever noticed this issue.

This PR changes the implementation of `isCoordInObject` to fixes this behavior. This PR also adds a unit test to check the implementation.